### PR TITLE
fix: rate limiting improvements

### DIFF
--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -14,7 +14,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 jobs:
   sync-versions:
@@ -30,8 +29,9 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
 
-          # Fetch latest develop
+          # Fetch latest develop and main
           git fetch origin develop
+          git fetch origin main
 
           # Checkout develop
           git checkout develop

--- a/.github/workflows/sync-version.yml
+++ b/.github/workflows/sync-version.yml
@@ -1,0 +1,53 @@
+# This workflow automatically syncs version bumps from main to develop branch
+# after a release is tagged. This prevents manual "merge main → develop" commits.
+#
+# NOTE: This workflow requires the develop branch to allow pushes from GitHub Actions.
+# Configure in Settings > Branches > Branch protection rules > develop
+# - Either disable "Require a pull request before merging" for develop
+# - Or add "github-actions[bot]" to "Allow specific actors to bypass"
+
+name: Sync Main to Develop
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-versions:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Sync main to develop
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+          # Fetch latest develop
+          git fetch origin develop
+
+          # Checkout develop
+          git checkout develop
+
+          # Attempt fast-forward merge first
+          if git merge --ff-only origin/main; then
+            echo "Fast-forward merge successful"
+          else
+            echo "Fast-forward not possible, attempting merge commit..."
+            git merge origin/main --no-edit || {
+              echo "Merge failed. Manual intervention required."
+              echo "Develop branch may have diverged from main."
+              exit 1
+            }
+          fi
+
+          # Push to develop
+          git push origin develop
+          echo "Successfully synced main to develop"

--- a/src/helpers/utils/cloudflareIps.ts
+++ b/src/helpers/utils/cloudflareIps.ts
@@ -1,0 +1,197 @@
+import { AxiosResponse } from 'axios'
+
+import pooledAxios from './connectionPool'
+
+const CLOUDFLARE_IPS_API = 'https://api.cloudflare.com/client/v4/ips'
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000 // 24 hours in milliseconds
+
+interface CloudflareApiResponse {
+	result: {
+		ipv4_cidrs: string[]
+		ipv6_cidrs: string[]
+		etag: string
+	}
+	success: boolean
+	errors: Array<{ code: number; message: string }>
+	messages: string[]
+}
+
+interface CloudflareIpsResult {
+	ipv4: string[]
+	ipv6: string[]
+	fetchedAt: number
+}
+
+interface CloudflareIpsCache {
+	data: CloudflareIpsResult | null
+	lastFetchTime: number
+}
+
+/**
+ * In-memory cache for Cloudflare IP ranges
+ * Module-level singleton that persists for the lifetime of the application
+ */
+const cache: CloudflareIpsCache = {
+	data: null,
+	lastFetchTime: 0
+}
+
+/**
+ * Fetch Cloudflare IP ranges from the Cloudflare API
+ * @returns Promise resolving to CloudflareIpsResult with ipv4 and ipv6 arrays
+ * @throws Error if the API request fails
+ */
+async function fetchIpsFromApi(): Promise<CloudflareIpsResult> {
+	const response: AxiosResponse<CloudflareApiResponse> = await pooledAxios.get(CLOUDFLARE_IPS_API)
+
+	if (!response.data.success) {
+		const errorMessages = response.data.errors.map((e) => `${e.code}: ${e.message}`).join(', ')
+		throw new Error(`Cloudflare API returned errors: ${errorMessages}`)
+	}
+
+	return {
+		ipv4: response.data.result.ipv4_cidrs,
+		ipv6: response.data.result.ipv6_cidrs,
+		fetchedAt: Date.now()
+	}
+}
+
+/**
+ * Get Cloudflare IP ranges, using cached data if available and not expired
+ * Fetches from API if cache is empty or expired
+ * @returns Promise resolving to CloudflareIpsResult
+ */
+async function getIps(): Promise<CloudflareIpsResult> {
+	const now = Date.now()
+
+	// Check if we have valid cached data
+	if (cache.data && now - cache.lastFetchTime < CACHE_TTL_MS) {
+		return cache.data
+	}
+
+	// Fetch fresh data
+	try {
+		const freshData = await fetchIpsFromApi()
+		cache.data = freshData
+		cache.lastFetchTime = now
+		return freshData
+	} catch {
+		// If fetch fails, return cached data if available (even if expired)
+		if (cache.data) {
+			return cache.data
+		}
+		// Otherwise return empty arrays
+		return {
+			ipv4: [],
+			ipv6: [],
+			fetchedAt: 0
+		}
+	}
+}
+
+/**
+ * Get all Cloudflare IP ranges as a flat array (both IPv4 and IPv6)
+ * Useful for TRUSTED_PROXIES configuration
+ * @returns Promise resolving to array of CIDR strings
+ */
+async function getAllIps(): Promise<string[]> {
+	const result = await getIps()
+	return [...result.ipv4, ...result.ipv6]
+}
+
+/**
+ * Get cached Cloudflare IPs without triggering a fetch
+ * Useful for checking if cache is populated
+ * @returns CloudflareIpsResult or null if not cached
+ */
+function getCachedIps(): CloudflareIpsResult | null {
+	const now = Date.now()
+	if (cache.data && now - cache.lastFetchTime < CACHE_TTL_MS) {
+		return cache.data
+	}
+	return cache.data // Return expired data if available
+}
+
+/**
+ * Clear the Cloudflare IPs cache
+ * Useful for testing or forcing a refresh
+ */
+function clearCache(): void {
+	cache.data = null
+	cache.lastFetchTime = 0
+}
+
+/**
+ * Check if cache is valid (not expired)
+ * @returns boolean indicating if cache has valid unexpired data
+ */
+function isCacheValid(): boolean {
+	if (!cache.data) return false
+	const now = Date.now()
+	return now - cache.lastFetchTime < CACHE_TTL_MS
+}
+
+/**
+ * CloudflareIps class for managing Cloudflare IP ranges
+ * Provides a class-based interface with static methods for convenience
+ */
+export class CloudflareIps {
+	/**
+	 * Fetch Cloudflare IP ranges from the API
+	 * @returns Promise resolving to CloudflareIpsResult
+	 */
+	static async fetchIps(): Promise<CloudflareIpsResult> {
+		return fetchIpsFromApi()
+	}
+
+	/**
+	 * Get Cloudflare IP ranges, using cache if available
+	 * @returns Promise resolving to CloudflareIpsResult
+	 */
+	static async getIps(): Promise<CloudflareIpsResult> {
+		return getIps()
+	}
+
+	/**
+	 * Get all Cloudflare IP ranges as a flat array
+	 * @returns Promise resolving to array of CIDR strings
+	 */
+	static async getAllIps(): Promise<string[]> {
+		return getAllIps()
+	}
+
+	/**
+	 * Get cached IPs without triggering a fetch
+	 * @returns CloudflareIpsResult or null
+	 */
+	static getCachedIps(): CloudflareIpsResult | null {
+		return getCachedIps()
+	}
+
+	/**
+	 * Clear the cache
+	 */
+	static clearCache(): void {
+		clearCache()
+	}
+
+	/**
+	 * Check if cache is valid
+	 * @returns boolean
+	 */
+	static isCacheValid(): boolean {
+		return isCacheValid()
+	}
+}
+
+export {
+	CACHE_TTL_MS,
+	clearCache,
+	CLOUDFLARE_IPS_API,
+	fetchIpsFromApi,
+	getAllIps,
+	getCachedIps,
+	getIps,
+	isCacheValid
+}
+export type { CloudflareApiResponse, CloudflareIpsResult }

--- a/src/helpers/utils/fetchPlus.ts
+++ b/src/helpers/utils/fetchPlus.ts
@@ -3,8 +3,41 @@ import { AxiosError, AxiosResponse } from 'axios'
 import pooledAxios from './connectionPool'
 
 /**
+ * Calculates the delay for retry attempts with exponential backoff.
+ * For 429 status, uses exponential backoff starting at 1s, doubling each retry (max 8s).
+ * Respects Retry-After header if present.
+ * @param {number} retries The current retry count
+ * @param {AxiosError} error The axios error response
+ * @returns {number} The delay in milliseconds
+ */
+function calculateRetryDelay(retries: number, error: AxiosError): number {
+	const retryAfter = error.response?.headers?.['retry-after']
+	if (retryAfter) {
+		// Retry-After can be a delay in seconds or a date
+		const parsed = parseInt(retryAfter, 10)
+		if (!isNaN(parsed)) {
+			return parsed * 1000
+		}
+	}
+
+	// Exponential backoff: 1s, 2s, 4s, max 8s
+	return Math.min(1000 * Math.pow(2, retries), 8000)
+}
+
+/**
+ * Sleep for a given number of milliseconds
+ * @param {number} ms The number of milliseconds to sleep
+ * @returns {Promise<void>} A promise that resolves after the delay
+ */
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
  * Fetches a url with axios and retries 3 additional times on non-200 status
- * Uses connection pooling for improved performance
+ * Uses connection pooling for improved performance.
+ * Implements exponential backoff for 429 (Too Many Requests) responses,
+ * respecting Retry-After header when present.
  * @param {string} url The url to fetch
  * @param {object} options The options to pass to axios (default: {})
  * @param {number} retries The number of retries to start from (default: 0)
@@ -21,8 +54,15 @@ function fetchPlus(url: string, options = {}, retries = 0): Promise<AxiosRespons
 					reject(response)
 				}
 			})
-			.catch((reason: AxiosError) => {
+			.catch(async (reason: AxiosError) => {
 				if (retries < 3) {
+					// Check if this is a 429 (Too Many Requests) response
+					const status = reason.response?.status
+					if (status === 429) {
+						const delay = calculateRetryDelay(retries, reason)
+						await sleep(delay)
+					}
+
 					fetchPlus(url, options, retries + 1)
 						.then(resolve)
 						.catch(reject)

--- a/tests/helpers/utils/cloudflareIps.test.ts
+++ b/tests/helpers/utils/cloudflareIps.test.ts
@@ -5,7 +5,6 @@ import { AxiosResponse } from 'axios'
 import {
 	clearCache,
 	CLOUDFLARE_IPS_API,
-	CloudflareIps,
 	fetchIpsFromApi,
 	getAllIps,
 	getCachedIps,
@@ -58,7 +57,7 @@ describe('cloudflareIps', () => {
 			expect(result.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
 			expect(result.ipv6).toEqual(mockCloudflareResponse.result.ipv6_cidrs)
 			expect(result.fetchedAt).toBeGreaterThan(0)
-			expect(pooledAxios.get).toHaveBeenCalledWith(CLOUDFLARE_IPS_API)
+			expect(pooledAxios.get).toHaveBeenCalledWith(CLOUDFLARE_IPS_API, {})
 		})
 
 		test('should throw error when API returns errors', async () => {
@@ -290,68 +289,6 @@ describe('cloudflareIps', () => {
 			clearCache()
 			expect(isCacheValid()).toBe(false)
 			expect(getCachedIps()).toBeNull()
-		})
-	})
-
-	describe('CloudflareIps class', () => {
-		test('should have static fetchIps method', async () => {
-			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
-			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
-
-			const result = await CloudflareIps.fetchIps()
-
-			expect(result.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
-			expect(result.ipv6).toEqual(mockCloudflareResponse.result.ipv6_cidrs)
-		})
-
-		test('should have static getIps method', async () => {
-			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
-			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
-
-			const result = await CloudflareIps.getIps()
-
-			expect(result.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
-		})
-
-		test('should have static getAllIps method', async () => {
-			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
-			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
-
-			const result = await CloudflareIps.getAllIps()
-
-			expect(result).toContain('173.245.48.0/20')
-			expect(result).toContain('2400:cb00::/32')
-		})
-
-		test('should have static getCachedIps method', async () => {
-			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
-			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
-
-			await CloudflareIps.getIps()
-
-			const result = CloudflareIps.getCachedIps()
-			expect(result?.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
-		})
-
-		test('should have static clearCache method', async () => {
-			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
-			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
-
-			await CloudflareIps.getIps()
-			expect(CloudflareIps.isCacheValid()).toBe(true)
-
-			CloudflareIps.clearCache()
-			expect(CloudflareIps.isCacheValid()).toBe(false)
-		})
-
-		test('should have static isCacheValid method', async () => {
-			expect(CloudflareIps.isCacheValid()).toBe(false)
-
-			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
-			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
-
-			await CloudflareIps.getIps()
-			expect(CloudflareIps.isCacheValid()).toBe(true)
 		})
 	})
 })

--- a/tests/helpers/utils/cloudflareIps.test.ts
+++ b/tests/helpers/utils/cloudflareIps.test.ts
@@ -1,0 +1,328 @@
+jest.mock('#helpers/utils/connectionPool')
+
+import { AxiosResponse } from 'axios'
+
+import {
+	clearCache,
+	CLOUDFLARE_IPS_API,
+	CloudflareIps,
+	fetchIpsFromApi,
+	getAllIps,
+	getCachedIps,
+	getIps,
+	isCacheValid
+} from '#helpers/utils/cloudflareIps'
+import pooledAxios from '#helpers/utils/connectionPool'
+
+const mockCloudflareResponse = {
+	result: {
+		ipv4_cidrs: ['173.245.48.0/20', '103.21.244.0/22'],
+		ipv6_cidrs: ['2400:cb00::/32', '2606:4700::/32'],
+		etag: 'test-etag'
+	},
+	success: true,
+	errors: [],
+	messages: []
+}
+
+const mockCloudflareResponseV2 = {
+	result: {
+		ipv4_cidrs: ['173.245.48.0/20', '103.21.244.0/22', '192.0.2.0/24'],
+		ipv6_cidrs: ['2400:cb00::/32', '2606:4700::/32', '2001:db8::/32'],
+		etag: 'test-etag-v2'
+	},
+	success: true,
+	errors: [],
+	messages: []
+}
+
+describe('cloudflareIps', () => {
+	beforeEach(() => {
+		jest.clearAllMocks()
+		clearCache()
+		jest.useRealTimers()
+	})
+
+	afterEach(() => {
+		clearCache()
+		jest.useRealTimers()
+	})
+
+	describe('fetchIpsFromApi', () => {
+		test('should fetch and return Cloudflare IP ranges', async () => {
+			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
+			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+
+			const result = await fetchIpsFromApi()
+
+			expect(result.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
+			expect(result.ipv6).toEqual(mockCloudflareResponse.result.ipv6_cidrs)
+			expect(result.fetchedAt).toBeGreaterThan(0)
+			expect(pooledAxios.get).toHaveBeenCalledWith(CLOUDFLARE_IPS_API)
+		})
+
+		test('should throw error when API returns errors', async () => {
+			const errorResponse = {
+				data: {
+					result: null,
+					success: false,
+					errors: [{ code: 1000, message: 'API Error' }],
+					messages: []
+				},
+				status: 200
+			} as AxiosResponse
+			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(errorResponse)
+
+			await expect(fetchIpsFromApi()).rejects.toThrow('Cloudflare API returned errors')
+		})
+
+		test('should throw error when network request fails', async () => {
+			;(pooledAxios.get as jest.Mock).mockRejectedValueOnce(new Error('Network error'))
+
+			await expect(fetchIpsFromApi()).rejects.toThrow()
+		})
+	})
+
+	describe('getIps', () => {
+		test('should fetch IPs when cache is empty', async () => {
+			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
+			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+
+			const result = await getIps()
+
+			expect(result.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
+			expect(result.ipv6).toEqual(mockCloudflareResponse.result.ipv6_cidrs)
+			expect(pooledAxios.get).toHaveBeenCalledTimes(1)
+		})
+
+		test('should return cached IPs on subsequent calls', async () => {
+			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
+			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+
+			// First call - should fetch
+			const result1 = await getIps()
+			expect(result1.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
+			expect(pooledAxios.get).toHaveBeenCalledTimes(1)
+
+			// Second call - should use cache
+			const result2 = await getIps()
+			expect(result2).toEqual(result1)
+			expect(pooledAxios.get).toHaveBeenCalledTimes(1) // No additional fetch
+		})
+
+		test('should refetch after cache expires', async () => {
+			jest.useFakeTimers()
+
+			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
+			const mockResponseV2 = { data: mockCloudflareResponseV2, status: 200 } as AxiosResponse
+			;(pooledAxios.get as jest.Mock)
+				.mockResolvedValueOnce(mockResponse)
+				.mockResolvedValueOnce(mockResponseV2)
+
+			// First call - should fetch
+			const result1 = await getIps()
+			expect(result1.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
+
+			// Advance time by 25 hours (cache expires after 24 hours)
+			jest.advanceTimersByTime(25 * 60 * 60 * 1000)
+
+			// Second call - should refetch
+			const result2 = await getIps()
+			expect(result2.ipv4).toEqual(mockCloudflareResponseV2.result.ipv4_cidrs)
+			expect(pooledAxios.get).toHaveBeenCalledTimes(2)
+
+			jest.useRealTimers()
+		})
+
+		test('should return stale cached data when fetch fails', async () => {
+			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
+			;(pooledAxios.get as jest.Mock)
+				.mockResolvedValueOnce(mockResponse)
+				.mockRejectedValueOnce(new Error('Network error'))
+
+			// First call - should fetch and cache
+			const result1 = await getIps()
+			expect(result1.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
+
+			// Force cache expiration by manipulating time
+			jest.useFakeTimers()
+			jest.advanceTimersByTime(25 * 60 * 60 * 1000)
+
+			// Second call - fetch fails, should return stale cache
+			const result2 = await getIps()
+			expect(result2).toEqual(result1)
+
+			jest.useRealTimers()
+		})
+
+		test('should return empty arrays when fetch fails and no cache exists', async () => {
+			;(pooledAxios.get as jest.Mock).mockRejectedValueOnce(new Error('Network error'))
+
+			const result = await getIps()
+
+			expect(result.ipv4).toEqual([])
+			expect(result.ipv6).toEqual([])
+			expect(result.fetchedAt).toBe(0)
+		})
+	})
+
+	describe('getAllIps', () => {
+		test('should return combined IPv4 and IPv6 ranges', async () => {
+			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
+			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+
+			const result = await getAllIps()
+
+			expect(result).toEqual([
+				...mockCloudflareResponse.result.ipv4_cidrs,
+				...mockCloudflareResponse.result.ipv6_cidrs
+			])
+		})
+	})
+
+	describe('getCachedIps', () => {
+		test('should return null when cache is empty', () => {
+			const result = getCachedIps()
+			expect(result).toBeNull()
+		})
+
+		test('should return cached data when available', async () => {
+			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
+			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+
+			// Populate cache
+			await getIps()
+
+			const result = getCachedIps()
+			expect(result?.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
+			expect(result?.ipv6).toEqual(mockCloudflareResponse.result.ipv6_cidrs)
+		})
+
+		test('should return expired data when available', async () => {
+			jest.useFakeTimers()
+
+			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
+			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+
+			// Populate cache
+			await getIps()
+
+			// Advance time past expiration
+			jest.advanceTimersByTime(25 * 60 * 60 * 1000)
+
+			// Should still return expired data
+			const result = getCachedIps()
+			expect(result?.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
+
+			jest.useRealTimers()
+		})
+	})
+
+	describe('isCacheValid', () => {
+		test('should return false when cache is empty', () => {
+			expect(isCacheValid()).toBe(false)
+		})
+
+		test('should return true when cache is valid', async () => {
+			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
+			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+
+			await getIps()
+			expect(isCacheValid()).toBe(true)
+		})
+
+		test('should return false when cache is expired', async () => {
+			jest.useFakeTimers()
+
+			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
+			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+
+			await getIps()
+
+			// Advance time past expiration
+			jest.advanceTimersByTime(25 * 60 * 60 * 1000)
+
+			expect(isCacheValid()).toBe(false)
+
+			jest.useRealTimers()
+		})
+	})
+
+	describe('clearCache', () => {
+		test('should clear the cache', async () => {
+			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
+			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+
+			// Populate cache
+			await getIps()
+			expect(isCacheValid()).toBe(true)
+
+			// Clear cache
+			clearCache()
+			expect(isCacheValid()).toBe(false)
+			expect(getCachedIps()).toBeNull()
+		})
+	})
+
+	describe('CloudflareIps class', () => {
+		test('should have static fetchIps method', async () => {
+			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
+			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+
+			const result = await CloudflareIps.fetchIps()
+
+			expect(result.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
+			expect(result.ipv6).toEqual(mockCloudflareResponse.result.ipv6_cidrs)
+		})
+
+		test('should have static getIps method', async () => {
+			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
+			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+
+			const result = await CloudflareIps.getIps()
+
+			expect(result.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
+		})
+
+		test('should have static getAllIps method', async () => {
+			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
+			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+
+			const result = await CloudflareIps.getAllIps()
+
+			expect(result).toContain('173.245.48.0/20')
+			expect(result).toContain('2400:cb00::/32')
+		})
+
+		test('should have static getCachedIps method', async () => {
+			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
+			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+
+			await CloudflareIps.getIps()
+
+			const result = CloudflareIps.getCachedIps()
+			expect(result?.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
+		})
+
+		test('should have static clearCache method', async () => {
+			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
+			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+
+			await CloudflareIps.getIps()
+			expect(CloudflareIps.isCacheValid()).toBe(true)
+
+			CloudflareIps.clearCache()
+			expect(CloudflareIps.isCacheValid()).toBe(false)
+		})
+
+		test('should have static isCacheValid method', async () => {
+			expect(CloudflareIps.isCacheValid()).toBe(false)
+
+			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
+			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+
+			await CloudflareIps.getIps()
+			expect(CloudflareIps.isCacheValid()).toBe(true)
+		})
+	})
+})


### PR DESCRIPTION
## Summary
Rate limiting fixes including Cloudflare IP auto-discovery, 429 exponential backoff, and race condition prevention.

## Changes
- Add Cloudflare IP auto-fetching to prevent rate limiting by Cloudflare edge nodes
- Implement exponential backoff for 429 responses (1s → 2s → 4s → max 8s)
- Support CIDR notation in TRUSTED_PROXIES
- Prevent race condition in concurrent IP fetches
- Add comprehensive tests

## Files Changed
- `src/server.ts` - Trust Cloudflare IPs and CIDR support
- `src/helpers/utils/fetchPlus.ts` - 429 exponential backoff
- `src/helpers/utils/cloudflareIps.ts` - New Cloudflare IP fetcher
- `tests/helpers/utils/cloudflareIps.test.ts` - Cloudflare IP tests
- `tests/helpers/utils/fetchPlus.test.ts` - 429 backoff tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exponential backoff retry for rate-limited requests.
  * In-memory caching of Cloudflare IP ranges for trusted-proxy decisions.

* **Improvements**
  * More resilient handling of rate limits and proxy verification (CIDR support).
  * Server startup now builds and logs trusted-proxy configuration.

* **Tests**
  * Comprehensive tests for Cloudflare IP caching and backoff behavior.

* **Automation**
  * Workflow to sync version bumps from main to develop after releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->