### PR TITLE
fix(api): distinguish delisted products from region-unavailable errors

### DIFF
--- a/src/helpers/books/audible/ApiHelper.ts
+++ b/src/helpers/books/audible/ApiHelper.ts
@@ -391,11 +391,16 @@ class ApiHelper {
 			'response_groups=customer_rights'
 		)
 		return fetch(url)
-			.then(async (response) => {
+			.then((response) => {
 				const json = response.data as { product?: { product_state?: string } }
 				return json?.product?.product_state
 			})
-			.catch(() => undefined)
+			.catch((error) => {
+				this.logger?.error(
+					`[AUDIBLE API] Failed to fetch product_state for ASIN ${this.asin}: ${error instanceof Error ? error.message : error}`
+				)
+				return undefined
+			})
 	}
 
 	/**

--- a/src/helpers/books/audible/ApiHelper.ts
+++ b/src/helpers/books/audible/ApiHelper.ts
@@ -29,6 +29,7 @@ import {
 	ErrorMessageHTTPFetch,
 	ErrorMessageNoData,
 	ErrorMessageParse,
+	ErrorMessageProductDelisted,
 	ErrorMessageRegion,
 	ErrorMessageReleaseDate,
 	ErrorMessageRequiredKey
@@ -372,6 +373,30 @@ class ApiHelper {
 				throw new Error(ErrorMessageHTTPFetch(this.asin, error.status, 'Audible API'))
 			})
 	}
+	/**
+	 * Fetches the product_state from the customer_rights response group.
+	 * Only called when the initial parse fails to determine the reason.
+	 * @returns {Promise<string | undefined>} product_state value, e.g. 'AVAILABLE', 'NOT_AVAILABLE_FOR_PURCHASE'
+	 */
+	async fetchProductState(): Promise<string | undefined> {
+		const helper = new SharedHelper()
+		const baseDomain = 'https://api.audible'
+		const regionTLD = regions[this.region].tld
+		const baseUrl = '1.0/catalog/products'
+		const url = helper.buildUrl(
+			this.asin,
+			baseDomain,
+			regionTLD,
+			baseUrl,
+			'response_groups=customer_rights'
+		)
+		return fetch(url)
+			.then(async (response) => {
+				const json = response.data as { product?: { product_state?: string } }
+				return json?.product?.product_state
+			})
+			.catch(() => undefined)
+	}
 
 	/**
 	 * Parses fetched Audible API data
@@ -412,7 +437,15 @@ class ApiHelper {
 				})
 				return this.getFinalData()
 			}
-			// baseShape also failed - likely truly unavailable in region
+			// baseShape also failed - fetch product_state for a specific error
+			const productState = await this.fetchProductState()
+			if (productState && productState !== 'AVAILABLE') {
+				throw new NotFoundError(ErrorMessageProductDelisted(this.asin, productState, this.region), {
+					asin: this.asin,
+					code: 'PRODUCT_DELISTED',
+					productState
+				})
+			}
 			throw new NotFoundError(ErrorMessageRegion(this.asin, this.region), {
 				asin: this.asin,
 				code: 'REGION_UNAVAILABLE'

--- a/src/helpers/routes/GenericShowHelper.ts
+++ b/src/helpers/routes/GenericShowHelper.ts
@@ -21,6 +21,7 @@ import PaprAudibleAuthorHelper from '#helpers/database/papr/audible/PaprAudibleA
 import PaprAudibleBookHelper from '#helpers/database/papr/audible/PaprAudibleBookHelper'
 import PaprAudibleChapterHelper from '#helpers/database/papr/audible/PaprAudibleChapterHelper'
 import RedisHelper from '#helpers/database/redis/RedisHelper'
+import { NotFoundError } from '#helpers/errors/ApiErrors'
 import SharedHelper from '#helpers/utils/shared'
 import {
 	ErrorMessageDataType,
@@ -201,7 +202,15 @@ export default class GenericShowHelper {
 			(await this.createOrUpdateData()
 				.then((data) => data)
 				.catch((err) => {
-					// Preserve custom errors with statusCode (NotFoundError, BadRequestError)
+					// If the product is no longer available on Audible (delisted or
+					// region-unavailable) but we have existing data, preserve it
+					if (err instanceof NotFoundError) {
+						this.logger?.warn(
+							`Update failed for ${this.type} ${this.asin}: ${err.message}. Returning existing data.`
+						)
+						return this.getDataWithProjection()
+					}
+					// Preserve other custom errors with statusCode (ContentTypeMismatchError, BadRequestError)
 					if (err instanceof Error && 'statusCode' in err) {
 						throw err
 					}

--- a/src/static/messages.ts
+++ b/src/static/messages.ts
@@ -22,6 +22,8 @@ export const ErrorMessageParse = (asin: string, source: string) =>
 // Item not available in region
 export const ErrorMessageRegion = (asin: string, region: string) =>
 	`Item not available in region '${region}' for ASIN: ${asin}`
+export const ErrorMessageProductDelisted = (asin: string, productState: string, region: string) =>
+	`Item is '${productState}' in region '${region}' for ASIN: ${asin}`
 // Content type mismatch
 export const ErrorMessageContentTypeMismatch = (
 	asin: string,


### PR DESCRIPTION
## Purpose/Goal

Provide accurate error messages when Audible products are delisted, and protect existing DB data from being overwritten or lost when a previously-available product is removed from Audible.

## Summary

When an ASIN is delisted from Audible (e.g. `NOT_AVAILABLE_FOR_PURCHASE`), the API returned a generic `REGION_UNAVAILABLE` error — misleading consumers into thinking the product simply was never available in their region. Additionally, requesting `update=1` on a delisted book that already existed in DB would throw a 404, making the existing data inaccessible.

## Key Changes

- **`ApiHelper.fetchProductState()`**: New method that queries the `customer_rights` response group only when the initial parse fails (zero overhead on happy path). Returns the `product_state` field (e.g. `AVAILABLE`, `NOT_AVAILABLE_FOR_PURCHASE`).
- **`ApiHelper.parseResponse()`**: When base shape parsing fails, calls `fetchProductState()`. If `product_state` is not `AVAILABLE`, throws `NotFoundError` with code `PRODUCT_DELISTED` and the actual state — otherwise falls back to `REGION_UNAVAILABLE`.
- **`GenericShowHelper.updateActions()`**: Catches `NotFoundError` during update and returns existing DB data instead of re-throwing. Logs a warning so operators can identify delisted products. Other errors (content type mismatch, validation, etc.) still propagate.
- **`messages.ts`**: Added `ErrorMessageProductDelisted(asin, productState, region)` for descriptive error messages.

## Risks

- `fetchProductState()` makes a second HTTP request to Audible on the failure path only. If the `customer_rights` response group is rate-limited differently, this could add latency on errors. The catch returns `undefined` gracefully if the request itself fails.

## Test Plan

- [x] `bun run lint` passes
- [x] `bun run build` passes
- [x] `bun run test` passes (112 tests)
- [x] E2E: delisted ASIN (B00475F1WO) returns 404 `PRODUCT_DELISTED` with no DB data
- [x] E2E: delisted ASIN with existing DB data + `update=1` returns 200 with existing data (DB not overwritten)
- [x] E2E: valid ASIN returns 200 normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added detection for delisted Audible products with improved error messaging.

* **Bug Fixes**
  * Enhanced error handling with better error context preservation for debugging.
  * Improved handling of region-unavailable content scenarios.

* **Chores**
  * Migrated project runtime from Node.js to Bun.
  * Updated CI/CD workflows and GitHub Actions for Bun compatibility.
  * Updated container base images and Docker configurations.
  * Updated dependencies including `@fastify/cors` and `p-limit`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laxamentumtech/audnexus/pull/862?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->