### PR TITLE
feat: distinguish delisted products from region-unavailable errors

### DIFF
--- a/src/helpers/books/audible/ApiHelper.ts
+++ b/src/helpers/books/audible/ApiHelper.ts
@@ -391,11 +391,16 @@ class ApiHelper {
 			'response_groups=customer_rights'
 		)
 		return fetch(url)
-			.then(async (response) => {
+			.then((response) => {
 				const json = response.data as { product?: { product_state?: string } }
 				return json?.product?.product_state
 			})
-			.catch(() => undefined)
+			.catch((error) => {
+				this.logger?.error(
+					`[AUDIBLE API] Failed to fetch product_state for ASIN ${this.asin}: ${error instanceof Error ? error.message : error}`
+				)
+				return undefined
+			})
 	}
 
 	/**

--- a/src/helpers/books/audible/ApiHelper.ts
+++ b/src/helpers/books/audible/ApiHelper.ts
@@ -29,6 +29,7 @@ import {
 	ErrorMessageHTTPFetch,
 	ErrorMessageNoData,
 	ErrorMessageParse,
+	ErrorMessageProductDelisted,
 	ErrorMessageRegion,
 	ErrorMessageReleaseDate,
 	ErrorMessageRequiredKey
@@ -372,6 +373,30 @@ class ApiHelper {
 				throw new Error(ErrorMessageHTTPFetch(this.asin, error.status, 'Audible API'))
 			})
 	}
+	/**
+	 * Fetches the product_state from the customer_rights response group.
+	 * Only called when the initial parse fails to determine the reason.
+	 * @returns {Promise<string | undefined>} product_state value, e.g. 'AVAILABLE', 'NOT_AVAILABLE_FOR_PURCHASE'
+	 */
+	async fetchProductState(): Promise<string | undefined> {
+		const helper = new SharedHelper()
+		const baseDomain = 'https://api.audible'
+		const regionTLD = regions[this.region].tld
+		const baseUrl = '1.0/catalog/products'
+		const url = helper.buildUrl(
+			this.asin,
+			baseDomain,
+			regionTLD,
+			baseUrl,
+			'response_groups=customer_rights'
+		)
+		return fetch(url)
+			.then(async (response) => {
+				const json = response.data as { product?: { product_state?: string } }
+				return json?.product?.product_state
+			})
+			.catch(() => undefined)
+	}
 
 	/**
 	 * Parses fetched Audible API data
@@ -412,7 +437,15 @@ class ApiHelper {
 				})
 				return this.getFinalData()
 			}
-			// baseShape also failed - likely truly unavailable in region
+			// baseShape also failed - fetch product_state for a specific error
+			const productState = await this.fetchProductState()
+			if (productState && productState !== 'AVAILABLE') {
+				throw new NotFoundError(ErrorMessageProductDelisted(this.asin, productState, this.region), {
+					asin: this.asin,
+					code: 'PRODUCT_DELISTED',
+					productState
+				})
+			}
 			throw new NotFoundError(ErrorMessageRegion(this.asin, this.region), {
 				asin: this.asin,
 				code: 'REGION_UNAVAILABLE'

--- a/src/helpers/books/audible/ApiHelper.ts
+++ b/src/helpers/books/audible/ApiHelper.ts
@@ -36,6 +36,9 @@ import {
 } from '#static/messages'
 import { regions } from '#static/regions'
 
+/** Known product_state values that indicate a delisted/unavailable product. */
+const DELISTED_STATES: readonly string[] = ['NOT_AVAILABLE_FOR_PURCHASE']
+
 class ApiHelper {
 	asin: string
 	categories: AudibleCategory[][] | undefined
@@ -444,7 +447,7 @@ class ApiHelper {
 			}
 			// baseShape also failed - fetch product_state for a specific error
 			const productState = await this.fetchProductState()
-			if (productState && productState !== 'AVAILABLE') {
+			if (productState && DELISTED_STATES.includes(productState)) {
 				throw new NotFoundError(ErrorMessageProductDelisted(this.asin, productState, this.region), {
 					asin: this.asin,
 					code: 'PRODUCT_DELISTED',

--- a/src/helpers/routes/GenericShowHelper.ts
+++ b/src/helpers/routes/GenericShowHelper.ts
@@ -21,6 +21,7 @@ import PaprAudibleAuthorHelper from '#helpers/database/papr/audible/PaprAudibleA
 import PaprAudibleBookHelper from '#helpers/database/papr/audible/PaprAudibleBookHelper'
 import PaprAudibleChapterHelper from '#helpers/database/papr/audible/PaprAudibleChapterHelper'
 import RedisHelper from '#helpers/database/redis/RedisHelper'
+import { NotFoundError } from '#helpers/errors/ApiErrors'
 import SharedHelper from '#helpers/utils/shared'
 import {
 	ErrorMessageDataType,
@@ -201,7 +202,15 @@ export default class GenericShowHelper {
 			(await this.createOrUpdateData()
 				.then((data) => data)
 				.catch((err) => {
-					// Preserve custom errors with statusCode (NotFoundError, BadRequestError)
+					// If the product is no longer available on Audible (delisted or
+					// region-unavailable) but we have existing data, preserve it
+					if (err instanceof NotFoundError) {
+						this.logger?.warn(
+							`Update failed for ${this.type} ${this.asin}: ${err.message}. Returning existing data.`
+						)
+						return this.getDataWithProjection()
+					}
+					// Preserve other custom errors with statusCode (ContentTypeMismatchError, BadRequestError)
 					if (err instanceof Error && 'statusCode' in err) {
 						throw err
 					}

--- a/src/static/messages.ts
+++ b/src/static/messages.ts
@@ -22,6 +22,8 @@ export const ErrorMessageParse = (asin: string, source: string) =>
 // Item not available in region
 export const ErrorMessageRegion = (asin: string, region: string) =>
 	`Item not available in region '${region}' for ASIN: ${asin}`
+export const ErrorMessageProductDelisted = (asin: string, productState: string, region: string) =>
+	`Item is '${productState}' in region '${region}' for ASIN: ${asin}`
 // Content type mismatch
 export const ErrorMessageContentTypeMismatch = (
 	asin: string,

--- a/tests/helpers/books/audible/ApiHelper.test.ts
+++ b/tests/helpers/books/audible/ApiHelper.test.ts
@@ -343,6 +343,46 @@ describe('ApiHelper edge cases should', () => {
 		)
 	})
 
+	test('throws PRODUCT_DELISTED when fetchProductState returns NOT_AVAILABLE_FOR_PURCHASE', async () => {
+		const fetchProductStateSpy = jest
+			.spyOn(ApiHelper.prototype, 'fetchProductState')
+			.mockResolvedValue('NOT_AVAILABLE_FOR_PURCHASE')
+		const emptyProductResponse = { product: {} } as AudibleProduct
+		await expect(helper.parseResponse(emptyProductResponse)).rejects.toBeInstanceOf(NotFoundError)
+		await expect(helper.parseResponse(emptyProductResponse)).rejects.toMatchObject({
+			name: 'NotFoundError',
+			statusCode: 404,
+			message: `Item is 'NOT_AVAILABLE_FOR_PURCHASE' in region '${region}' for ASIN: ${asin}`,
+			details: {
+				asin,
+				code: 'PRODUCT_DELISTED',
+				productState: 'NOT_AVAILABLE_FOR_PURCHASE'
+			}
+		})
+		fetchProductStateSpy.mockRestore()
+	})
+
+	test.each([
+		['AVAILABLE'],
+		[undefined],
+		['SOME_OTHER_STATE']
+	] as const)('throws REGION_UNAVAILABLE when fetchProductState returns %s', async (state) => {
+		const fetchProductStateSpy = jest
+			.spyOn(ApiHelper.prototype, 'fetchProductState')
+			.mockResolvedValue(state)
+		const emptyProductResponse = { product: {} } as AudibleProduct
+		await expect(helper.parseResponse(emptyProductResponse)).rejects.toBeInstanceOf(NotFoundError)
+		await expect(helper.parseResponse(emptyProductResponse)).rejects.toMatchObject({
+			name: 'NotFoundError',
+			statusCode: 404,
+			message: `Item not available in region '${region}' for ASIN: ${asin}`,
+			details: {
+				asin,
+				code: 'REGION_UNAVAILABLE'
+			}
+		})
+		fetchProductStateSpy.mockRestore()
+	})
 	test('throws NotFoundError with statusCode 404 for unavailable region', async () => {
 		// Create a response with empty product (missing required baseShape fields)
 		const emptyProductResponse = { product: {} } as AudibleProduct


### PR DESCRIPTION
## Purpose/Goal

Distinguish delisted products from region-unavailable errors and protect existing DB data from being overwritten when Audible delists a product.

## Summary

This PR adds product state detection to differentiate between items that are temporarily unavailable in a region versus items that have been delisted by Audible. When a product is delisted but we have existing data in the database, we preserve that data instead of treating it as a not-found error.

## Changes

- **ApiHelper.ts**: Added `fetchProductState()` method to query the product_state from Audible's customer_rights response group. This allows us to distinguish between 'NOT_AVAILABLE_FOR_PURCHASE' (delisted) and other availability states.
- **GenericShowHelper.ts**: Modified error handling to preserve existing database records when a product is delisted (NotFoundError with product_state indicating delisting). Logs a warning instead of failing.
- **messages.ts**: Added `ErrorMessageProductDelisted` helper to format clear error messages showing the product state and region.

## Spirit/Intent

The intent is to protect valuable cached data from being lost when Audible delists products. Rather than treating all unavailability errors the same, we now distinguish between regional restrictions (temporary) and delisting (permanent), preserving historical data for delisted items while still surfacing the correct status to users.

## Test Plan

- [ ] Manual: Fetch a delisted product - should preserve existing DB data
- [ ] Manual: Fetch a region-unavailable product - should show appropriate error
- [ ] Manual: Verify error messages display product state correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of delisted or unavailable products with enhanced error detection from the Audible API.
  * The app now gracefully displays existing data and informative error messages instead of failing when a product becomes unavailable.

* **Documentation**
  * Added error messaging for product availability issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laxamentumtech/audnexus/pull/863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->