### PR TITLE
refactor(test): complete Jest-to-Bun test runner migration

### DIFF
--- a/.github/workflows/bun.yml
+++ b/.github/workflows/bun.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.11
+          bun-version: 1.3.14
       - name: Install dependencies
         run: bun install
       - name: Run linter

--- a/bun.lock
+++ b/bun.lock
@@ -40,10 +40,7 @@
         "concurrently": "^9.1.2",
         "eslint": "^10.0.0",
         "eslint-config-prettier": "^10.1.2",
-        "eslint-plugin-jest": "^28.11.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
-        "globals": "^17.3.0",
-        "jest-mock-extended": "4.0.0",
         "prettier": "^3.5.3",
         "standard-version": "^9.5.0",
         "typescript": "^5.9.3",
@@ -53,81 +50,9 @@
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "7.28.5", "js-tokens": "4.0.0", "picocolors": "1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
-    "@babel/compat-data": ["@babel/compat-data@7.29.0", "", {}, "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg=="],
-
-    "@babel/core": ["@babel/core@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-compilation-targets": "^7.28.6", "@babel/helper-module-transforms": "^7.28.6", "@babel/helpers": "^7.28.6", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/traverse": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA=="],
-
-    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
-
-    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.28.6", "", { "dependencies": { "@babel/compat-data": "^7.28.6", "@babel/helper-validator-option": "^7.27.1", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA=="],
-
-    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
-
-    "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
-
-    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.28.6", "", { "dependencies": { "@babel/helper-module-imports": "^7.28.6", "@babel/helper-validator-identifier": "^7.28.5", "@babel/traverse": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA=="],
-
-    "@babel/helper-plugin-utils": ["@babel/helper-plugin-utils@7.28.6", "", {}, "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug=="],
-
-    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
-
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
-    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.27.1", "", {}, "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg=="],
-
-    "@babel/helpers": ["@babel/helpers@7.28.6", "", { "dependencies": { "@babel/template": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw=="],
-
-    "@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
-
-    "@babel/plugin-syntax-async-generators": ["@babel/plugin-syntax-async-generators@7.8.4", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw=="],
-
-    "@babel/plugin-syntax-bigint": ["@babel/plugin-syntax-bigint@7.8.3", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg=="],
-
-    "@babel/plugin-syntax-class-properties": ["@babel/plugin-syntax-class-properties@7.12.13", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.12.13" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA=="],
-
-    "@babel/plugin-syntax-class-static-block": ["@babel/plugin-syntax-class-static-block@7.14.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.14.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw=="],
-
-    "@babel/plugin-syntax-import-attributes": ["@babel/plugin-syntax-import-attributes@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw=="],
-
-    "@babel/plugin-syntax-import-meta": ["@babel/plugin-syntax-import-meta@7.10.4", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.10.4" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g=="],
-
-    "@babel/plugin-syntax-json-strings": ["@babel/plugin-syntax-json-strings@7.8.3", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA=="],
-
-    "@babel/plugin-syntax-jsx": ["@babel/plugin-syntax-jsx@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w=="],
-
-    "@babel/plugin-syntax-logical-assignment-operators": ["@babel/plugin-syntax-logical-assignment-operators@7.10.4", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.10.4" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig=="],
-
-    "@babel/plugin-syntax-nullish-coalescing-operator": ["@babel/plugin-syntax-nullish-coalescing-operator@7.8.3", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ=="],
-
-    "@babel/plugin-syntax-numeric-separator": ["@babel/plugin-syntax-numeric-separator@7.10.4", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.10.4" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug=="],
-
-    "@babel/plugin-syntax-object-rest-spread": ["@babel/plugin-syntax-object-rest-spread@7.8.3", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA=="],
-
-    "@babel/plugin-syntax-optional-catch-binding": ["@babel/plugin-syntax-optional-catch-binding@7.8.3", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q=="],
-
-    "@babel/plugin-syntax-optional-chaining": ["@babel/plugin-syntax-optional-chaining@7.8.3", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg=="],
-
-    "@babel/plugin-syntax-private-property-in-object": ["@babel/plugin-syntax-private-property-in-object@7.14.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.14.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg=="],
-
-    "@babel/plugin-syntax-top-level-await": ["@babel/plugin-syntax-top-level-await@7.14.5", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.14.5" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw=="],
-
-    "@babel/plugin-syntax-typescript": ["@babel/plugin-syntax-typescript@7.28.6", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A=="],
-
     "@babel/runtime": ["@babel/runtime@7.28.6", "", {}, "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA=="],
-
-    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
-
-    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
-
-    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
-
-    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@0.2.3", "", {}, "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="],
-
-    "@emnapi/core": ["@emnapi/core@1.8.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" } }, "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg=="],
-
-    "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
-
-    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
 
     "@emotion/is-prop-valid": ["@emotion/is-prop-valid@1.4.0", "", { "dependencies": { "@emotion/memoize": "0.9.0" } }, "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw=="],
 
@@ -197,61 +122,9 @@
 
     "@isaacs/cliui": ["@isaacs/cliui@9.0.0", "", {}, "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg=="],
 
-    "@istanbuljs/load-nyc-config": ["@istanbuljs/load-nyc-config@1.1.0", "", { "dependencies": { "camelcase": "^5.3.1", "find-up": "^4.1.0", "get-package-type": "^0.1.0", "js-yaml": "^3.13.1", "resolve-from": "^5.0.0" } }, "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ=="],
-
-    "@istanbuljs/schema": ["@istanbuljs/schema@0.1.3", "", {}, "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA=="],
-
-    "@jest/console": ["@jest/console@30.2.0", "", { "dependencies": { "@jest/types": "30.2.0", "@types/node": "*", "chalk": "^4.1.2", "jest-message-util": "30.2.0", "jest-util": "30.2.0", "slash": "^3.0.0" } }, "sha512-+O1ifRjkvYIkBqASKWgLxrpEhQAAE7hY77ALLUufSk5717KfOShg6IbqLmdsLMPdUiFvA2kTs0R7YZy+l0IzZQ=="],
-
-    "@jest/core": ["@jest/core@30.2.0", "", { "dependencies": { "@jest/console": "30.2.0", "@jest/pattern": "30.0.1", "@jest/reporters": "30.2.0", "@jest/test-result": "30.2.0", "@jest/transform": "30.2.0", "@jest/types": "30.2.0", "@types/node": "*", "ansi-escapes": "^4.3.2", "chalk": "^4.1.2", "ci-info": "^4.2.0", "exit-x": "^0.2.2", "graceful-fs": "^4.2.11", "jest-changed-files": "30.2.0", "jest-config": "30.2.0", "jest-haste-map": "30.2.0", "jest-message-util": "30.2.0", "jest-regex-util": "30.0.1", "jest-resolve": "30.2.0", "jest-resolve-dependencies": "30.2.0", "jest-runner": "30.2.0", "jest-runtime": "30.2.0", "jest-snapshot": "30.2.0", "jest-util": "30.2.0", "jest-validate": "30.2.0", "jest-watcher": "30.2.0", "micromatch": "^4.0.8", "pretty-format": "30.2.0", "slash": "^3.0.0" }, "peerDependencies": { "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0" }, "optionalPeers": ["node-notifier"] }, "sha512-03W6IhuhjqTlpzh/ojut/pDB2LPRygyWX8ExpgHtQA8H/3K7+1vKmcINx5UzeOX1se6YEsBsOHQ1CRzf3fOwTQ=="],
-
-    "@jest/diff-sequences": ["@jest/diff-sequences@30.0.1", "", {}, "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw=="],
-
-    "@jest/environment": ["@jest/environment@30.2.0", "", { "dependencies": { "@jest/fake-timers": "30.2.0", "@jest/types": "30.2.0", "@types/node": "*", "jest-mock": "30.2.0" } }, "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g=="],
-
-    "@jest/expect": ["@jest/expect@30.2.0", "", { "dependencies": { "expect": "30.2.0", "jest-snapshot": "30.2.0" } }, "sha512-V9yxQK5erfzx99Sf+7LbhBwNWEZ9eZay8qQ9+JSC0TrMR1pMDHLMY+BnVPacWU6Jamrh252/IKo4F1Xn/zfiqA=="],
-
-    "@jest/expect-utils": ["@jest/expect-utils@30.2.0", "", { "dependencies": { "@jest/get-type": "30.1.0" } }, "sha512-1JnRfhqpD8HGpOmQp180Fo9Zt69zNtC+9lR+kT7NVL05tNXIi+QC8Csz7lfidMoVLPD3FnOtcmp0CEFnxExGEA=="],
-
-    "@jest/fake-timers": ["@jest/fake-timers@30.2.0", "", { "dependencies": { "@jest/types": "30.2.0", "@sinonjs/fake-timers": "^13.0.0", "@types/node": "*", "jest-message-util": "30.2.0", "jest-mock": "30.2.0", "jest-util": "30.2.0" } }, "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw=="],
-
-    "@jest/get-type": ["@jest/get-type@30.1.0", "", {}, "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA=="],
-
-    "@jest/globals": ["@jest/globals@30.2.0", "", { "dependencies": { "@jest/environment": "30.2.0", "@jest/expect": "30.2.0", "@jest/types": "30.2.0", "jest-mock": "30.2.0" } }, "sha512-b63wmnKPaK+6ZZfpYhz9K61oybvbI1aMcIs80++JI1O1rR1vaxHUCNqo3ITu6NU0d4V34yZFoHMn/uoKr/Rwfw=="],
-
-    "@jest/pattern": ["@jest/pattern@30.0.1", "", { "dependencies": { "@types/node": "*", "jest-regex-util": "30.0.1" } }, "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA=="],
-
-    "@jest/reporters": ["@jest/reporters@30.2.0", "", { "dependencies": { "@bcoe/v8-coverage": "^0.2.3", "@jest/console": "30.2.0", "@jest/test-result": "30.2.0", "@jest/transform": "30.2.0", "@jest/types": "30.2.0", "@jridgewell/trace-mapping": "^0.3.25", "@types/node": "*", "chalk": "^4.1.2", "collect-v8-coverage": "^1.0.2", "exit-x": "^0.2.2", "glob": "^10.3.10", "graceful-fs": "^4.2.11", "istanbul-lib-coverage": "^3.0.0", "istanbul-lib-instrument": "^6.0.0", "istanbul-lib-report": "^3.0.0", "istanbul-lib-source-maps": "^5.0.0", "istanbul-reports": "^3.1.3", "jest-message-util": "30.2.0", "jest-util": "30.2.0", "jest-worker": "30.2.0", "slash": "^3.0.0", "string-length": "^4.0.2", "v8-to-istanbul": "^9.0.1" }, "peerDependencies": { "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0" }, "optionalPeers": ["node-notifier"] }, "sha512-DRyW6baWPqKMa9CzeiBjHwjd8XeAyco2Vt8XbcLFjiwCOEKOvy82GJ8QQnJE9ofsxCMPjH4MfH8fCWIHHDKpAQ=="],
-
-    "@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
-
-    "@jest/snapshot-utils": ["@jest/snapshot-utils@30.2.0", "", { "dependencies": { "@jest/types": "30.2.0", "chalk": "^4.1.2", "graceful-fs": "^4.2.11", "natural-compare": "^1.4.0" } }, "sha512-0aVxM3RH6DaiLcjj/b0KrIBZhSX1373Xci4l3cW5xiUWPctZ59zQ7jj4rqcJQ/Z8JuN/4wX3FpJSa3RssVvCug=="],
-
-    "@jest/source-map": ["@jest/source-map@30.0.1", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "callsites": "^3.1.0", "graceful-fs": "^4.2.11" } }, "sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg=="],
-
-    "@jest/test-result": ["@jest/test-result@30.2.0", "", { "dependencies": { "@jest/console": "30.2.0", "@jest/types": "30.2.0", "@types/istanbul-lib-coverage": "^2.0.6", "collect-v8-coverage": "^1.0.2" } }, "sha512-RF+Z+0CCHkARz5HT9mcQCBulb1wgCP3FBvl9VFokMX27acKphwyQsNuWH3c+ojd1LeWBLoTYoxF0zm6S/66mjg=="],
-
-    "@jest/test-sequencer": ["@jest/test-sequencer@30.2.0", "", { "dependencies": { "@jest/test-result": "30.2.0", "graceful-fs": "^4.2.11", "jest-haste-map": "30.2.0", "slash": "^3.0.0" } }, "sha512-wXKgU/lk8fKXMu/l5Hog1R61bL4q5GCdT6OJvdAFz1P+QrpoFuLU68eoKuVc4RbrTtNnTL5FByhWdLgOPSph+Q=="],
-
-    "@jest/transform": ["@jest/transform@30.2.0", "", { "dependencies": { "@babel/core": "^7.27.4", "@jest/types": "30.2.0", "@jridgewell/trace-mapping": "^0.3.25", "babel-plugin-istanbul": "^7.0.1", "chalk": "^4.1.2", "convert-source-map": "^2.0.0", "fast-json-stable-stringify": "^2.1.0", "graceful-fs": "^4.2.11", "jest-haste-map": "30.2.0", "jest-regex-util": "30.0.1", "jest-util": "30.2.0", "micromatch": "^4.0.8", "pirates": "^4.0.7", "slash": "^3.0.0", "write-file-atomic": "^5.0.1" } }, "sha512-XsauDV82o5qXbhalKxD7p4TZYYdwcaEXC77PPD2HixEFF+6YGppjrAAQurTl2ECWcEomHBMMNS9AH3kcCFx8jA=="],
-
-    "@jest/types": ["@jest/types@30.2.0", "", { "dependencies": { "@jest/pattern": "30.0.1", "@jest/schemas": "30.0.5", "@types/istanbul-lib-coverage": "^2.0.6", "@types/istanbul-reports": "^3.0.4", "@types/node": "*", "@types/yargs": "^17.0.33", "chalk": "^4.1.2" } }, "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg=="],
-
-    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
-
-    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
-
-    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
-
-    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
-
-    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
-
     "@lukeed/ms": ["@lukeed/ms@2.0.2", "", {}, "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA=="],
 
     "@mongodb-js/saslprep": ["@mongodb-js/saslprep@1.4.6", "", { "dependencies": { "sparse-bitfield": "3.0.3" } }, "sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g=="],
-
-    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "^1.4.3", "@emnapi/runtime": "^1.4.3", "@tybys/wasm-util": "^0.10.0" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -282,10 +155,6 @@
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.34.0", "", {}, "sha512-aKcOkyrorBGlajjRdVoJWHTxfxO1vCNHLJVlSDaRHDIdjU+pX8IYQPvPDkYiujKLbRnWU+1TBwEt0QRgSm4SGA=="],
 
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
-
-    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
-
-    "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -319,22 +188,6 @@
 
     "@selderee/plugin-htmlparser2": ["@selderee/plugin-htmlparser2@0.11.0", "", { "dependencies": { "domhandler": "5.0.3", "selderee": "0.11.0" } }, "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ=="],
 
-    "@sinclair/typebox": ["@sinclair/typebox@0.34.48", "", {}, "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA=="],
-
-    "@sinonjs/commons": ["@sinonjs/commons@3.0.1", "", { "dependencies": { "type-detect": "4.0.8" } }, "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ=="],
-
-    "@sinonjs/fake-timers": ["@sinonjs/fake-timers@13.0.5", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw=="],
-
-    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
-
-    "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
-
-    "@types/babel__generator": ["@types/babel__generator@7.27.0", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg=="],
-
-    "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
-
-    "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
-
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
@@ -342,12 +195,6 @@
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
     "@types/html-to-text": ["@types/html-to-text@9.0.4", "", {}, "sha512-pUY3cKH/Nm2yYrEmDlPR1mR7yszjGx4DrwPjQ702C4/D5CwHuZTgZdIdwPkRbcuhs7BAh2L5rg3CL5cbRiGTCQ=="],
-
-    "@types/istanbul-lib-coverage": ["@types/istanbul-lib-coverage@2.0.6", "", {}, "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w=="],
-
-    "@types/istanbul-lib-report": ["@types/istanbul-lib-report@3.0.3", "", { "dependencies": { "@types/istanbul-lib-coverage": "*" } }, "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA=="],
-
-    "@types/istanbul-reports": ["@types/istanbul-reports@3.0.4", "", { "dependencies": { "@types/istanbul-lib-report": "*" } }, "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
@@ -361,8 +208,6 @@
 
     "@types/normalize-package-data": ["@types/normalize-package-data@2.4.4", "", {}, "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA=="],
 
-    "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
-
     "@types/stylis": ["@types/stylis@4.2.7", "", {}, "sha512-VgDNokpBoKF+wrdvhAAfS55OMQpL6QRglwTwNC3kIgBrzZxA4WsFj+2eLfEA/uMUDzBcEhYmjSbwQakn/i3ajA=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
@@ -370,10 +215,6 @@
     "@types/webidl-conversions": ["@types/webidl-conversions@7.0.3", "", {}, "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA=="],
 
     "@types/whatwg-url": ["@types/whatwg-url@13.0.0", "", { "dependencies": { "@types/webidl-conversions": "7.0.3" } }, "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q=="],
-
-    "@types/yargs": ["@types/yargs@17.0.35", "", { "dependencies": { "@types/yargs-parser": "*" } }, "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg=="],
-
-    "@types/yargs-parser": ["@types/yargs-parser@21.0.3", "", {}, "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.55.0", "", { "dependencies": { "@eslint-community/regexpp": "4.12.2", "@typescript-eslint/scope-manager": "8.55.0", "@typescript-eslint/type-utils": "8.55.0", "@typescript-eslint/utils": "8.55.0", "@typescript-eslint/visitor-keys": "8.55.0", "ignore": "7.0.5", "natural-compare": "1.4.0", "ts-api-utils": "2.4.0" }, "peerDependencies": { "@typescript-eslint/parser": "8.55.0", "eslint": "10.0.0", "typescript": "5.9.3" } }, "sha512-1y/MVSz0NglV1ijHC8OT49mPJ4qhPYjiK08YUQVbIOyu+5k862LKUHFkpKHWu//zmr7hDR2rhwUm6gnCGNmGBQ=="],
 
@@ -395,46 +236,6 @@
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.55.0", "", { "dependencies": { "@typescript-eslint/types": "8.55.0", "eslint-visitor-keys": "4.2.1" } }, "sha512-AxNRwEie8Nn4eFS1FzDMJWIISMGoXMb037sgCBJ3UR6o0fQTzr2tqN9WT+DkWJPhIdQCfV7T6D387566VtnCJA=="],
 
-    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
-
-    "@unrs/resolver-binding-android-arm-eabi": ["@unrs/resolver-binding-android-arm-eabi@1.11.1", "", { "os": "android", "cpu": "arm" }, "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw=="],
-
-    "@unrs/resolver-binding-android-arm64": ["@unrs/resolver-binding-android-arm64@1.11.1", "", { "os": "android", "cpu": "arm64" }, "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g=="],
-
-    "@unrs/resolver-binding-darwin-arm64": ["@unrs/resolver-binding-darwin-arm64@1.11.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g=="],
-
-    "@unrs/resolver-binding-darwin-x64": ["@unrs/resolver-binding-darwin-x64@1.11.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ=="],
-
-    "@unrs/resolver-binding-freebsd-x64": ["@unrs/resolver-binding-freebsd-x64@1.11.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw=="],
-
-    "@unrs/resolver-binding-linux-arm-gnueabihf": ["@unrs/resolver-binding-linux-arm-gnueabihf@1.11.1", "", { "os": "linux", "cpu": "arm" }, "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw=="],
-
-    "@unrs/resolver-binding-linux-arm-musleabihf": ["@unrs/resolver-binding-linux-arm-musleabihf@1.11.1", "", { "os": "linux", "cpu": "arm" }, "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw=="],
-
-    "@unrs/resolver-binding-linux-arm64-gnu": ["@unrs/resolver-binding-linux-arm64-gnu@1.11.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ=="],
-
-    "@unrs/resolver-binding-linux-arm64-musl": ["@unrs/resolver-binding-linux-arm64-musl@1.11.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w=="],
-
-    "@unrs/resolver-binding-linux-ppc64-gnu": ["@unrs/resolver-binding-linux-ppc64-gnu@1.11.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA=="],
-
-    "@unrs/resolver-binding-linux-riscv64-gnu": ["@unrs/resolver-binding-linux-riscv64-gnu@1.11.1", "", { "os": "linux", "cpu": "none" }, "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ=="],
-
-    "@unrs/resolver-binding-linux-riscv64-musl": ["@unrs/resolver-binding-linux-riscv64-musl@1.11.1", "", { "os": "linux", "cpu": "none" }, "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew=="],
-
-    "@unrs/resolver-binding-linux-s390x-gnu": ["@unrs/resolver-binding-linux-s390x-gnu@1.11.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg=="],
-
-    "@unrs/resolver-binding-linux-x64-gnu": ["@unrs/resolver-binding-linux-x64-gnu@1.11.1", "", { "os": "linux", "cpu": "x64" }, "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w=="],
-
-    "@unrs/resolver-binding-linux-x64-musl": ["@unrs/resolver-binding-linux-x64-musl@1.11.1", "", { "os": "linux", "cpu": "x64" }, "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA=="],
-
-    "@unrs/resolver-binding-wasm32-wasi": ["@unrs/resolver-binding-wasm32-wasi@1.11.1", "", { "dependencies": { "@napi-rs/wasm-runtime": "^0.2.11" }, "cpu": "none" }, "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ=="],
-
-    "@unrs/resolver-binding-win32-arm64-msvc": ["@unrs/resolver-binding-win32-arm64-msvc@1.11.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw=="],
-
-    "@unrs/resolver-binding-win32-ia32-msvc": ["@unrs/resolver-binding-win32-ia32-msvc@1.11.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ=="],
-
-    "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
-
     "JSONStream": ["JSONStream@1.3.5", "", { "dependencies": { "jsonparse": "1.3.1", "through": "2.3.8" }, "bin": { "JSONStream": "./bin.js" } }, "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ=="],
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "5.0.1" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
@@ -453,13 +254,9 @@
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "optionalDependencies": { "ajv": "@redocly/ajv@8.17.4" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
-    "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
-
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
-
-    "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
@@ -475,31 +272,13 @@
 
     "axios": ["axios@1.13.5", "", { "dependencies": { "follow-redirects": "1.15.11", "form-data": "4.0.5", "proxy-from-env": "1.1.0" } }, "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q=="],
 
-    "babel-jest": ["babel-jest@30.2.0", "", { "dependencies": { "@jest/transform": "30.2.0", "@types/babel__core": "^7.20.5", "babel-plugin-istanbul": "^7.0.1", "babel-preset-jest": "30.2.0", "chalk": "^4.1.2", "graceful-fs": "^4.2.11", "slash": "^3.0.0" }, "peerDependencies": { "@babel/core": "^7.11.0 || ^8.0.0-0" } }, "sha512-0YiBEOxWqKkSQWL9nNGGEgndoeL0ZpWrbLMNL5u/Kaxrli3Eaxlt3ZtIDktEvXt4L/R9r3ODr2zKwGM/2BjxVw=="],
-
-    "babel-plugin-istanbul": ["babel-plugin-istanbul@7.0.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.0.0", "@istanbuljs/load-nyc-config": "^1.0.0", "@istanbuljs/schema": "^0.1.3", "istanbul-lib-instrument": "^6.0.2", "test-exclude": "^6.0.0" } }, "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA=="],
-
-    "babel-plugin-jest-hoist": ["babel-plugin-jest-hoist@30.2.0", "", { "dependencies": { "@types/babel__core": "^7.20.5" } }, "sha512-ftzhzSGMUnOzcCXd6WHdBGMyuwy15Wnn0iyyWGKgBDLxf9/s5ABuraCSpBX2uG0jUg4rqJnxsLc5+oYBqoxVaA=="],
-
-    "babel-preset-current-node-syntax": ["babel-preset-current-node-syntax@1.2.0", "", { "dependencies": { "@babel/plugin-syntax-async-generators": "^7.8.4", "@babel/plugin-syntax-bigint": "^7.8.3", "@babel/plugin-syntax-class-properties": "^7.12.13", "@babel/plugin-syntax-class-static-block": "^7.14.5", "@babel/plugin-syntax-import-attributes": "^7.24.7", "@babel/plugin-syntax-import-meta": "^7.10.4", "@babel/plugin-syntax-json-strings": "^7.8.3", "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4", "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3", "@babel/plugin-syntax-numeric-separator": "^7.10.4", "@babel/plugin-syntax-object-rest-spread": "^7.8.3", "@babel/plugin-syntax-optional-catch-binding": "^7.8.3", "@babel/plugin-syntax-optional-chaining": "^7.8.3", "@babel/plugin-syntax-private-property-in-object": "^7.14.5", "@babel/plugin-syntax-top-level-await": "^7.14.5" }, "peerDependencies": { "@babel/core": "^7.0.0 || ^8.0.0-0" } }, "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg=="],
-
-    "babel-preset-jest": ["babel-preset-jest@30.2.0", "", { "dependencies": { "babel-plugin-jest-hoist": "30.2.0", "babel-preset-current-node-syntax": "^1.2.0" }, "peerDependencies": { "@babel/core": "^7.11.0 || ^8.0.0-beta.1" } }, "sha512-US4Z3NOieAQumwFnYdUWKvUKh8+YSnS/gB3t6YBiz0bskpu7Pine8pPCheNxlPEW4wnUkma2a94YuW2q3guvCQ=="],
-
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "baseline-browser-mapping": ["baseline-browser-mapping@2.9.19", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg=="],
 
     "better-ajv-errors": ["better-ajv-errors@1.2.0", "", { "dependencies": { "@babel/code-frame": "7.29.0", "@humanwhocodes/momoa": "2.0.4", "chalk": "4.1.2", "jsonpointer": "5.0.1", "leven": "3.1.0" }, "peerDependencies": { "ajv": "npm:@redocly/ajv@8.17.4" } }, "sha512-UW+IsFycygIo7bclP9h5ugkNH8EjCSgqyFB/yQ4Hqqa1OEYDtb0uFIkYE0b6+CjkgJYVM5UKI/pJPxjYe9EZlA=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
     "brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "1.0.2", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
-
-    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
-
-    "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
-
-    "bser": ["bser@2.1.1", "", { "dependencies": { "node-int64": "^0.4.0" } }, "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ=="],
 
     "bson": ["bson@7.2.0", "", {}, "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ=="],
 
@@ -513,25 +292,17 @@
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
-    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "camelcase-keys": ["camelcase-keys@6.2.2", "", { "dependencies": { "camelcase": "5.3.1", "map-obj": "4.3.0", "quick-lru": "4.0.1" } }, "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg=="],
 
     "camelize": ["camelize@1.0.1", "", {}, "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001770", "", {}, "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw=="],
-
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "4.3.0", "supports-color": "7.2.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
-
-    "char-regex": ["char-regex@1.0.2", "", {}, "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="],
 
     "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "2.1.0", "dom-serializer": "2.0.0", "domhandler": "5.0.3", "domutils": "3.2.2", "encoding-sniffer": "0.2.1", "htmlparser2": "10.1.0", "parse5": "7.3.0", "parse5-htmlparser2-tree-adapter": "7.1.0", "parse5-parser-stream": "7.1.2", "undici": "7.21.0", "whatwg-mimetype": "4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
 
     "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "1.0.0", "css-select": "5.2.2", "css-what": "6.2.2", "domelementtype": "2.3.0", "domhandler": "5.0.3", "domutils": "3.2.2" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
-
-    "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
-
-    "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
     "classnames": ["classnames@2.5.1", "", {}, "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="],
 
@@ -540,10 +311,6 @@
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
-
-    "co": ["co@4.6.0", "", {}, "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ=="],
-
-    "collect-v8-coverage": ["collect-v8-coverage@1.0.3", "", {}, "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -595,8 +362,6 @@
 
     "conventional-recommended-bump": ["conventional-recommended-bump@6.1.0", "", { "dependencies": { "concat-stream": "2.0.0", "conventional-changelog-preset-loader": "2.3.4", "conventional-commits-filter": "2.0.7", "conventional-commits-parser": "3.2.4", "git-raw-commits": "2.0.11", "git-semver-tags": "4.1.1", "meow": "8.1.2", "q": "1.5.1" }, "bin": { "conventional-recommended-bump": "cli.js" } }, "sha512-uiApbSiNGM/kkdL9GTOLAqC4hbptObFo4wW2QRyHsKciGAfQuLU1ShZ1BIVI/+K2BE/W1AWYQMCXAsv4dyKPaw=="],
 
-    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
-
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "core-js": ["core-js@3.48.0", "", {}, "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ=="],
@@ -628,8 +393,6 @@
     "decamelize-keys": ["decamelize-keys@1.1.1", "", { "dependencies": { "decamelize": "1.2.0", "map-obj": "1.0.1" } }, "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg=="],
 
     "decko": ["decko@1.2.0", "", {}, "sha512-m8FnyHXV1QX+S1cl+KPFDIl6NMkxtKsy6+U/aYyjrOqWMuwAwYWu7ePqrsUHtDR5Y8Yk2pi/KIDSgF+vT4cPOQ=="],
-
-    "dedent": ["dedent@1.7.1", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
@@ -663,12 +426,6 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "1.0.2", "es-errors": "1.3.0", "gopd": "1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
-    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
-
-    "electron-to-chromium": ["electron-to-chromium@1.5.286", "", {}, "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A=="],
-
-    "emittery": ["emittery@0.13.1", "", {}, "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ=="],
-
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "0.6.3", "whatwg-encoding": "3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
@@ -695,8 +452,6 @@
 
     "eslint-config-prettier": ["eslint-config-prettier@10.1.8", "", { "peerDependencies": { "eslint": "10.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w=="],
 
-    "eslint-plugin-jest": ["eslint-plugin-jest@28.14.0", "", { "dependencies": { "@typescript-eslint/utils": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "peerDependencies": { "@typescript-eslint/eslint-plugin": "^6.0.0 || ^7.0.0 || ^8.0.0", "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0", "jest": "*" }, "optionalPeers": ["@typescript-eslint/eslint-plugin", "jest"] }, "sha512-P9s/qXSMTpRTerE2FQ0qJet2gKbcGyFTPAJipoKxmWqR6uuFqIqk8FuEfg5yBieOezVrEfAMZrEwJ6yEp+1MFQ=="],
-
     "eslint-plugin-simple-import-sort": ["eslint-plugin-simple-import-sort@12.1.1", "", { "peerDependencies": { "eslint": "10.0.0" } }, "sha512-6nuzu4xwQtE3332Uz0to+TxDQYRLTKRESSc2hefVT48Zc8JthmN23Gx9lnYhu0FtkRSL1oxny3kJ2aveVhmOVA=="],
 
     "eslint-scope": ["eslint-scope@9.1.0", "", { "dependencies": { "@types/esrecurse": "4.3.1", "@types/estree": "1.0.8", "esrecurse": "4.3.0", "estraverse": "5.3.0" } }, "sha512-CkWE42hOJsNj9FJRaoMX9waUFYhqY4jmyLFdAdzZr6VaCg3ynLYx4WnOdkaIifGfH4gsUcBTn4OZbHXkpLD0FQ=="],
@@ -704,8 +459,6 @@
     "eslint-visitor-keys": ["eslint-visitor-keys@5.0.0", "", {}, "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q=="],
 
     "espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "8.15.0", "acorn-jsx": "5.3.2", "eslint-visitor-keys": "4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
-
-    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
     "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "5.3.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
 
@@ -718,12 +471,6 @@
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
-
-    "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
-
-    "exit-x": ["exit-x@0.2.2", "", {}, "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ=="],
-
-    "expect": ["expect@30.2.0", "", { "dependencies": { "@jest/expect-utils": "30.2.0", "@jest/get-type": "30.1.0", "jest-matcher-utils": "30.2.0", "jest-message-util": "30.2.0", "jest-mock": "30.2.0", "jest-util": "30.2.0" } }, "sha512-u/feCi0GPsI+988gU2FLcsHyAHTU0MX1Wg68NhAnN7z/+C5wqG+CY8J53N9ioe8RXgaoz0nBR/TYMf3AycUuPw=="],
 
     "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
@@ -749,15 +496,11 @@
 
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "1.1.0" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
-    "fb-watchman": ["fb-watchman@2.0.2", "", { "dependencies": { "bser": "2.1.1" } }, "sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA=="],
-
     "fdir": ["fdir@6.5.0", "", { "optionalDependencies": { "picomatch": "4.0.3" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "figures": ["figures@3.2.0", "", { "dependencies": { "escape-string-regexp": "1.0.5" } }, "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "4.0.1" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
-
-    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
     "find-my-way": ["find-my-way@9.4.0", "", { "dependencies": { "fast-deep-equal": "3.1.3", "fast-querystring": "1.1.2", "safe-regex2": "5.0.0" } }, "sha512-5Ye4vHsypZRYtS01ob/iwHzGRUDELlsoCftI/OZFhcLs1M0tkGPcXldE80TAZC5yYuJMBPJQQ43UHlqbJWiX2w=="],
 
@@ -775,25 +518,15 @@
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "0.4.0", "combined-stream": "1.0.8", "es-set-tostringtag": "2.1.0", "hasown": "2.0.2", "mime-types": "2.1.35" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
-    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
-
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
-
-    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "1.0.2", "es-define-property": "1.0.1", "es-errors": "1.3.0", "es-object-atoms": "1.1.1", "function-bind": "1.1.2", "get-proto": "1.0.1", "gopd": "1.2.0", "has-symbols": "1.1.0", "hasown": "2.0.2", "math-intrinsics": "1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
-    "get-package-type": ["get-package-type@0.1.0", "", {}, "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="],
-
     "get-pkg-repo": ["get-pkg-repo@4.2.1", "", { "dependencies": { "@hutson/parse-repository-url": "3.0.2", "hosted-git-info": "4.1.0", "through2": "2.0.5", "yargs": "16.2.0" }, "bin": { "get-pkg-repo": "src/cli.js" } }, "sha512-2+QbHjFRfGB74v/pYWjd5OhU3TDIC2Gv/YKUTk/tCvAz0pkn/Mz6P3uByuBimLOcPvN2jYdScl3xGFSrx0jEcA=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "1.0.1", "es-object-atoms": "1.1.1" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
-
-    "get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
 
     "git-raw-commits": ["git-raw-commits@2.0.11", "", { "dependencies": { "dargs": "7.0.0", "lodash": "4.17.23", "meow": "8.1.2", "split2": "3.2.2", "through2": "4.0.2" }, "bin": { "git-raw-commits": "cli.js" } }, "sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A=="],
 
@@ -807,7 +540,7 @@
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
-    "globals": ["globals@17.3.0", "", {}, "sha512-yMqGUQVVCkD4tqjOJf3TnrvaaHDMYp4VlUSObbkIiuCPe/ofdMBFIAcBbCSRFWOnos6qRiTVStDwqPLUclaxIw=="],
+    "globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
@@ -829,8 +562,6 @@
 
     "hosted-git-info": ["hosted-git-info@4.1.0", "", { "dependencies": { "lru-cache": "6.0.0" } }, "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA=="],
 
-    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
-
     "html-to-text": ["html-to-text@9.0.5", "", { "dependencies": { "@selderee/plugin-htmlparser2": "0.11.0", "deepmerge": "4.3.1", "dom-serializer": "2.0.0", "htmlparser2": "8.0.2", "selderee": "0.11.0" } }, "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg=="],
 
     "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "2.3.0", "domhandler": "5.0.3", "domutils": "3.2.2", "entities": "7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
@@ -839,21 +570,15 @@
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "7.1.4", "debug": "4.4.3" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
-    "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
-
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": "2.1.2" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "1.0.1", "resolve-from": "4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
-    "import-local": ["import-local@3.2.0", "", { "dependencies": { "pkg-dir": "^4.2.0", "resolve-cwd": "^3.0.0" }, "bin": { "import-local-fixture": "fixtures/cli.js" } }, "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA=="],
-
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
     "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
-
-    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -873,17 +598,11 @@
 
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
-    "is-generator-fn": ["is-generator-fn@2.1.0", "", {}, "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ=="],
-
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
-
-    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-obj": ["is-obj@2.0.0", "", {}, "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="],
 
     "is-plain-obj": ["is-plain-obj@1.1.0", "", {}, "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="],
-
-    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
     "is-text-path": ["is-text-path@1.0.1", "", { "dependencies": { "text-extensions": "1.9.0" } }, "sha512-xFuJpne9oFz5qDaodwmmG08e3CawH/2ZV8Qqza1Ko7Sk8POWbkRdwIoAWVhqvq0XeUzANEhKo2n0IXUGBm7A/w=="],
 
@@ -891,77 +610,13 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
-    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
-
-    "istanbul-lib-instrument": ["istanbul-lib-instrument@6.0.3", "", { "dependencies": { "@babel/core": "^7.23.9", "@babel/parser": "^7.23.9", "@istanbuljs/schema": "^0.1.3", "istanbul-lib-coverage": "^3.2.0", "semver": "^7.5.4" } }, "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q=="],
-
-    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
-
-    "istanbul-lib-source-maps": ["istanbul-lib-source-maps@5.0.6", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.23", "debug": "^4.1.1", "istanbul-lib-coverage": "^3.0.0" } }, "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A=="],
-
-    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
-
     "jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
-
-    "jest": ["jest@30.2.0", "", { "dependencies": { "@jest/core": "30.2.0", "@jest/types": "30.2.0", "import-local": "^3.2.0", "jest-cli": "30.2.0" }, "peerDependencies": { "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0" }, "optionalPeers": ["node-notifier"], "bin": "./bin/jest.js" }, "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A=="],
-
-    "jest-changed-files": ["jest-changed-files@30.2.0", "", { "dependencies": { "execa": "^5.1.1", "jest-util": "30.2.0", "p-limit": "^3.1.0" } }, "sha512-L8lR1ChrRnSdfeOvTrwZMlnWV8G/LLjQ0nG9MBclwWZidA2N5FviRki0Bvh20WRMOX31/JYvzdqTJrk5oBdydQ=="],
-
-    "jest-circus": ["jest-circus@30.2.0", "", { "dependencies": { "@jest/environment": "30.2.0", "@jest/expect": "30.2.0", "@jest/test-result": "30.2.0", "@jest/types": "30.2.0", "@types/node": "*", "chalk": "^4.1.2", "co": "^4.6.0", "dedent": "^1.6.0", "is-generator-fn": "^2.1.0", "jest-each": "30.2.0", "jest-matcher-utils": "30.2.0", "jest-message-util": "30.2.0", "jest-runtime": "30.2.0", "jest-snapshot": "30.2.0", "jest-util": "30.2.0", "p-limit": "^3.1.0", "pretty-format": "30.2.0", "pure-rand": "^7.0.0", "slash": "^3.0.0", "stack-utils": "^2.0.6" } }, "sha512-Fh0096NC3ZkFx05EP2OXCxJAREVxj1BcW/i6EWqqymcgYKWjyyDpral3fMxVcHXg6oZM7iULer9wGRFvfpl+Tg=="],
-
-    "jest-cli": ["jest-cli@30.2.0", "", { "dependencies": { "@jest/core": "30.2.0", "@jest/test-result": "30.2.0", "@jest/types": "30.2.0", "chalk": "^4.1.2", "exit-x": "^0.2.2", "import-local": "^3.2.0", "jest-config": "30.2.0", "jest-util": "30.2.0", "jest-validate": "30.2.0", "yargs": "^17.7.2" }, "peerDependencies": { "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0" }, "optionalPeers": ["node-notifier"], "bin": { "jest": "./bin/jest.js" } }, "sha512-Os9ukIvADX/A9sLt6Zse3+nmHtHaE6hqOsjQtNiugFTbKRHYIYtZXNGNK9NChseXy7djFPjndX1tL0sCTlfpAA=="],
-
-    "jest-config": ["jest-config@30.2.0", "", { "dependencies": { "@babel/core": "^7.27.4", "@jest/get-type": "30.1.0", "@jest/pattern": "30.0.1", "@jest/test-sequencer": "30.2.0", "@jest/types": "30.2.0", "babel-jest": "30.2.0", "chalk": "^4.1.2", "ci-info": "^4.2.0", "deepmerge": "^4.3.1", "glob": "^10.3.10", "graceful-fs": "^4.2.11", "jest-circus": "30.2.0", "jest-docblock": "30.2.0", "jest-environment-node": "30.2.0", "jest-regex-util": "30.0.1", "jest-resolve": "30.2.0", "jest-runner": "30.2.0", "jest-util": "30.2.0", "jest-validate": "30.2.0", "micromatch": "^4.0.8", "parse-json": "^5.2.0", "pretty-format": "30.2.0", "slash": "^3.0.0", "strip-json-comments": "^3.1.1" }, "peerDependencies": { "@types/node": "*", "esbuild-register": ">=3.4.0", "ts-node": ">=9.0.0" }, "optionalPeers": ["@types/node", "esbuild-register", "ts-node"] }, "sha512-g4WkyzFQVWHtu6uqGmQR4CQxz/CH3yDSlhzXMWzNjDx843gYjReZnMRanjRCq5XZFuQrGDxgUaiYWE8BRfVckA=="],
-
-    "jest-diff": ["jest-diff@30.2.0", "", { "dependencies": { "@jest/diff-sequences": "30.0.1", "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "pretty-format": "30.2.0" } }, "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A=="],
-
-    "jest-docblock": ["jest-docblock@30.2.0", "", { "dependencies": { "detect-newline": "^3.1.0" } }, "sha512-tR/FFgZKS1CXluOQzZvNH3+0z9jXr3ldGSD8bhyuxvlVUwbeLOGynkunvlTMxchC5urrKndYiwCFC0DLVjpOCA=="],
-
-    "jest-each": ["jest-each@30.2.0", "", { "dependencies": { "@jest/get-type": "30.1.0", "@jest/types": "30.2.0", "chalk": "^4.1.2", "jest-util": "30.2.0", "pretty-format": "30.2.0" } }, "sha512-lpWlJlM7bCUf1mfmuqTA8+j2lNURW9eNafOy99knBM01i5CQeY5UH1vZjgT9071nDJac1M4XsbyI44oNOdhlDQ=="],
-
-    "jest-environment-node": ["jest-environment-node@30.2.0", "", { "dependencies": { "@jest/environment": "30.2.0", "@jest/fake-timers": "30.2.0", "@jest/types": "30.2.0", "@types/node": "*", "jest-mock": "30.2.0", "jest-util": "30.2.0", "jest-validate": "30.2.0" } }, "sha512-ElU8v92QJ9UrYsKrxDIKCxu6PfNj4Hdcktcn0JX12zqNdqWHB0N+hwOnnBBXvjLd2vApZtuLUGs1QSY+MsXoNA=="],
-
-    "jest-haste-map": ["jest-haste-map@30.2.0", "", { "dependencies": { "@jest/types": "30.2.0", "@types/node": "*", "anymatch": "^3.1.3", "fb-watchman": "^2.0.2", "graceful-fs": "^4.2.11", "jest-regex-util": "30.0.1", "jest-util": "30.2.0", "jest-worker": "30.2.0", "micromatch": "^4.0.8", "walker": "^1.0.8" }, "optionalDependencies": { "fsevents": "^2.3.3" } }, "sha512-sQA/jCb9kNt+neM0anSj6eZhLZUIhQgwDt7cPGjumgLM4rXsfb9kpnlacmvZz3Q5tb80nS+oG/if+NBKrHC+Xw=="],
-
-    "jest-leak-detector": ["jest-leak-detector@30.2.0", "", { "dependencies": { "@jest/get-type": "30.1.0", "pretty-format": "30.2.0" } }, "sha512-M6jKAjyzjHG0SrQgwhgZGy9hFazcudwCNovY/9HPIicmNSBuockPSedAP9vlPK6ONFJ1zfyH/M2/YYJxOz5cdQ=="],
-
-    "jest-matcher-utils": ["jest-matcher-utils@30.2.0", "", { "dependencies": { "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "jest-diff": "30.2.0", "pretty-format": "30.2.0" } }, "sha512-dQ94Nq4dbzmUWkQ0ANAWS9tBRfqCrn0bV9AMYdOi/MHW726xn7eQmMeRTpX2ViC00bpNaWXq+7o4lIQ3AX13Hg=="],
-
-    "jest-message-util": ["jest-message-util@30.2.0", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@jest/types": "30.2.0", "@types/stack-utils": "^2.0.3", "chalk": "^4.1.2", "graceful-fs": "^4.2.11", "micromatch": "^4.0.8", "pretty-format": "30.2.0", "slash": "^3.0.0", "stack-utils": "^2.0.6" } }, "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw=="],
-
-    "jest-mock": ["jest-mock@30.2.0", "", { "dependencies": { "@jest/types": "30.2.0", "@types/node": "*", "jest-util": "30.2.0" } }, "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw=="],
-
-    "jest-mock-extended": ["jest-mock-extended@4.0.0", "", { "dependencies": { "ts-essentials": "^10.0.2" }, "peerDependencies": { "@jest/globals": "^28.0.0 || ^29.0.0 || ^30.0.0", "jest": "^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0 || ^30.0.0", "typescript": "^3.0.0 || ^4.0.0 || ^5.0.0" } }, "sha512-7BZpfuvLam+/HC+NxifIi9b+5VXj/utUDMPUqrDJehGWVuXPtLS9Jqlob2mJLrI/pg2k1S8DMfKDvEB88QNjaQ=="],
-
-    "jest-pnp-resolver": ["jest-pnp-resolver@1.2.3", "", { "peerDependencies": { "jest-resolve": "*" }, "optionalPeers": ["jest-resolve"] }, "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w=="],
-
-    "jest-regex-util": ["jest-regex-util@30.0.1", "", {}, "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA=="],
-
-    "jest-resolve": ["jest-resolve@30.2.0", "", { "dependencies": { "chalk": "^4.1.2", "graceful-fs": "^4.2.11", "jest-haste-map": "30.2.0", "jest-pnp-resolver": "^1.2.3", "jest-util": "30.2.0", "jest-validate": "30.2.0", "slash": "^3.0.0", "unrs-resolver": "^1.7.11" } }, "sha512-TCrHSxPlx3tBY3hWNtRQKbtgLhsXa1WmbJEqBlTBrGafd5fiQFByy2GNCEoGR+Tns8d15GaL9cxEzKOO3GEb2A=="],
-
-    "jest-resolve-dependencies": ["jest-resolve-dependencies@30.2.0", "", { "dependencies": { "jest-regex-util": "30.0.1", "jest-snapshot": "30.2.0" } }, "sha512-xTOIGug/0RmIe3mmCqCT95yO0vj6JURrn1TKWlNbhiAefJRWINNPgwVkrVgt/YaerPzY3iItufd80v3lOrFJ2w=="],
-
-    "jest-runner": ["jest-runner@30.2.0", "", { "dependencies": { "@jest/console": "30.2.0", "@jest/environment": "30.2.0", "@jest/test-result": "30.2.0", "@jest/transform": "30.2.0", "@jest/types": "30.2.0", "@types/node": "*", "chalk": "^4.1.2", "emittery": "^0.13.1", "exit-x": "^0.2.2", "graceful-fs": "^4.2.11", "jest-docblock": "30.2.0", "jest-environment-node": "30.2.0", "jest-haste-map": "30.2.0", "jest-leak-detector": "30.2.0", "jest-message-util": "30.2.0", "jest-resolve": "30.2.0", "jest-runtime": "30.2.0", "jest-util": "30.2.0", "jest-watcher": "30.2.0", "jest-worker": "30.2.0", "p-limit": "^3.1.0", "source-map-support": "0.5.13" } }, "sha512-PqvZ2B2XEyPEbclp+gV6KO/F1FIFSbIwewRgmROCMBo/aZ6J1w8Qypoj2pEOcg3G2HzLlaP6VUtvwCI8dM3oqQ=="],
-
-    "jest-runtime": ["jest-runtime@30.2.0", "", { "dependencies": { "@jest/environment": "30.2.0", "@jest/fake-timers": "30.2.0", "@jest/globals": "30.2.0", "@jest/source-map": "30.0.1", "@jest/test-result": "30.2.0", "@jest/transform": "30.2.0", "@jest/types": "30.2.0", "@types/node": "*", "chalk": "^4.1.2", "cjs-module-lexer": "^2.1.0", "collect-v8-coverage": "^1.0.2", "glob": "^10.3.10", "graceful-fs": "^4.2.11", "jest-haste-map": "30.2.0", "jest-message-util": "30.2.0", "jest-mock": "30.2.0", "jest-regex-util": "30.0.1", "jest-resolve": "30.2.0", "jest-snapshot": "30.2.0", "jest-util": "30.2.0", "slash": "^3.0.0", "strip-bom": "^4.0.0" } }, "sha512-p1+GVX/PJqTucvsmERPMgCPvQJpFt4hFbM+VN3n8TMo47decMUcJbt+rgzwrEme0MQUA/R+1de2axftTHkKckg=="],
-
-    "jest-snapshot": ["jest-snapshot@30.2.0", "", { "dependencies": { "@babel/core": "^7.27.4", "@babel/generator": "^7.27.5", "@babel/plugin-syntax-jsx": "^7.27.1", "@babel/plugin-syntax-typescript": "^7.27.1", "@babel/types": "^7.27.3", "@jest/expect-utils": "30.2.0", "@jest/get-type": "30.1.0", "@jest/snapshot-utils": "30.2.0", "@jest/transform": "30.2.0", "@jest/types": "30.2.0", "babel-preset-current-node-syntax": "^1.2.0", "chalk": "^4.1.2", "expect": "30.2.0", "graceful-fs": "^4.2.11", "jest-diff": "30.2.0", "jest-matcher-utils": "30.2.0", "jest-message-util": "30.2.0", "jest-util": "30.2.0", "pretty-format": "30.2.0", "semver": "^7.7.2", "synckit": "^0.11.8" } }, "sha512-5WEtTy2jXPFypadKNpbNkZ72puZCa6UjSr/7djeecHWOu7iYhSXSnHScT8wBz3Rn8Ena5d5RYRcsyKIeqG1IyA=="],
-
-    "jest-util": ["jest-util@30.2.0", "", { "dependencies": { "@jest/types": "30.2.0", "@types/node": "*", "chalk": "^4.1.2", "ci-info": "^4.2.0", "graceful-fs": "^4.2.11", "picomatch": "^4.0.2" } }, "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA=="],
-
-    "jest-validate": ["jest-validate@30.2.0", "", { "dependencies": { "@jest/get-type": "30.1.0", "@jest/types": "30.2.0", "camelcase": "^6.3.0", "chalk": "^4.1.2", "leven": "^3.1.0", "pretty-format": "30.2.0" } }, "sha512-FBGWi7dP2hpdi8nBoWxSsLvBFewKAg0+uSQwBaof4Y4DPgBabXgpSYC5/lR7VmnIlSpASmCi/ntRWPbv7089Pw=="],
-
-    "jest-watcher": ["jest-watcher@30.2.0", "", { "dependencies": { "@jest/test-result": "30.2.0", "@jest/types": "30.2.0", "@types/node": "*", "ansi-escapes": "^4.3.2", "chalk": "^4.1.2", "emittery": "^0.13.1", "jest-util": "30.2.0", "string-length": "^4.0.2" } }, "sha512-PYxa28dxJ9g777pGm/7PrbnMeA0Jr7osHP9bS7eJy9DuAjMgdGtxgf0uKMyoIsTWAkIbUW5hSDdJ3urmgXBqxg=="],
-
-    "jest-worker": ["jest-worker@30.2.0", "", { "dependencies": { "@types/node": "*", "@ungap/structured-clone": "^1.3.0", "jest-util": "30.2.0", "merge-stream": "^2.0.0", "supports-color": "^8.1.1" } }, "sha512-0Q4Uk8WF7BUwqXHuAjc23vmopWJw5WH7w2tqBoUOZpOjW/ZnR44GXXd1r82RvnmI2GZge3ivrYXk/BE2+VtW2g=="],
 
     "js-levenshtein": ["js-levenshtein@1.1.6", "", {}, "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
-
-    "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
@@ -980,8 +635,6 @@
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
     "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
-
-    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonparse": ["jsonparse@1.3.1", "", {}, "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="],
 
@@ -1025,10 +678,6 @@
 
     "lunr": ["lunr@2.3.9", "", {}, "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow=="],
 
-    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
-
-    "makeerror": ["makeerror@1.0.12", "", { "dependencies": { "tmpl": "1.0.5" } }, "sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg=="],
-
     "map-obj": ["map-obj@4.3.0", "", {}, "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="],
 
     "mark.js": ["mark.js@8.11.1", "", {}, "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ=="],
@@ -1041,15 +690,9 @@
 
     "meow": ["meow@8.1.2", "", { "dependencies": { "@types/minimist": "1.2.5", "camelcase-keys": "6.2.2", "decamelize-keys": "1.1.1", "hard-rejection": "2.1.0", "minimist-options": "4.1.0", "normalize-package-data": "3.0.3", "read-pkg-up": "7.0.1", "redent": "3.0.0", "trim-newlines": "3.0.1", "type-fest": "0.18.1", "yargs-parser": "20.2.9" } }, "sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q=="],
 
-    "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
-
-    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
-
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
-
-    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
@@ -1079,8 +722,6 @@
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
-    "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
-
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "neo-async": ["neo-async@2.6.2", "", {}, "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="],
@@ -1089,17 +730,9 @@
 
     "node-fetch-h2": ["node-fetch-h2@2.3.0", "", { "dependencies": { "http2-client": "1.3.5" } }, "sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg=="],
 
-    "node-int64": ["node-int64@0.4.0", "", {}, "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw=="],
-
     "node-readfiles": ["node-readfiles@0.2.0", "", { "dependencies": { "es6-promise": "3.3.1" } }, "sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA=="],
 
-    "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
-
     "normalize-package-data": ["normalize-package-data@3.0.3", "", { "dependencies": { "hosted-git-info": "4.1.0", "is-core-module": "2.16.1", "semver": "7.7.4", "validate-npm-package-license": "3.0.4" } }, "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA=="],
-
-    "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
-
-    "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
@@ -1116,10 +749,6 @@
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
-
-    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
-
-    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
     "openapi-sampler": ["openapi-sampler@1.6.2", "", { "dependencies": { "@types/json-schema": "7.0.15", "fast-xml-parser": "4.5.3", "json-pointer": "0.6.2" } }, "sha512-NyKGiFKfSWAZr4srD/5WDhInOWDhfml32h/FKUqLpEwKJt0kG0LGUU0MdyNkKrVGuJnw6DuPWq/sHCwAMpiRxg=="],
 
@@ -1139,7 +768,7 @@
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "3.1.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
-    "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "7.29.0", "error-ex": "1.3.4", "json-parse-even-better-errors": "2.3.1", "lines-and-columns": "1.2.4" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+    "parse-json": ["parse-json@4.0.0", "", { "dependencies": { "error-ex": "1.3.4", "json-parse-better-errors": "1.0.2" } }, "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw=="],
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "6.0.1" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
@@ -1152,8 +781,6 @@
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
-
-    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -1179,10 +806,6 @@
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
-    "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
-
-    "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
-
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
     "polished": ["polished@4.3.1", "", { "dependencies": { "@babel/runtime": "7.28.6" } }, "sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA=="],
@@ -1194,8 +817,6 @@
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
-
-    "pretty-format": ["pretty-format@30.2.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA=="],
 
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
 
@@ -1210,8 +831,6 @@
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
-
-    "pure-rand": ["pure-rand@7.0.1", "", {}, "sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ=="],
 
     "q": ["q@1.5.1", "", {}, "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="],
 
@@ -1254,8 +873,6 @@
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "2.16.1", "path-parse": "1.0.7", "supports-preserve-symlinks-flag": "1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
-
-    "resolve-cwd": ["resolve-cwd@3.0.0", "", { "dependencies": { "resolve-from": "^5.0.0" } }, "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
@@ -1309,8 +926,6 @@
 
     "simple-websocket": ["simple-websocket@9.1.0", "", { "dependencies": { "debug": "4.4.3", "queue-microtask": "1.2.3", "randombytes": "2.1.0", "readable-stream": "3.6.2", "ws": "7.5.10" } }, "sha512-8MJPnjRN6A8UCp1I+H/dSFyjwJhp6wta4hsVRhjf8w9qBHRzxYt14RaOcjvQnhD1N4yKOddEjflwMnQM4VtXjQ=="],
 
-    "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
-
     "slugify": ["slugify@1.4.7", "", {}, "sha512-tf+h5W1IrjNm/9rKKj0JU2MDMruiopx0jjVA5zCdBtcGjfp0+c5rHw/zADLC3IeKlGHtVbHtpfzvYA0OYT+HKg=="],
 
     "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
@@ -1318,8 +933,6 @@
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
-
-    "source-map-support": ["source-map-support@0.5.13", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w=="],
 
     "sparse-bitfield": ["sparse-bitfield@3.0.3", "", { "dependencies": { "memory-pager": "1.5.0" } }, "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ=="],
 
@@ -1335,21 +948,13 @@
 
     "split2": ["split2@3.2.2", "", { "dependencies": { "readable-stream": "3.6.2" } }, "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg=="],
 
-    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
-
-    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
-
     "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
     "standard-version": ["standard-version@9.5.0", "", { "dependencies": { "chalk": "2.4.2", "conventional-changelog": "3.1.25", "conventional-changelog-config-spec": "2.1.0", "conventional-changelog-conventionalcommits": "4.6.3", "conventional-recommended-bump": "6.1.0", "detect-indent": "6.1.0", "detect-newline": "3.1.0", "dotgitignore": "2.1.0", "figures": "3.2.0", "find-up": "5.0.0", "git-semver-tags": "4.1.1", "semver": "7.7.4", "stringify-package": "1.0.1", "yargs": "16.2.0" }, "bin": { "standard-version": "bin/cli.js" } }, "sha512-3zWJ/mmZQsOaO+fOlsa0+QK90pwhNd042qEcw6hKFNoLFs7peGyvPffpEBbK/DSGPbyOvli0mUIFv5A4qTjh2Q=="],
 
     "stickyfill": ["stickyfill@1.1.1", "", {}, "sha512-GCp7vHAfpao+Qh/3Flh9DXEJ/qSi0KJwJw6zYlZOtRYXWUIpMM6mC2rIep/dK8RQqwW0KxGJIllmjPIBOGN8AA=="],
 
-    "string-length": ["string-length@4.0.2", "", { "dependencies": { "char-regex": "^1.0.2", "strip-ansi": "^6.0.0" } }, "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ=="],
-
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "8.0.0", "is-fullwidth-code-point": "3.0.0", "strip-ansi": "6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
-
-    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "8.0.0", "is-fullwidth-code-point": "3.0.0", "strip-ansi": "6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
@@ -1357,11 +962,7 @@
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "strip-bom": ["strip-bom@4.0.0", "", {}, "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="],
-
-    "strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
+    "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "1.0.1" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
@@ -1379,10 +980,6 @@
 
     "swagger2openapi": ["swagger2openapi@7.0.8", "", { "dependencies": { "call-me-maybe": "1.0.2", "node-fetch": "2.7.0", "node-fetch-h2": "2.3.0", "node-readfiles": "0.2.0", "oas-kit-common": "1.0.8", "oas-resolver": "2.5.6", "oas-schema-walker": "1.1.5", "oas-validator": "5.0.8", "reftools": "1.1.9", "yaml": "1.10.2", "yargs": "17.7.2" }, "bin": { "swagger2openapi": "swagger2openapi.js", "oas-validate": "oas-validate.js", "boast": "boast.js" } }, "sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g=="],
 
-    "synckit": ["synckit@0.11.12", "", { "dependencies": { "@pkgr/core": "^0.2.9" } }, "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ=="],
-
-    "test-exclude": ["test-exclude@6.0.0", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^7.1.4", "minimatch": "^3.0.4" } }, "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w=="],
-
     "text-extensions": ["text-extensions@1.9.0", "", {}, "sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ=="],
 
     "thread-stream": ["thread-stream@4.0.0", "", { "dependencies": { "real-require": "0.2.0" } }, "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA=="],
@@ -1392,10 +989,6 @@
     "through2": ["through2@4.0.2", "", { "dependencies": { "readable-stream": "3.6.2" } }, "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "6.5.0", "picomatch": "4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
-
-    "tmpl": ["tmpl@1.0.5", "", {}, "sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw=="],
-
-    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "toad-cache": ["toad-cache@3.7.0", "", {}, "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="],
 
@@ -1411,13 +1004,9 @@
 
     "ts-api-utils": ["ts-api-utils@2.4.0", "", { "peerDependencies": { "typescript": "5.9.3" } }, "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA=="],
 
-    "ts-essentials": ["ts-essentials@10.1.1", "", { "peerDependencies": { "typescript": ">=4.5.0" }, "optionalPeers": ["typescript"] }, "sha512-4aTB7KLHKmUvkjNj8V+EdnmuVTiECzn3K+zIbRthumvHu+j44x3w63xpfs0JL3NGIzGXqoQ7AV591xHO+XrOTw=="],
-
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
-
-    "type-detect": ["type-detect@4.0.8", "", {}, "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="],
 
     "type-fest": ["type-fest@0.18.1", "", {}, "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="],
 
@@ -1433,10 +1022,6 @@
 
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
-    "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
-
-    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
-
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "2.3.1" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "url-template": ["url-template@2.0.8", "", {}, "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="],
@@ -1445,11 +1030,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "v8-to-istanbul": ["v8-to-istanbul@9.3.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.12", "@types/istanbul-lib-coverage": "^2.0.1", "convert-source-map": "^2.0.0" } }, "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA=="],
-
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "3.2.0", "spdx-expression-parse": "3.0.1" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
-
-    "walker": ["walker@1.0.8", "", { "dependencies": { "makeerror": "1.0.12" } }, "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ=="],
 
     "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 
@@ -1466,12 +1047,6 @@
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "4.3.0", "string-width": "4.2.3", "strip-ansi": "6.0.1" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "4.3.0", "string-width": "4.2.3", "strip-ansi": "6.0.1" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
-
-    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
-
-    "write-file-atomic": ["write-file-atomic@5.0.1", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^4.0.1" } }, "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw=="],
 
     "ws": ["ws@7.5.10", "", {}, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
@@ -1493,31 +1068,13 @@
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
-    "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
-
-    "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/config-array/minimatch": ["minimatch@10.2.0", "", { "dependencies": { "brace-expansion": "5.0.2" } }, "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w=="],
 
-    "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
-
     "@fastify/ajv-compiler/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "3.1.3", "fast-uri": "3.1.0", "json-schema-traverse": "1.0.0", "require-from-string": "2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "@fastify/proxy-addr/ipaddr.js": ["ipaddr.js@2.3.0", "", {}, "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg=="],
-
-    "@istanbuljs/load-nyc-config/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
-
-    "@istanbuljs/load-nyc-config/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "5.0.0", "path-exists": "4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
-
-    "@istanbuljs/load-nyc-config/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
-
-    "@istanbuljs/load-nyc-config/resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
-
-    "@jest/reporters/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "@redocly/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -1537,13 +1094,7 @@
 
     "ajv-formats/ajv": ["@redocly/ajv@8.17.4", "", { "dependencies": { "fast-deep-equal": "3.1.3", "fast-uri": "3.1.0", "json-schema-traverse": "1.0.0", "require-from-string": "2.0.2" } }, "sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA=="],
 
-    "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
-
-    "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
     "better-ajv-errors/ajv": ["@redocly/ajv@8.17.4", "", { "dependencies": { "fast-deep-equal": "3.1.3", "fast-uri": "3.1.0", "json-schema-traverse": "1.0.0", "require-from-string": "2.0.2" } }, "sha512-BieiCML/IgP6x99HZByJSt7fJE4ipgzO7KAFss92Bs+PEI35BhY7vGIysFXLT+YmS7nHtQjZjhOQyPPEf7xGHA=="],
-
-    "camelcase-keys/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -1565,8 +1116,6 @@
 
     "espree/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
-    "execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
-
     "fast-json-stringify/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "3.1.3", "fast-uri": "3.1.0", "json-schema-traverse": "1.0.0", "require-from-string": "2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "figures/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
@@ -1585,33 +1134,13 @@
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
-    "istanbul-lib-report/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
-
-    "jest-changed-files/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
-
-    "jest-circus/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
-
-    "jest-cli/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "8.0.1", "escalade": "3.2.0", "get-caller-file": "2.0.5", "require-directory": "2.1.1", "string-width": "4.2.3", "y18n": "5.0.8", "yargs-parser": "21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
-
-    "jest-config/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
-
-    "jest-runner/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
-
-    "jest-runtime/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
-
     "light-my-request/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "light-my-request/process-warning": ["process-warning@4.0.1", "", {}, "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="],
 
-    "load-json-file/parse-json": ["parse-json@4.0.0", "", { "dependencies": { "error-ex": "1.3.4", "json-parse-better-errors": "1.0.2" } }, "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw=="],
-
     "load-json-file/pify": ["pify@3.0.0", "", {}, "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg=="],
 
-    "load-json-file/strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
-
     "meow/read-pkg-up": ["read-pkg-up@7.0.1", "", { "dependencies": { "find-up": "4.1.0", "read-pkg": "5.2.0", "type-fest": "0.8.1" } }, "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg=="],
-
-    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "0.0.3", "webidl-conversions": "3.0.1" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
@@ -1625,21 +1154,11 @@
 
     "pino-abstract-transport/split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
-    "pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "5.0.0", "path-exists": "4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
-
-    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
-
-    "pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
-
     "read-pkg/normalize-package-data": ["normalize-package-data@2.5.0", "", { "dependencies": { "hosted-git-info": "2.8.9", "resolve": "1.22.11", "semver": "5.7.2", "validate-npm-package-license": "3.0.4" } }, "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA=="],
 
     "read-pkg-up/find-up": ["find-up@2.1.0", "", { "dependencies": { "locate-path": "2.0.0" } }, "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ=="],
 
     "redoc/@redocly/openapi-core": ["@redocly/openapi-core@1.34.6", "", { "dependencies": { "@redocly/ajv": "8.17.4", "@redocly/config": "0.22.2", "colorette": "1.4.0", "https-proxy-agent": "7.0.6", "js-levenshtein": "1.1.6", "js-yaml": "4.1.1", "minimatch": "5.1.6", "pluralize": "8.0.0", "yaml-ast-parser": "0.0.43" } }, "sha512-2+O+riuIUgVSuLl3Lyh5AplWZyVMNuG2F98/o6NrutKJfW4/GTZdPpZlIphS0HGgcOHgmWcCSHj+dWFlZaGSHw=="],
-
-    "resolve-cwd/resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
-
-    "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
     "standard-version/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "3.2.1", "escape-string-regexp": "1.0.5", "supports-color": "5.5.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
@@ -1647,23 +1166,9 @@
 
     "swagger2openapi/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "8.0.1", "escalade": "3.2.0", "get-caller-file": "2.0.5", "require-directory": "2.1.1", "string-width": "4.2.3", "y18n": "5.0.8", "yargs-parser": "21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
-    "test-exclude/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
-
-    "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
-
     "@eslint/config-array/minimatch/brace-expansion": ["brace-expansion@5.0.2", "", { "dependencies": { "balanced-match": "4.0.2" } }, "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw=="],
 
     "@fastify/ajv-compiler/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "@istanbuljs/load-nyc-config/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
-
-    "@istanbuljs/load-nyc-config/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
-
-    "@jest/reporters/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
-
-    "@jest/reporters/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "2.0.2" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "@jest/reporters/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "@redocly/cli/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -1693,28 +1198,6 @@
 
     "glob/minimatch/brace-expansion": ["brace-expansion@5.0.2", "", { "dependencies": { "balanced-match": "4.0.2" } }, "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw=="],
 
-    "jest-changed-files/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
-
-    "jest-circus/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
-
-    "jest-cli/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "4.2.3", "strip-ansi": "6.0.1", "wrap-ansi": "7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
-
-    "jest-cli/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
-
-    "jest-config/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
-
-    "jest-config/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "2.0.2" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "jest-config/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
-
-    "jest-runner/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
-
-    "jest-runtime/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
-
-    "jest-runtime/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "2.0.2" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
-
-    "jest-runtime/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
-
     "meow/read-pkg-up/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "5.0.0", "path-exists": "4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "meow/read-pkg-up/read-pkg": ["read-pkg@5.2.0", "", { "dependencies": { "@types/normalize-package-data": "2.4.4", "normalize-package-data": "2.5.0", "parse-json": "5.2.0", "type-fest": "0.6.0" } }, "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg=="],
@@ -1730,8 +1213,6 @@
     "oas-resolver/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
-
-    "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "read-pkg-up/find-up/locate-path": ["locate-path@2.0.0", "", { "dependencies": { "p-locate": "2.0.0", "path-exists": "3.0.0" } }, "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA=="],
 
@@ -1755,14 +1236,6 @@
 
     "@eslint/config-array/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.2", "", { "dependencies": { "jackspeak": "4.2.3" } }, "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg=="],
 
-    "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "2.3.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
-
-    "@jest/reporters/glob/jackspeak/@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
-
-    "@jest/reporters/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "1.0.2" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
-
-    "@jest/reporters/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
     "dotgitignore/find-up/locate-path/p-locate": ["p-locate@3.0.0", "", { "dependencies": { "p-limit": "2.3.0" } }, "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ=="],
 
     "dotgitignore/find-up/locate-path/path-exists": ["path-exists@3.0.0", "", {}, "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="],
@@ -1775,25 +1248,13 @@
 
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.2", "", { "dependencies": { "jackspeak": "4.2.3" } }, "sha512-x0K50QvKQ97fdEz2kPehIerj+YTeptKF9hyYkKf6egnwmMWAkADiO0QCzSp0R5xN8FTZgYaBfSaue46Ej62nMg=="],
 
-    "jest-config/glob/jackspeak/@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
-
-    "jest-config/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "1.0.2" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
-
-    "jest-config/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "jest-runtime/glob/jackspeak/@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
-
-    "jest-runtime/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "1.0.2" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
-
-    "jest-runtime/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
     "meow/read-pkg-up/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "meow/read-pkg-up/read-pkg/normalize-package-data": ["normalize-package-data@2.5.0", "", { "dependencies": { "hosted-git-info": "2.8.9", "resolve": "1.22.11", "semver": "5.7.2", "validate-npm-package-license": "3.0.4" } }, "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA=="],
 
-    "meow/read-pkg-up/read-pkg/type-fest": ["type-fest@0.6.0", "", {}, "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="],
+    "meow/read-pkg-up/read-pkg/parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "7.29.0", "error-ex": "1.3.4", "json-parse-even-better-errors": "2.3.1", "lines-and-columns": "1.2.4" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
-    "pkg-dir/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "2.3.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+    "meow/read-pkg-up/read-pkg/type-fest": ["type-fest@0.6.0", "", {}, "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="],
 
     "read-pkg-up/find-up/locate-path/p-locate": ["p-locate@2.0.0", "", { "dependencies": { "p-limit": "1.3.0" } }, "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg=="],
 
@@ -1805,27 +1266,7 @@
 
     "standard-version/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 
-    "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "2.2.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
-
-    "@jest/reporters/glob/jackspeak/@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
-
-    "@jest/reporters/glob/jackspeak/@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
-    "@jest/reporters/glob/jackspeak/@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
-
     "dotgitignore/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "2.2.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
-
-    "jest-config/glob/jackspeak/@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
-
-    "jest-config/glob/jackspeak/@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
-    "jest-config/glob/jackspeak/@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
-
-    "jest-runtime/glob/jackspeak/@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
-
-    "jest-runtime/glob/jackspeak/@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
-    "jest-runtime/glob/jackspeak/@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "meow/read-pkg-up/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "2.3.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
@@ -1833,29 +1274,9 @@
 
     "meow/read-pkg-up/read-pkg/normalize-package-data/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
 
-    "pkg-dir/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "2.2.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
-
     "read-pkg-up/find-up/locate-path/p-locate/p-limit": ["p-limit@1.3.0", "", { "dependencies": { "p-try": "1.0.0" } }, "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q=="],
 
     "standard-version/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
-
-    "@jest/reporters/glob/jackspeak/@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
-
-    "@jest/reporters/glob/jackspeak/@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "@jest/reporters/glob/jackspeak/@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
-    "jest-config/glob/jackspeak/@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
-
-    "jest-config/glob/jackspeak/@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "jest-config/glob/jackspeak/@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
-    "jest-runtime/glob/jackspeak/@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
-
-    "jest-runtime/glob/jackspeak/@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "jest-runtime/glob/jackspeak/@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "meow/read-pkg-up/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "2.2.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "eslint": "^10.0.0",
         "eslint-config-prettier": "^10.1.2",
         "eslint-plugin-simple-import-sort": "^12.1.1",
+        "globals": "^17.3.0",
         "prettier": "^3.5.3",
         "standard-version": "^9.5.0",
         "typescript": "^5.9.3",
@@ -540,7 +541,7 @@
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
-    "globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+    "globals": ["globals@17.6.0", "", {}, "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
@@ -1071,6 +1072,8 @@
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/config-array/minimatch": ["minimatch@10.2.0", "", { "dependencies": { "brace-expansion": "5.0.2" } }, "sha512-ugkC31VaVg9cF0DFVoADH12k6061zNZkZON+aX8AWsR9GhPcErkcMBceb6znR8wLERM2AkkOxy2nWRLpT9Jq5w=="],
+
+    "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
 
     "@fastify/ajv-compiler/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "3.1.3", "fast-uri": "3.1.0", "json-schema-traverse": "1.0.0", "require-from-string": "2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,4 @@
 import typescriptEslint from '@typescript-eslint/eslint-plugin'
-import jest from 'eslint-plugin-jest'
 import simpleImportSort from 'eslint-plugin-simple-import-sort'
 import globals from 'globals'
 import tsParser from '@typescript-eslint/parser'
@@ -27,14 +26,12 @@ export default [
 	{
 		plugins: {
 			'@typescript-eslint': typescriptEslint,
-			jest,
 			'simple-import-sort': simpleImportSort
 		},
 
 		languageOptions: {
 			globals: {
-				...globals.node,
-				...jest.environments.globals.globals
+				...globals.node
 			},
 
 			parser: tsParser,

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
 		"concurrently": "^9.1.2",
 		"eslint": "^10.0.0",
 		"eslint-config-prettier": "^10.1.2",
+		"globals": "^17.3.0",
 		"eslint-plugin-simple-import-sort": "^12.1.1",
 		"prettier": "^3.5.3",
 		"standard-version": "^9.5.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"release": "standard-version",
 		"serve": "bun run dist/server.js",
 		"start": "bun run build && bun run serve",
-		"test": "bun test --timeout 30000 tests/typing tests/static tests/helpers/errors tests/helpers/routes/GenericShowHelper.test.ts tests/helpers/utils/cleanupDescription.test.ts tests/helpers/utils/batchProcessor.test.ts tests/helpers/utils/connectionPool.test.ts",
+		"test": "bun test --timeout 30000 --parallel=1 tests/typing tests/static tests/helpers/errors tests/helpers/routes tests/helpers/utils tests/helpers/books tests/helpers/authors tests/database tests/config tests/audible",
 		"test:live": "bun test --timeout 60000 tests/live",
 		"watch-debug": "bun --watch --inspect src/server.ts",
 		"watch": "bun --watch src/server.ts"
@@ -65,10 +65,7 @@
 		"concurrently": "^9.1.2",
 		"eslint": "^10.0.0",
 		"eslint-config-prettier": "^10.1.2",
-		"eslint-plugin-jest": "^28.11.0",
 		"eslint-plugin-simple-import-sort": "^12.1.1",
-		"globals": "^17.3.0",
-		"jest-mock-extended": "4.0.0",
 		"prettier": "^3.5.3",
 		"standard-version": "^9.5.0",
 		"typescript": "^5.9.3"

--- a/src/config/routes/metrics.ts
+++ b/src/config/routes/metrics.ts
@@ -111,12 +111,16 @@ export function registerMetricsRoute(fastify: FastifyInstance): void {
 			preHandler: async (request: FastifyRequest, reply: FastifyReply) => {
 				// Return 404 if metrics endpoint is disabled
 				if (!config.METRICS_ENABLED) {
-					return reply.code(404).send({ error: 'Metrics endpoint disabled' })
+					reply.code(404).send({ error: 'Metrics endpoint disabled' })
+					reply.hijack()
+					return
 				}
 
 				// Validate auth if configured
 				if (!validateMetricsAuth(request)) {
-					return reply.code(403).send({ error: 'Forbidden' })
+					reply.code(403).send({ error: 'Forbidden' })
+					reply.hijack()
+					return
 				}
 			}
 		},

--- a/src/config/routes/metrics.ts
+++ b/src/config/routes/metrics.ts
@@ -105,30 +105,20 @@ export function registerMetricsRoute(fastify: FastifyInstance): void {
 		}
 	}
 
-	fastify.get(
-		'/metrics',
-		{
-			preHandler: async (request: FastifyRequest, reply: FastifyReply) => {
-				// Return 404 if metrics endpoint is disabled
-				if (!config.METRICS_ENABLED) {
-					reply.code(404).send({ error: 'Metrics endpoint disabled' })
-					reply.hijack()
-					return
-				}
-
-				// Validate auth if configured
-				if (!validateMetricsAuth(request)) {
-					reply.code(403).send({ error: 'Forbidden' })
-					reply.hijack()
-					return
-				}
-			}
-		},
-		async () => {
-			const metrics = getPerformanceMetrics()
-			return metrics
+	fastify.get('/metrics', async (request: FastifyRequest, reply: FastifyReply) => {
+		// Return 404 if metrics endpoint is disabled
+		if (!config.METRICS_ENABLED) {
+			return reply.code(404).send({ error: 'Metrics endpoint disabled' })
 		}
-	)
+
+		// Validate auth if configured
+		if (!validateMetricsAuth(request)) {
+			return reply.code(403).send({ error: 'Forbidden' })
+		}
+
+		const metrics = getPerformanceMetrics()
+		return metrics
+	})
 }
 
 export default { registerMetricsRoute }

--- a/src/config/test-context.ts
+++ b/src/config/test-context.ts
@@ -2,7 +2,7 @@ import { mock } from 'bun:test'
 import type { MongoClient } from 'mongodb'
 
 export type MockContext = {
-	client: Partial<MongoClient>
+	client: Pick<MongoClient, 'db' | 'connect'>
 }
 
 export const createMockContext = (): MockContext => {

--- a/src/config/test-context.ts
+++ b/src/config/test-context.ts
@@ -1,13 +1,15 @@
-import type { DeepMockProxy } from 'jest-mock-extended'
-import { mockDeep } from 'jest-mock-extended'
+import { mock } from 'bun:test'
 import type { MongoClient } from 'mongodb'
 
 export type MockContext = {
-	client: DeepMockProxy<MongoClient>
+	client: Partial<MongoClient>
 }
 
 export const createMockContext = (): MockContext => {
 	return {
-		client: mockDeep<MongoClient>()
+		client: {
+			db: mock(),
+			connect: mock()
+		}
 	}
 }

--- a/src/helpers/utils/fetchPlus.ts
+++ b/src/helpers/utils/fetchPlus.ts
@@ -1,6 +1,7 @@
 import { AxiosError, AxiosResponse } from 'axios'
 
 import pooledAxios from '#helpers/utils/connectionPool'
+import sleep from '#helpers/utils/sleep'
 
 /**
  * Calculates the delay for retry attempts with exponential backoff.
@@ -40,15 +41,6 @@ function calculateRetryDelay(retries: number, error: AxiosError): number {
 
 	// Invalid Retry-After value, fall back to exponential backoff
 	return Math.min(1000 * Math.pow(2, retries), 8000)
-}
-
-/**
- * Sleep for a given number of milliseconds
- * @param {number} ms The number of milliseconds to sleep
- * @returns {Promise<void>} A promise that resolves after the delay
- */
-function sleep(ms: number): Promise<void> {
-	return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 /**

--- a/src/helpers/utils/sleep.ts
+++ b/src/helpers/utils/sleep.ts
@@ -1,0 +1,3 @@
+export default function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/tests/audible/authors/scrape.test.ts
+++ b/tests/audible/authors/scrape.test.ts
@@ -1,4 +1,6 @@
-import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios'
+ 
+import type { AxiosResponse } from 'axios'
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
 
 import { ApiAuthorProfile } from '#config/types'
 import ScrapeHelper from '#helpers/authors/audible/ScrapeHelper'
@@ -10,7 +12,9 @@ import {
 	mockHtmlB0034NFIOI
 } from '#tests/datasets/audible/authors/scrape'
 
-jest.mock('#helpers/utils/fetchPlus')
+mock.module('#helpers/utils/fetchPlus', () => {
+	return { default: mock() }
+})
 
 let asin: string
 let helper: ScrapeHelper
@@ -26,16 +30,16 @@ const createMockResponse = (data: string, status: number): AxiosResponse => ({
 
 describe('Audible Author HTML', () => {
 	beforeEach(() => {
-		jest.clearAllMocks()
+		mock.clearAllMocks()
 	})
 
 	describe('When scraping Andy Weir from Audible', () => {
 		beforeAll(async () => {
 			asin = 'B00G0WYW92'
 			helper = new ScrapeHelper(asin, 'us')
-			jest
-				.spyOn(fetchPlus, 'default')
-				.mockImplementation(() => Promise.resolve(createMockResponse(mockHtmlB00G0WYW92, 200)))
+			spyOn(fetchPlus, 'default').mockImplementation(() =>
+				Promise.resolve(createMockResponse(mockHtmlB00G0WYW92, 200))
+			)
 			response = await helper.process()
 		}, 10000)
 
@@ -72,9 +76,9 @@ describe('Audible Author HTML', () => {
 		beforeAll(async () => {
 			asin = 'B0034NFIOI'
 			helper = new ScrapeHelper(asin, 'us')
-			jest
-				.spyOn(fetchPlus, 'default')
-				.mockImplementation(() => Promise.resolve(createMockResponse(mockHtmlB0034NFIOI, 200)))
+			spyOn(fetchPlus, 'default').mockImplementation(() =>
+				Promise.resolve(createMockResponse(mockHtmlB0034NFIOI, 200))
+			)
 			response = await helper.process()
 		}, 10000)
 
@@ -111,7 +115,7 @@ describe('Audible Author HTML', () => {
 		it('threw an error', async () => {
 			asin = '103940202X'
 			helper = new ScrapeHelper(asin, 'us')
-			jest.spyOn(fetchPlus, 'default').mockImplementation(() => Promise.reject({ status: 404 }))
+			spyOn(fetchPlus, 'default').mockImplementation(() => Promise.reject({ status: 404 }))
 			await expect(helper.fetchAuthor()).rejects.toThrow(
 				`An error occured while fetching data from Audible HTML. Response: 404, ASIN: ${asin}`
 			)
@@ -122,20 +126,22 @@ describe('Audible Author HTML', () => {
 		it('threw an error', async () => {
 			asin = 'B079LRSMNN'
 			helper = new ScrapeHelper(asin, 'us')
-			jest
-				.spyOn(fetchPlus, 'default')
-				.mockImplementation(() =>
-					Promise.resolve(
-						createMockResponse(
-							'<html><body><h1 class="bc-heading bc-color-base bc-size-extra-large bc-text-secondary bc-text-bold">Showing titles\n in All Categories</h1></body></html>',
-							200
-						)
+			spyOn(fetchPlus, 'default').mockImplementation(() =>
+				Promise.resolve(
+					createMockResponse(
+						'<html><body><h1 class="bc-heading bc-color-base bc-size-extra-large bc-text-secondary bc-text-bold">Showing titles\n in All Categories</h1></body></html>',
+						200
 					)
 				)
+			)
 			const response = await helper.fetchAuthor()
 			await expect(helper.parseResponse(response)).rejects.toThrow(
 				`Item not available in region 'us' for ASIN: ${asin}`
 			)
 		})
 	})
+})
+
+afterAll(() => {
+	mock.restore()
 })

--- a/tests/audible/authors/scrape.test.ts
+++ b/tests/audible/authors/scrape.test.ts
@@ -1,5 +1,5 @@
  
-import type { AxiosResponse } from 'axios'
+import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
 
 import { ApiAuthorProfile } from '#config/types'

--- a/tests/audible/authors/scrape.test.ts
+++ b/tests/audible/authors/scrape.test.ts
@@ -115,7 +115,7 @@ describe('Audible Author HTML', () => {
 		it('threw an error', async () => {
 			asin = '103940202X'
 			helper = new ScrapeHelper(asin, 'us')
-			spyOn(fetchPlus, 'default').mockImplementation(() => Promise.reject({ status: 404 }))
+			spyOn(fetchPlus, 'default').mockImplementation(() => Promise.reject(Object.assign(new Error('Not Found'), { status: 404 })))
 			await expect(helper.fetchAuthor()).rejects.toThrow(
 				`An error occured while fetching data from Audible HTML. Response: 404, ASIN: ${asin}`
 			)

--- a/tests/audible/books/api.test.ts
+++ b/tests/audible/books/api.test.ts
@@ -1,16 +1,8 @@
 import { beforeAll, describe, expect, it } from 'bun:test'
 
-import type { ApiBook, AudibleProduct } from '#config/types'
+import type { ApiBook } from '#config/types'
 import ApiHelper from '#helpers/books/audible/ApiHelper'
-import type { MinimalResponse } from '#tests/datasets/audible/books/api'
-import {
-	B08C6YJ1LS,
-	B017V4IM1G,
-	minimalB08C6YJ1LS,
-	minimalB08G9PRS1K,
-	setupMinimalParsed,
-	setupMinimalResponse
-} from '#tests/datasets/audible/books/api'
+import { B08C6YJ1LS, B017V4IM1G, setupMinimalParsed } from '#tests/datasets/audible/books/api'
 import {
 	B08C6YJ1LScopyright,
 	B08C6YJ1LSdescription,
@@ -22,52 +14,17 @@ import {
 
 let asin: string
 let helper: ApiHelper
-let minimalResponse: MinimalResponse
 let minimalParsed: ApiBook
 
 describe('Audible API', () => {
-	describe.skip('When fetching Project Hail Mary', () => {
-		let response: AudibleProduct['product']
-		beforeAll(async () => {
-			asin = 'B08G9PRS1K'
-			helper = new ApiHelper(asin, 'us')
-			const fetched = await helper.fetchBook()
-			response = fetched.product
-			// Make an object with the same keys as the response
-			minimalResponse = setupMinimalResponse(response)
-		}, 10000)
-
-		it('returned the correct data', () => {
-			expect(minimalResponse).toEqual(minimalB08G9PRS1K)
-		})
-	})
-
-	describe.skip('When fetching The Coldest Case', () => {
-		let response: AudibleProduct['product']
-		beforeAll(async () => {
-			asin = 'B08C6YJ1LS'
-			helper = new ApiHelper(asin, 'us')
-			const fetched = await helper.fetchBook()
-			response = fetched.product
-			// Make an object with the same keys as the response
-			minimalResponse = setupMinimalResponse(response)
-		}, 10000)
-
-		it('returned the correct data', () => {
-			expect(minimalResponse).toEqual(minimalB08C6YJ1LS)
-		})
-	})
-
-	describe.skip('When parsing The Coldest Case', () => {
+	describe('When parsing The Coldest Case', () => {
 		let response: ApiBook
 		beforeAll(async () => {
 			asin = 'B08C6YJ1LS'
 			helper = new ApiHelper(asin, 'us')
-			const fetched = await helper.fetchBook()
-			const parsed = await helper.parseResponse(fetched)
+			const parsed = await helper.parseResponse(B08C6YJ1LS)
 			if (!parsed.genres) throw new Error('Parsed is undefined')
 			response = parsed
-			// Make an object with the same keys as the response
 			minimalParsed = setupMinimalParsed(
 				B08C6YJ1LS.product,
 				B08C6YJ1LScopyright,
@@ -75,23 +32,21 @@ describe('Audible API', () => {
 				B08C6YJ1LSimage,
 				parsed.genres
 			)
-		}, 10000)
+		})
 
 		it('returned the correct data', () => {
 			expect(response).toEqual(minimalParsed)
 		})
 	})
 
-	describe.skip('When parsing Scorcerers Stone', () => {
+	describe('When parsing Scorcerers Stone', () => {
 		let response: ApiBook
 		beforeAll(async () => {
 			asin = 'B017V4IM1G'
 			helper = new ApiHelper(asin, 'us')
-			const fetched = await helper.fetchBook()
-			const parsed = await helper.parseResponse(fetched)
+			const parsed = await helper.parseResponse(B017V4IM1G)
 			if (!parsed.genres) throw new Error('Parsed is undefined')
 			response = parsed
-			// Make an object with the same keys as the response
 			minimalParsed = setupMinimalParsed(
 				B017V4IM1G.product,
 				B017V4IM1Gcopyright,
@@ -99,7 +54,7 @@ describe('Audible API', () => {
 				B017V4IM1Gimage,
 				parsed.genres
 			)
-		}, 10000)
+		})
 
 		it('returned the correct data', () => {
 			expect(response).toEqual(minimalParsed)

--- a/tests/audible/books/api.test.ts
+++ b/tests/audible/books/api.test.ts
@@ -1,3 +1,5 @@
+import { beforeAll, describe, expect, it } from 'bun:test'
+
 import type { ApiBook, AudibleProduct } from '#config/types'
 import ApiHelper from '#helpers/books/audible/ApiHelper'
 import type { MinimalResponse } from '#tests/datasets/audible/books/api'
@@ -24,7 +26,7 @@ let minimalResponse: MinimalResponse
 let minimalParsed: ApiBook
 
 describe('Audible API', () => {
-	describe('When fetching Project Hail Mary', () => {
+	describe.skip('When fetching Project Hail Mary', () => {
 		let response: AudibleProduct['product']
 		beforeAll(async () => {
 			asin = 'B08G9PRS1K'
@@ -40,7 +42,7 @@ describe('Audible API', () => {
 		})
 	})
 
-	describe('When fetching The Coldest Case', () => {
+	describe.skip('When fetching The Coldest Case', () => {
 		let response: AudibleProduct['product']
 		beforeAll(async () => {
 			asin = 'B08C6YJ1LS'
@@ -56,7 +58,7 @@ describe('Audible API', () => {
 		})
 	})
 
-	describe('When parsing The Coldest Case', () => {
+	describe.skip('When parsing The Coldest Case', () => {
 		let response: ApiBook
 		beforeAll(async () => {
 			asin = 'B08C6YJ1LS'
@@ -80,7 +82,7 @@ describe('Audible API', () => {
 		})
 	})
 
-	describe('When parsing Scorcerers Stone', () => {
+	describe.skip('When parsing Scorcerers Stone', () => {
 		let response: ApiBook
 		beforeAll(async () => {
 			asin = 'B017V4IM1G'

--- a/tests/audible/books/chapter.test.ts
+++ b/tests/audible/books/chapter.test.ts
@@ -1,11 +1,11 @@
 import { beforeAll, describe, expect, it } from 'bun:test'
 
-import { ApiChapter, AudibleChapter } from '#config/types'
+import { ApiChapter } from '#config/types'
 import ChapterHelper from '#helpers/books/audible/ChapterHelper'
 import { NotFoundError } from '#helpers/errors/ApiErrors'
 import {
-	chapterParsed1721358595,
-	chapterResponseB017V4IM1G
+	chapterResponseB017V4IM1G,
+	setupParsedChapter
 } from '#tests/datasets/audible/books/chapter'
 
 // Set up environment variables for ChapterHelper
@@ -32,35 +32,18 @@ let helper: ChapterHelper
 
 // Run through known book data to test responses
 describe('Audible API', () => {
-	describe.skip('When fetching Project Hail Mary chapters', () => {
-		let response: AudibleChapter
+	describe('When parsing chapter data', () => {
+		let response: ApiChapter
 		beforeAll(async () => {
 			asin = 'B017V4IM1G'
 			helper = new ChapterHelper(asin, 'us')
-			const fetched = await helper.fetchChapter()
-			if (!fetched) throw new Error('Parsed is undefined')
-			response = fetched
-		}, 10000)
-
-		it('returned the correct data - SKIPPED: requires valid Audible API credentials', () => {
-			expect(response).toEqual(chapterResponseB017V4IM1G)
-		})
-	})
-
-	// Run through chapter parsing of a book with bad names
-	describe.skip('When parsing The Seep', () => {
-		let response: ApiChapter
-		beforeAll(async () => {
-			asin = '1721358595'
-			helper = new ChapterHelper(asin, 'us')
-			const fetched = await helper.fetchChapter()
-			const parsed = await helper.parseResponse(fetched)
+			const parsed = await helper.parseResponse(chapterResponseB017V4IM1G)
 			if (!parsed) throw new Error('Parsed is undefined')
 			response = parsed
-		}, 10000)
+		})
 
-		it('returned the correct data - SKIPPED: requires valid Audible API credentials', () => {
-			expect(response).toEqual(chapterParsed1721358595)
+		it('returned the correct data', () => {
+			expect(response).toEqual(setupParsedChapter(chapterResponseB017V4IM1G, asin))
 		})
 	})
 

--- a/tests/audible/books/chapter.test.ts
+++ b/tests/audible/books/chapter.test.ts
@@ -1,3 +1,5 @@
+import { beforeAll, describe, expect, it } from 'bun:test'
+
 import { ApiChapter, AudibleChapter } from '#config/types'
 import ChapterHelper from '#helpers/books/audible/ChapterHelper'
 import { NotFoundError } from '#helpers/errors/ApiErrors'
@@ -30,7 +32,7 @@ let helper: ChapterHelper
 
 // Run through known book data to test responses
 describe('Audible API', () => {
-	describe('When fetching Project Hail Mary chapters', () => {
+	describe.skip('When fetching Project Hail Mary chapters', () => {
 		let response: AudibleChapter
 		beforeAll(async () => {
 			asin = 'B017V4IM1G'
@@ -40,13 +42,14 @@ describe('Audible API', () => {
 			response = fetched
 		}, 10000)
 
-		it.skip('returned the correct data - SKIPPED: requires valid Audible API credentials', () => {
+		it('returned the correct data - SKIPPED: requires valid Audible API credentials', () => {
 			expect(response).toEqual(chapterResponseB017V4IM1G)
 		})
 	})
 
 	// Run through chapter parsing of a book with bad names
-	describe('When parsing The Seep', () => {
+	// Run through chapter parsing of a book with bad names
+	describe.skip('When parsing The Seep', () => {
 		let response: ApiChapter
 		beforeAll(async () => {
 			asin = '1721358595'
@@ -57,7 +60,7 @@ describe('Audible API', () => {
 			response = parsed
 		}, 10000)
 
-		it.skip('returned the correct data - SKIPPED: requires valid Audible API credentials', () => {
+		it('returned the correct data - SKIPPED: requires valid Audible API credentials', () => {
 			expect(response).toEqual(chapterParsed1721358595)
 		})
 	})

--- a/tests/audible/books/chapter.test.ts
+++ b/tests/audible/books/chapter.test.ts
@@ -48,7 +48,6 @@ describe('Audible API', () => {
 	})
 
 	// Run through chapter parsing of a book with bad names
-	// Run through chapter parsing of a book with bad names
 	describe.skip('When parsing The Seep', () => {
 		let response: ApiChapter
 		beforeAll(async () => {

--- a/tests/audible/books/scrape.test.ts
+++ b/tests/audible/books/scrape.test.ts
@@ -1,5 +1,10 @@
 import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios'
+import { afterAll, beforeAll, describe, expect, it, mock, spyOn, test } from 'bun:test'
 import * as cheerio from 'cheerio'
+
+mock.module('#helpers/utils/fetchPlus', () => {
+	return { default: mock() }
+})
 
 import { HtmlBook } from '#config/types'
 import ScrapeHelper from '#helpers/books/audible/ScrapeHelper'
@@ -12,8 +17,6 @@ import {
 	parsedB08G9PRS1K,
 	parsedB017V4IM1G
 } from '#tests/datasets/audible/books/scrape'
-
-jest.mock('#helpers/utils/fetchPlus')
 
 let asin: string
 let helper: ScrapeHelper
@@ -32,8 +35,7 @@ describe('Audible HTML', () => {
 		beforeAll(async () => {
 			asin = 'B08G9PRS1K'
 			helper = new ScrapeHelper(asin, 'us')
-			jest
-				.spyOn(fetchPlus, 'default')
+			spyOn(fetchPlus, 'default')
 				.mockImplementation(() => Promise.resolve(createMockResponse(mockHtmlB08G9PRS1K, 200)))
 			const fetched = await helper.fetchBook()
 			const parsed = await helper.parseResponse(fetched)
@@ -51,8 +53,7 @@ describe('Audible HTML', () => {
 		beforeAll(async () => {
 			asin = 'B017V4IM1G'
 			helper = new ScrapeHelper(asin, 'us')
-			jest
-				.spyOn(fetchPlus, 'default')
+			spyOn(fetchPlus, 'default')
 				.mockImplementation(() => Promise.resolve(createMockResponse(mockHtmlB017V4IM1G, 200)))
 			const fetched = await helper.fetchBook()
 			const parsed = await helper.parseResponse(fetched)
@@ -70,8 +71,7 @@ describe('Audible HTML', () => {
 		beforeAll(async () => {
 			asin = 'B08C6YJ1LS'
 			helper = new ScrapeHelper(asin, 'us')
-			jest
-				.spyOn(fetchPlus, 'default')
+			spyOn(fetchPlus, 'default')
 				.mockImplementation(() => Promise.resolve(createMockResponse(mockHtmlB08C6YJ1LS, 200)))
 			const fetched = await helper.fetchBook()
 			const parsed = await helper.parseResponse(fetched)
@@ -89,7 +89,7 @@ describe('Audible HTML', () => {
 		beforeAll(async () => {
 			asin = 'B00B5HZGUG'
 			helper = new ScrapeHelper(asin, 'us')
-			jest.spyOn(fetchPlus, 'default').mockImplementation(() => Promise.reject({ status: 404 }))
+			spyOn(fetchPlus, 'default').mockImplementation(() => Promise.reject({ status: 404 }))
 			const fetched = await helper.fetchBook()
 			response = fetched
 		}, 10000)
@@ -104,8 +104,7 @@ describe('Audible HTML', () => {
 		beforeAll(async () => {
 			asin = 'B0036I54I6'
 			helper = new ScrapeHelper(asin, 'us')
-			jest
-				.spyOn(fetchPlus, 'default')
+			spyOn(fetchPlus, 'default')
 				.mockImplementation(() =>
 					Promise.resolve(createMockResponse('<html><body></body></html>', 200))
 				)
@@ -122,4 +121,8 @@ describe('Audible HTML', () => {
 	test.todo('When fetching a book with no genres')
 
 	test.todo('WHen fetching a book with only 1 genre')
+})
+
+afterAll(() => {
+	mock.restore()
 })

--- a/tests/audible/books/scrape.test.ts
+++ b/tests/audible/books/scrape.test.ts
@@ -1,5 +1,5 @@
 import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios'
-import { afterAll, beforeAll, describe, expect, it, mock, spyOn, test } from 'bun:test'
+import { afterAll, beforeAll, describe, expect, it, mock, spyOn } from 'bun:test'
 import * as cheerio from 'cheerio'
 
 mock.module('#helpers/utils/fetchPlus', () => {
@@ -13,9 +13,12 @@ import {
 	mockHtmlB08C6YJ1LS,
 	mockHtmlB08G9PRS1K,
 	mockHtmlB017V4IM1G,
+	mockHtmlNoGenres,
+	mockHtmlSingleGenre,
 	parsedB08C6YJ1LS,
 	parsedB08G9PRS1K,
-	parsedB017V4IM1G
+	parsedB017V4IM1G,
+	parsedSingleGenre
 } from '#tests/datasets/audible/books/scrape'
 
 let asin: string
@@ -35,8 +38,9 @@ describe('Audible HTML', () => {
 		beforeAll(async () => {
 			asin = 'B08G9PRS1K'
 			helper = new ScrapeHelper(asin, 'us')
-			spyOn(fetchPlus, 'default')
-				.mockImplementation(() => Promise.resolve(createMockResponse(mockHtmlB08G9PRS1K, 200)))
+			spyOn(fetchPlus, 'default').mockImplementation(() =>
+				Promise.resolve(createMockResponse(mockHtmlB08G9PRS1K, 200))
+			)
 			const fetched = await helper.fetchBook()
 			const parsed = await helper.parseResponse(fetched)
 			if (!parsed) throw new Error('Parsed is undefined')
@@ -53,8 +57,9 @@ describe('Audible HTML', () => {
 		beforeAll(async () => {
 			asin = 'B017V4IM1G'
 			helper = new ScrapeHelper(asin, 'us')
-			spyOn(fetchPlus, 'default')
-				.mockImplementation(() => Promise.resolve(createMockResponse(mockHtmlB017V4IM1G, 200)))
+			spyOn(fetchPlus, 'default').mockImplementation(() =>
+				Promise.resolve(createMockResponse(mockHtmlB017V4IM1G, 200))
+			)
 			const fetched = await helper.fetchBook()
 			const parsed = await helper.parseResponse(fetched)
 			if (!parsed) throw new Error('Parsed is undefined')
@@ -71,8 +76,9 @@ describe('Audible HTML', () => {
 		beforeAll(async () => {
 			asin = 'B08C6YJ1LS'
 			helper = new ScrapeHelper(asin, 'us')
-			spyOn(fetchPlus, 'default')
-				.mockImplementation(() => Promise.resolve(createMockResponse(mockHtmlB08C6YJ1LS, 200)))
+			spyOn(fetchPlus, 'default').mockImplementation(() =>
+				Promise.resolve(createMockResponse(mockHtmlB08C6YJ1LS, 200))
+			)
 			const fetched = await helper.fetchBook()
 			const parsed = await helper.parseResponse(fetched)
 			if (!parsed) throw new Error('Parsed is undefined')
@@ -89,7 +95,9 @@ describe('Audible HTML', () => {
 		beforeAll(async () => {
 			asin = 'B00B5HZGUG'
 			helper = new ScrapeHelper(asin, 'us')
-			spyOn(fetchPlus, 'default').mockImplementation(() => Promise.reject(Object.assign(new Error('Not Found'), { status: 404 })))
+			spyOn(fetchPlus, 'default').mockImplementation(() =>
+				Promise.reject(Object.assign(new Error('Not Found'), { status: 404 }))
+			)
 			const fetched = await helper.fetchBook()
 			response = fetched
 		}, 10000)
@@ -104,10 +112,9 @@ describe('Audible HTML', () => {
 		beforeAll(async () => {
 			asin = 'B0036I54I6'
 			helper = new ScrapeHelper(asin, 'us')
-			spyOn(fetchPlus, 'default')
-				.mockImplementation(() =>
-					Promise.resolve(createMockResponse('<html><body></body></html>', 200))
-				)
+			spyOn(fetchPlus, 'default').mockImplementation(() =>
+				Promise.resolve(createMockResponse('<html><body></body></html>', 200))
+			)
 			const fetched = await helper.fetchBook()
 			const parsed = await helper.parseResponse(fetched)
 			response = parsed
@@ -118,9 +125,42 @@ describe('Audible HTML', () => {
 		})
 	})
 
-	test.todo('When fetching a book with no genres')
+	describe('When fetching a book with no genres', () => {
+		let response: HtmlBook | undefined
+		beforeAll(async () => {
+			asin = 'BNOGENRE01'
+			helper = new ScrapeHelper(asin, 'us')
+			spyOn(fetchPlus, 'default').mockImplementation(() =>
+				Promise.resolve(createMockResponse(mockHtmlNoGenres, 200))
+			)
+			const fetched = await helper.fetchBook()
+			const parsed = await helper.parseResponse(fetched)
+			response = parsed
+		})
 
-	test.todo('WHen fetching a book with only 1 genre')
+		it('returned undefined since no genres found', () => {
+			expect(response).toBeUndefined()
+		})
+	})
+
+	describe('When fetching a book with only 1 genre', () => {
+		let response: HtmlBook
+		beforeAll(async () => {
+			asin = 'BSINGLEGENR'
+			helper = new ScrapeHelper(asin, 'us')
+			spyOn(fetchPlus, 'default').mockImplementation(() =>
+				Promise.resolve(createMockResponse(mockHtmlSingleGenre, 200))
+			)
+			const fetched = await helper.fetchBook()
+			const parsed = await helper.parseResponse(fetched)
+			if (!parsed) throw new Error('Parsed is undefined')
+			response = parsed
+		})
+
+		it('returned the correct data', () => {
+			expect(response).toEqual(parsedSingleGenre)
+		})
+	})
 })
 
 afterAll(() => {

--- a/tests/audible/books/scrape.test.ts
+++ b/tests/audible/books/scrape.test.ts
@@ -89,7 +89,7 @@ describe('Audible HTML', () => {
 		beforeAll(async () => {
 			asin = 'B00B5HZGUG'
 			helper = new ScrapeHelper(asin, 'us')
-			spyOn(fetchPlus, 'default').mockImplementation(() => Promise.reject({ status: 404 }))
+			spyOn(fetchPlus, 'default').mockImplementation(() => Promise.reject(Object.assign(new Error('Not Found'), { status: 404 })))
 			const fetched = await helper.fetchBook()
 			response = fetched
 		}, 10000)

--- a/tests/audible/books/stitch.test.ts
+++ b/tests/audible/books/stitch.test.ts
@@ -1,13 +1,8 @@
-import { ApiBook, ApiChapter } from '#config/types'
+import { ApiBook } from '#config/types'
 import ChapterHelper from '#helpers/books/audible/ChapterHelper'
 import StitchHelper from '#helpers/books/audible/StitchHelper'
 import { NotFoundError } from '#helpers/errors/ApiErrors'
 import { minimalB0036I54I6 } from '#tests/datasets/audible/books/api'
-import {
-	chapterResponseB08C6YJ1LS,
-	chapterResponseB017V4IM1G,
-	setupParsedChapter
-} from '#tests/datasets/audible/books/chapter'
 import { combinedB08C6YJ1LS, combinedB017V4IM1G } from '#tests/datasets/audible/books/stitch'
 
 // Set up environment variables for ChapterHelper
@@ -31,75 +26,43 @@ wJhvGwWnOXbc/RAmdfeZH4H2XJCEZ/yzCG9d0XOpnyAZ
 
 let asin: string
 let helper: StitchHelper
-let chapterHelper: ChapterHelper
 let response: ApiBook
-let chapters: ApiChapter | undefined
-
-async function safeProcessChapter<T>(operation: () => Promise<T>): Promise<T | undefined> {
-	try {
-		return await operation()
-	} catch (error) {
-		if (error instanceof NotFoundError) {
-			return undefined
-		}
-		throw error
-	}
-}
 
 describe('Audible API and HTML Parsing', () => {
 	describe('When stitching together Scorcerers Stone', () => {
 		beforeAll(async () => {
 			asin = 'B017V4IM1G'
-			// Setup helpers
-			chapterHelper = new ChapterHelper(asin, 'us')
 			helper = new StitchHelper(asin, 'us')
-			// Run helpers - chapter helper may throw NotFoundError without valid credentials
-			chapters = await safeProcessChapter(() => chapterHelper.process())
 			const newBook = await helper.process()
-			// Set variables
 			response = newBook
 		}, 10000)
 
 		it('returned the correct data', () => {
 			expect(response).toEqual(combinedB017V4IM1G)
 		})
-
-		it.skip('returned the correct chapters - SKIPPED: requires valid Audible API credentials', () => {
-			expect(chapters).toEqual(setupParsedChapter(chapterResponseB017V4IM1G, asin))
-		})
 	})
 
 	describe('When stitching together The Coldest Case', () => {
 		beforeAll(async () => {
 			asin = 'B08C6YJ1LS'
-			// Setup helpers
-			chapterHelper = new ChapterHelper(asin, 'us')
 			helper = new StitchHelper(asin, 'us')
-			// Run helpers - chapter helper may throw NotFoundError without valid credentials
-			chapters = await safeProcessChapter(() => chapterHelper.process())
 			const newBook = await helper.process()
-			// Set variables
 			response = newBook
 		}, 10000)
 
 		it('returned the correct data', () => {
 			expect(response).toEqual(combinedB08C6YJ1LS)
 		})
-
-		it.skip('returned the correct chapters - SKIPPED: requires valid Audible API credentials', () => {
-			expect(chapters).toEqual(setupParsedChapter(chapterResponseB08C6YJ1LS, asin))
-		})
 	})
 
 	describe('When fetching an ASIN that has no chapters or HTML', () => {
 		let chapterError!: NotFoundError
+		let chapterHelper: ChapterHelper
 		beforeAll(async () => {
 			asin = 'B0036I54I6'
-			// Setup helpers
-			chapterHelper = new ChapterHelper(asin, 'us')
 			helper = new StitchHelper(asin, 'us')
-			// Run helpers
 			try {
+				chapterHelper = new ChapterHelper(asin, 'us')
 				await chapterHelper.process()
 				fail('Expected NotFoundError to be thrown')
 			} catch (e) {
@@ -110,7 +73,6 @@ describe('Audible API and HTML Parsing', () => {
 				}
 			}
 			const newBook = await helper.process()
-			// Set variables
 			response = newBook
 		}, 10000)
 

--- a/tests/config/performance/hooks.test.ts
+++ b/tests/config/performance/hooks.test.ts
@@ -1,3 +1,4 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
 import Fastify from 'fastify'
 
 import {
@@ -12,10 +13,6 @@ import {
 	resetMetrics
 } from '#config/performance/hooks'
 
-/**
- * Factory function for creating test PerformanceConfig instances.
- * Provides a reusable base configuration with optional overrides.
- */
 const createTestConfig = (overrides: Partial<PerformanceConfig>): PerformanceConfig => ({
 	...DEFAULT_PERFORMANCE_CONFIG,
 	...overrides
@@ -215,9 +212,7 @@ describe('Performance Hooks', () => {
 
 			const metrics = getPerformanceMetrics()
 			expect(metrics.requests['/test']).toBeDefined()
-			// Count should still be accurate even though durations are capped
 			expect(metrics.requests['/test'].count).toBe(101)
-			// Min and avg should still be calculated correctly
 			expect(metrics.requests['/test'].min).toBeGreaterThanOrEqual(0)
 			expect(metrics.requests['/test'].avg).toBeGreaterThanOrEqual(0)
 

--- a/tests/config/performance/hooks.test.ts
+++ b/tests/config/performance/hooks.test.ts
@@ -56,26 +56,22 @@ describe('Performance Hooks', () => {
 	})
 
 	describe('registerPerformanceHooks', () => {
-		// Skipped: Fastify hook ordering issue - response-time hook may not fire before
-		// response is sent in test environment with inject()
-		it.skip('should add X-Response-Time header', async () => {
+		it('should execute onResponse hook (metrics tracked)', async () => {
 			const fastify = Fastify()
 			fastify.get('/test', async () => ({ message: 'ok' }))
 			registerPerformanceHooks(fastify)
 			await fastify.ready()
 
-			const response = await fastify.inject({
+			await fastify.inject({
 				method: 'GET',
 				url: '/test'
 			})
 
-			const responseTimeHeader =
-				response.headers['x-response-time'] || response.headers['X-Response-Time']
-			expect(responseTimeHeader).toBeDefined()
-			const responseTime = parseFloat(responseTimeHeader as string)
-			expect(responseTime).toBeGreaterThanOrEqual(0)
-
-			await fastify.close()
+			// inject() captures headers before onResponse sets X-Response-Time,
+			// so verify the hook ran via the metrics store instead
+			const metrics = getPerformanceMetrics()
+			expect(metrics.requests['/test']).toBeDefined()
+			expect(metrics.requests['/test'].count).toBe(1)
 		})
 
 		it('should track request metrics', async () => {

--- a/tests/config/performance/hooks.test.ts
+++ b/tests/config/performance/hooks.test.ts
@@ -58,20 +58,24 @@ describe('Performance Hooks', () => {
 	describe('registerPerformanceHooks', () => {
 		it('should execute onResponse hook (metrics tracked)', async () => {
 			const fastify = Fastify()
-			fastify.get('/test', async () => ({ message: 'ok' }))
-			registerPerformanceHooks(fastify)
-			await fastify.ready()
+			try {
+				fastify.get('/test', async () => ({ message: 'ok' }))
+				registerPerformanceHooks(fastify)
+				await fastify.ready()
 
-			await fastify.inject({
-				method: 'GET',
-				url: '/test'
-			})
+				await fastify.inject({
+					method: 'GET',
+					url: '/test'
+				})
 
-			// inject() captures headers before onResponse sets X-Response-Time,
-			// so verify the hook ran via the metrics store instead
-			const metrics = getPerformanceMetrics()
-			expect(metrics.requests['/test']).toBeDefined()
-			expect(metrics.requests['/test'].count).toBe(1)
+				// inject() captures headers before onResponse sets X-Response-Time,
+				// so verify the hook ran via the metrics store instead
+				const metrics = getPerformanceMetrics()
+				expect(metrics.requests['/test']).toBeDefined()
+				expect(metrics.requests['/test'].count).toBe(1)
+			} finally {
+				await fastify.close()
+			}
 		})
 
 		it('should track request metrics', async () => {

--- a/tests/config/routes/health.test.ts
+++ b/tests/config/routes/health.test.ts
@@ -84,8 +84,7 @@ describe('health route should', () => {
 
 	// Helper to extract route handler
 	const getRouteHandler = () => {
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		return (app.get as any).mock.calls[0][1]
+		return app.get.mock.calls[0][1]
 	}
 
 	test('return 200 and healthy status when all services are up', async () => {

--- a/tests/config/routes/health.test.ts
+++ b/tests/config/routes/health.test.ts
@@ -43,6 +43,7 @@ describe('health route should', () => {
 
 		mockMongoConnect.mockResolvedValue(undefined)
 		mockMongoCommand.mockResolvedValue({ ok: 1 })
+		mockMongoDb.mockReturnValue({ command: mockMongoCommand })
 		mockMongoClose.mockResolvedValue(undefined)
 
 		mockMongoClient = {
@@ -69,10 +70,26 @@ describe('health route should', () => {
 		}
 	})
 
+	// Helper function to create mock reply with optional assertions
+	const createMockReply = (assertions?: (data: HealthCheckResponse) => void) => {
+		const reply = {
+			status: mock(() => reply),
+			send: mock().mockImplementation((data: HealthCheckResponse) => {
+				if (assertions) assertions(data)
+				return reply
+			})
+		}
+		return reply
+	}
+
+	// Helper to extract route handler
+	const getRouteHandler = () => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		return (app.get as any).mock.calls[0][1]
+	}
+
 	test('return 200 and healthy status when all services are up', async () => {
-		mockMongoDb.mockReturnValue({
-			command: mockMongoCommand
-		})
+
 		mockMongoCommand.mockResolvedValue({ ok: 1 })
 
 		app.redis = {
@@ -81,22 +98,17 @@ describe('health route should', () => {
 
 		await health(app)
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const routeHandler = (app.get as any).mock.calls[0][1]
+		const routeHandler = getRouteHandler()
+
 
 		const mockRequest = createMockRequest()
-		const mockReply = {
-			status: mock(() => mockReply),
-			send: mock().mockImplementation((data: HealthCheckResponse) => {
-				expect(data.status).toBe('healthy')
-				expect(data.checks.server).toBe(true)
-				expect(data.checks.database).toBe(true)
-				expect(data.checks.redis).toBe(true)
-				expect(data.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/)
-				return mockReply
-			})
-		}
+		const mockReply = createMockReply((data) => {
+			expect(data.status).toBe('healthy')
+			expect(data.checks.server).toBe(true)
+			expect(data.checks.database).toBe(true)
+			expect(data.checks.redis).toBe(true)
+			expect(data.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/)
+		})
 
 		await routeHandler(mockRequest, mockReply)
 
@@ -104,9 +116,7 @@ describe('health route should', () => {
 	})
 
 	test('return 503 and unhealthy status when MongoDB is down', async () => {
-		mockMongoDb.mockReturnValue({
-			command: mockMongoCommand
-		})
+
 		mockMongoCommand.mockRejectedValue(new Error('MongoDB connection failed'))
 
 		app.redis = {
@@ -114,22 +124,18 @@ describe('health route should', () => {
 		}
 
 		await health(app)
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const routeHandler = (app.get as any).mock.calls[0][1]
+		const routeHandler = getRouteHandler()
+
 
 
 		const mockRequest = createMockRequest()
-		const mockReply = {
-			status: mock(() => mockReply),
-			send: mock().mockImplementation((data: HealthCheckResponse) => {
-				expect(data.status).toBe('unhealthy')
-				expect(data.checks.server).toBe(true)
-				expect(data.checks.database).toBe(false)
-				expect(data.checks.redis).toBe(true)
-				expect(data.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/)
-				return mockReply
-			})
-		}
+		const mockReply = createMockReply((data) => {
+			expect(data.status).toBe('unhealthy')
+			expect(data.checks.server).toBe(true)
+			expect(data.checks.database).toBe(false)
+			expect(data.checks.redis).toBe(true)
+			expect(data.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/)
+		})
 
 		await routeHandler(mockRequest, mockReply)
 
@@ -137,9 +143,7 @@ describe('health route should', () => {
 	})
 
 	test('return 503 and unhealthy status when Redis is down', async () => {
-		mockMongoDb.mockReturnValue({
-			command: mockMongoCommand
-		})
+
 		mockMongoCommand.mockResolvedValue({ ok: 1 })
 
 		app.redis = {
@@ -148,21 +152,17 @@ describe('health route should', () => {
 
 		await health(app)
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const routeHandler = (app.get as any).mock.calls[0][1]
+		const routeHandler = getRouteHandler()
+
 
 		const mockRequest = createMockRequest()
-		const mockReply = {
-			status: mock(() => mockReply),
-			send: mock().mockImplementation((data: HealthCheckResponse) => {
-				expect(data.status).toBe('unhealthy')
-				expect(data.checks.server).toBe(true)
-				expect(data.checks.database).toBe(true)
-				expect(data.checks.redis).toBe(false)
-				expect(data.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/)
-				return mockReply
-			})
-		}
+		const mockReply = createMockReply((data) => {
+			expect(data.status).toBe('unhealthy')
+			expect(data.checks.server).toBe(true)
+			expect(data.checks.database).toBe(true)
+			expect(data.checks.redis).toBe(false)
+			expect(data.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/)
+		})
 
 		await routeHandler(mockRequest, mockReply)
 
@@ -170,9 +170,7 @@ describe('health route should', () => {
 	})
 
 	test('return 503 and unhealthy status when both MongoDB and Redis are down', async () => {
-		mockMongoDb.mockReturnValue({
-			command: mockMongoCommand
-		})
+
 		mockMongoCommand.mockRejectedValue(new Error('MongoDB connection failed'))
 
 		app.redis = {
@@ -180,21 +178,17 @@ describe('health route should', () => {
 		}
 
 		await health(app)
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const routeHandler = (app.get as any).mock.calls[0][1]
+		const routeHandler = getRouteHandler()
+
 
 		const mockRequest = createMockRequest()
-		const mockReply = {
-			status: mock(() => mockReply),
-			send: mock().mockImplementation((data: HealthCheckResponse) => {
-				expect(data.status).toBe('unhealthy')
-				expect(data.checks.server).toBe(true)
-				expect(data.checks.database).toBe(false)
-				expect(data.checks.redis).toBe(false)
-				expect(data.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/)
-				return mockReply
-			})
-		}
+		const mockReply = createMockReply((data) => {
+			expect(data.status).toBe('unhealthy')
+			expect(data.checks.server).toBe(true)
+			expect(data.checks.database).toBe(false)
+			expect(data.checks.redis).toBe(false)
+			expect(data.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/)
+		})
 
 		await routeHandler(mockRequest, mockReply)
 
@@ -202,29 +196,23 @@ describe('health route should', () => {
 	})
 
 	test('return 200 and redis as null when Redis is not registered', async () => {
-		mockMongoDb.mockReturnValue({
-			command: mockMongoCommand
-		})
+
 		mockMongoCommand.mockResolvedValue({ ok: 1 })
 
 		app.redis = undefined
 		await health(app)
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const routeHandler = (app.get as any).mock.calls[0][1]
+		const routeHandler = getRouteHandler()
+
 
 
 		const mockRequest = createMockRequest()
-		const mockReply = {
-			status: mock(() => mockReply),
-			send: mock().mockImplementation((data: HealthCheckResponse) => {
-				expect(data.status).toBe('healthy')
-				expect(data.checks.server).toBe(true)
-				expect(data.checks.database).toBe(true)
-				expect(data.checks.redis).toBeNull()
-				expect(data.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/)
-				return mockReply
-			})
-		}
+		const mockReply = createMockReply((data) => {
+			expect(data.status).toBe('healthy')
+			expect(data.checks.server).toBe(true)
+			expect(data.checks.database).toBe(true)
+			expect(data.checks.redis).toBeNull()
+			expect(data.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/)
+		})
 
 		await routeHandler(mockRequest, mockReply)
 
@@ -232,27 +220,20 @@ describe('health route should', () => {
 	})
 
 	test('verify response structure has all required fields', async () => {
-		mockMongoDb.mockReturnValue({
-			command: mockMongoCommand
-		})
+
 		mockMongoCommand.mockResolvedValue({ ok: 1 })
 		app.redis = {
 			ping: mock().mockResolvedValue('PONG')
 		}
 
 		await health(app)
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const routeHandler = (app.get as any).mock.calls[0][1]
+		const routeHandler = getRouteHandler()
 
 		const mockRequest = createMockRequest()
 		let capturedData: HealthCheckResponse | null = null
-		const mockReply = {
-			status: mock(() => mockReply),
-			send: mock().mockImplementation((data: HealthCheckResponse) => {
-				capturedData = data
-				return mockReply
-			})
-		}
+		const mockReply = createMockReply((data) => {
+			capturedData = data
+		})
 
 		await routeHandler(mockRequest, mockReply)
 
@@ -273,27 +254,20 @@ describe('health route should', () => {
 	})
 
 	test('verify timestamp is valid ISO format', async () => {
-		mockMongoDb.mockReturnValue({
-			command: mockMongoCommand
-		})
+
 		mockMongoCommand.mockResolvedValue({ ok: 1 })
 		app.redis = {
 			ping: mock().mockResolvedValue('PONG')
 		}
 
 		await health(app)
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const routeHandler = (app.get as any).mock.calls[0][1]
+		const routeHandler = getRouteHandler()
 
 		const mockRequest = createMockRequest()
 		let capturedData: HealthCheckResponse | null = null
-		const mockReply = {
-			status: mock(() => mockReply),
-			send: mock().mockImplementation((data: HealthCheckResponse) => {
-				capturedData = data
-				return mockReply
-			})
-		}
+		const mockReply = createMockReply((data) => {
+			capturedData = data
+		})
 
 		await routeHandler(mockRequest, mockReply)
 

--- a/tests/config/routes/health.test.ts
+++ b/tests/config/routes/health.test.ts
@@ -1,69 +1,67 @@
-import type { FastifyInstance } from 'fastify'
-import { mockDeep } from 'jest-mock-extended'
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
 import { MongoClient } from 'mongodb'
 
 import health, { HealthCheckResponse } from '#config/routes/health'
 
-const isBun = 'Bun' in globalThis
-const describeOrSkip = isBun ? describe.skip : describe
+const mockMongoConnect = mock()
+const mockMongoDb = mock()
+const mockMongoCommand = mock()
+const mockMongoClose = mock()
 
-// Mock the MongoClient
-jest.mock('mongodb', () => ({
-	MongoClient: jest.fn().mockImplementation(() => ({
-		connect: jest.fn().mockResolvedValue(undefined),
-		db: jest.fn().mockReturnValue({
-			command: jest.fn()
-		}),
-		close: jest.fn().mockResolvedValue(undefined)
-	}))
+mock.module('mongodb', () => ({
+	MongoClient: class MockMongoClient {
+		connect = mockMongoConnect
+		db = mockMongoDb
+		close = mockMongoClose
+	}
 }))
 
-describeOrSkip('health route should', () => {
+describe('health route should', () => {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	let app: any
 	let mockMongoClient: MongoClient
 	let originalMongoUri: string | undefined
 
-	// Shared mock request factory
 	const createMockRequest = () => ({
 		log: {
-			error: jest.fn(),
-			info: jest.fn(),
-			debug: jest.fn(),
-			warn: jest.fn()
+			error: mock(),
+			info: mock(),
+			debug: mock(),
+			warn: mock()
 		}
 	})
 
 	beforeEach(() => {
-		// Save original MONGODB_URI to prevent environment variable leaks
 		originalMongoUri = process.env.MONGODB_URI
 
-		// Create a deep mock of FastifyInstance
-		app = mockDeep<FastifyInstance>()
+		app = {
+			get: mock(),
+			mongoClient: null,
+			redis: null,
+			reply: null
+		}
 
-		// Create mock MongoClient
+		mockMongoConnect.mockResolvedValue(undefined)
+		mockMongoCommand.mockResolvedValue({ ok: 1 })
+		mockMongoClose.mockResolvedValue(undefined)
+
 		mockMongoClient = {
-			connect: jest.fn().mockResolvedValue(undefined),
-			db: jest.fn().mockReturnValue({
-				command: jest.fn()
-			}),
-			close: jest.fn().mockResolvedValue(undefined)
+			connect: mockMongoConnect,
+			db: mockMongoDb,
+			close: mockMongoClose
 		} as unknown as MongoClient
 
-		// Attach mongoClient to app
 		app.mongoClient = mockMongoClient
 
-		// Mock reply.send and reply.status
 		const mockReply = {
-			status: jest.fn().mockReturnThis(),
-			send: jest.fn().mockReturnThis()
+			status: mock(() => mockReply),
+			send: mock(() => mockReply)
 		}
 		app.reply = mockReply
 	})
 
 	afterEach(() => {
-		jest.clearAllMocks()
-		// Restore original MONGODB_URI to prevent environment variable leaks
+		mock.clearAllMocks()
 		if (originalMongoUri === undefined) {
 			delete process.env.MONGODB_URI
 		} else {
@@ -72,26 +70,25 @@ describeOrSkip('health route should', () => {
 	})
 
 	test('return 200 and healthy status when all services are up', async () => {
-		// Mock MongoDB ping success
-		;(mockMongoClient.db().command as jest.Mock).mockResolvedValue({ ok: 1 })
+		mockMongoDb.mockReturnValue({
+			command: mockMongoCommand
+		})
+		mockMongoCommand.mockResolvedValue({ ok: 1 })
 
-		// Mock Redis ping success
 		app.redis = {
-			ping: jest.fn().mockResolvedValue('PONG')
+			ping: mock().mockResolvedValue('PONG')
 		}
 
-		// Register health route
 		await health(app)
 
-		// Get the route handler
-		const routeHandler = (app.get as jest.Mock).mock.calls[0][1]
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const routeHandler = (app.get as any).mock.calls[0][1]
 
-		// Create mock request and reply
 		const mockRequest = createMockRequest()
 		const mockReply = {
-			status: jest.fn().mockReturnThis(),
-			send: jest.fn().mockImplementation((data: HealthCheckResponse) => {
-				// Verify the response structure
+			status: mock(() => mockReply),
+			send: mock().mockImplementation((data: HealthCheckResponse) => {
 				expect(data.status).toBe('healthy')
 				expect(data.checks.server).toBe(true)
 				expect(data.checks.database).toBe(true)
@@ -101,36 +98,30 @@ describeOrSkip('health route should', () => {
 			})
 		}
 
-		// Call the route handler
 		await routeHandler(mockRequest, mockReply)
 
-		// Verify reply.status was called with 200
 		expect(mockReply.status).toHaveBeenCalledWith(200)
 	})
 
 	test('return 503 and unhealthy status when MongoDB is down', async () => {
-		// Mock MongoDB ping failure
-		;(mockMongoClient.db().command as jest.Mock).mockRejectedValue(
-			new Error('MongoDB connection failed')
-		)
+		mockMongoDb.mockReturnValue({
+			command: mockMongoCommand
+		})
+		mockMongoCommand.mockRejectedValue(new Error('MongoDB connection failed'))
 
-		// Mock Redis ping success
 		app.redis = {
-			ping: jest.fn().mockResolvedValue('PONG')
+			ping: mock().mockResolvedValue('PONG')
 		}
 
-		// Register health route
 		await health(app)
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const routeHandler = (app.get as any).mock.calls[0][1]
 
-		// Get the route handler
-		const routeHandler = (app.get as jest.Mock).mock.calls[0][1]
 
-		// Create mock request and reply
 		const mockRequest = createMockRequest()
 		const mockReply = {
-			status: jest.fn().mockReturnThis(),
-			send: jest.fn().mockImplementation((data: HealthCheckResponse) => {
-				// Verify the response structure
+			status: mock(() => mockReply),
+			send: mock().mockImplementation((data: HealthCheckResponse) => {
 				expect(data.status).toBe('unhealthy')
 				expect(data.checks.server).toBe(true)
 				expect(data.checks.database).toBe(false)
@@ -140,34 +131,30 @@ describeOrSkip('health route should', () => {
 			})
 		}
 
-		// Call the route handler
 		await routeHandler(mockRequest, mockReply)
 
-		// Verify reply.status was called with 503
 		expect(mockReply.status).toHaveBeenCalledWith(503)
 	})
 
 	test('return 503 and unhealthy status when Redis is down', async () => {
-		// Mock MongoDB ping success
-		;(mockMongoClient.db().command as jest.Mock).mockResolvedValue({ ok: 1 })
+		mockMongoDb.mockReturnValue({
+			command: mockMongoCommand
+		})
+		mockMongoCommand.mockResolvedValue({ ok: 1 })
 
-		// Mock Redis ping failure
 		app.redis = {
-			ping: jest.fn().mockRejectedValue(new Error('Redis connection failed'))
+			ping: mock().mockRejectedValue(new Error('Redis connection failed'))
 		}
 
-		// Register health route
 		await health(app)
 
-		// Get the route handler
-		const routeHandler = (app.get as jest.Mock).mock.calls[0][1]
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const routeHandler = (app.get as any).mock.calls[0][1]
 
-		// Create mock request and reply
 		const mockRequest = createMockRequest()
 		const mockReply = {
-			status: jest.fn().mockReturnThis(),
-			send: jest.fn().mockImplementation((data: HealthCheckResponse) => {
-				// Verify the response structure
+			status: mock(() => mockReply),
+			send: mock().mockImplementation((data: HealthCheckResponse) => {
 				expect(data.status).toBe('unhealthy')
 				expect(data.checks.server).toBe(true)
 				expect(data.checks.database).toBe(true)
@@ -177,36 +164,29 @@ describeOrSkip('health route should', () => {
 			})
 		}
 
-		// Call the route handler
 		await routeHandler(mockRequest, mockReply)
 
-		// Verify reply.status was called with 503
 		expect(mockReply.status).toHaveBeenCalledWith(503)
 	})
 
 	test('return 503 and unhealthy status when both MongoDB and Redis are down', async () => {
-		// Mock MongoDB ping failure
-		;(mockMongoClient.db().command as jest.Mock).mockRejectedValue(
-			new Error('MongoDB connection failed')
-		)
+		mockMongoDb.mockReturnValue({
+			command: mockMongoCommand
+		})
+		mockMongoCommand.mockRejectedValue(new Error('MongoDB connection failed'))
 
-		// Mock Redis ping failure
 		app.redis = {
-			ping: jest.fn().mockRejectedValue(new Error('Redis connection failed'))
+			ping: mock().mockRejectedValue(new Error('Redis connection failed'))
 		}
 
-		// Register health route
 		await health(app)
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const routeHandler = (app.get as any).mock.calls[0][1]
 
-		// Get the route handler
-		const routeHandler = (app.get as jest.Mock).mock.calls[0][1]
-
-		// Create mock request and reply
 		const mockRequest = createMockRequest()
 		const mockReply = {
-			status: jest.fn().mockReturnThis(),
-			send: jest.fn().mockImplementation((data: HealthCheckResponse) => {
-				// Verify the response structure
+			status: mock(() => mockReply),
+			send: mock().mockImplementation((data: HealthCheckResponse) => {
 				expect(data.status).toBe('unhealthy')
 				expect(data.checks.server).toBe(true)
 				expect(data.checks.database).toBe(false)
@@ -216,32 +196,27 @@ describeOrSkip('health route should', () => {
 			})
 		}
 
-		// Call the route handler
 		await routeHandler(mockRequest, mockReply)
 
-		// Verify reply.status was called with 503
 		expect(mockReply.status).toHaveBeenCalledWith(503)
 	})
 
 	test('return 200 and redis as null when Redis is not registered', async () => {
-		// Mock MongoDB ping success
-		;(mockMongoClient.db().command as jest.Mock).mockResolvedValue({ ok: 1 })
+		mockMongoDb.mockReturnValue({
+			command: mockMongoCommand
+		})
+		mockMongoCommand.mockResolvedValue({ ok: 1 })
 
-		// Redis not registered
 		app.redis = undefined
-
-		// Register health route
 		await health(app)
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const routeHandler = (app.get as any).mock.calls[0][1]
 
-		// Get the route handler
-		const routeHandler = (app.get as jest.Mock).mock.calls[0][1]
 
-		// Create mock request and reply
 		const mockRequest = createMockRequest()
 		const mockReply = {
-			status: jest.fn().mockReturnThis(),
-			send: jest.fn().mockImplementation((data: HealthCheckResponse) => {
-				// Verify the response structure
+			status: mock(() => mockReply),
+			send: mock().mockImplementation((data: HealthCheckResponse) => {
 				expect(data.status).toBe('healthy')
 				expect(data.checks.server).toBe(true)
 				expect(data.checks.database).toBe(true)
@@ -251,41 +226,36 @@ describeOrSkip('health route should', () => {
 			})
 		}
 
-		// Call the route handler
 		await routeHandler(mockRequest, mockReply)
 
-		// Verify reply.status was called with 200
 		expect(mockReply.status).toHaveBeenCalledWith(200)
 	})
 
 	test('verify response structure has all required fields', async () => {
-		// Mock all services healthy
-		;(mockMongoClient.db().command as jest.Mock).mockResolvedValue({ ok: 1 })
+		mockMongoDb.mockReturnValue({
+			command: mockMongoCommand
+		})
+		mockMongoCommand.mockResolvedValue({ ok: 1 })
 		app.redis = {
-			ping: jest.fn().mockResolvedValue('PONG')
+			ping: mock().mockResolvedValue('PONG')
 		}
 
-		// Register health route
 		await health(app)
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const routeHandler = (app.get as any).mock.calls[0][1]
 
-		// Get the route handler
-		const routeHandler = (app.get as jest.Mock).mock.calls[0][1]
-
-		// Create mock request and reply
 		const mockRequest = createMockRequest()
 		let capturedData: HealthCheckResponse | null = null
 		const mockReply = {
-			status: jest.fn().mockReturnThis(),
-			send: jest.fn().mockImplementation((data: HealthCheckResponse) => {
+			status: mock(() => mockReply),
+			send: mock().mockImplementation((data: HealthCheckResponse) => {
 				capturedData = data
 				return mockReply
 			})
 		}
 
-		// Call the route handler
 		await routeHandler(mockRequest, mockReply)
 
-		// Verify all required fields exist
 		expect(capturedData).toHaveProperty('status')
 		expect(capturedData).toHaveProperty('timestamp')
 		expect(capturedData).toHaveProperty('checks')
@@ -293,7 +263,6 @@ describeOrSkip('health route should', () => {
 		expect(capturedData!.checks).toHaveProperty('database')
 		expect(capturedData!.checks).toHaveProperty('redis')
 
-		// Verify types
 		expect(typeof capturedData!.status).toBe('string')
 		expect(typeof capturedData!.timestamp).toBe('string')
 		expect(typeof capturedData!.checks.server).toBe('boolean')
@@ -304,36 +273,37 @@ describeOrSkip('health route should', () => {
 	})
 
 	test('verify timestamp is valid ISO format', async () => {
-		// Mock all services healthy
-		;(mockMongoClient.db().command as jest.Mock).mockResolvedValue({ ok: 1 })
+		mockMongoDb.mockReturnValue({
+			command: mockMongoCommand
+		})
+		mockMongoCommand.mockResolvedValue({ ok: 1 })
 		app.redis = {
-			ping: jest.fn().mockResolvedValue('PONG')
+			ping: mock().mockResolvedValue('PONG')
 		}
 
-		// Register health route
 		await health(app)
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const routeHandler = (app.get as any).mock.calls[0][1]
 
-		// Get the route handler
-		const routeHandler = (app.get as jest.Mock).mock.calls[0][1]
-
-		// Create mock request and reply
 		const mockRequest = createMockRequest()
 		let capturedData: HealthCheckResponse | null = null
 		const mockReply = {
-			status: jest.fn().mockReturnThis(),
-			send: jest.fn().mockImplementation((data: HealthCheckResponse) => {
+			status: mock(() => mockReply),
+			send: mock().mockImplementation((data: HealthCheckResponse) => {
 				capturedData = data
 				return mockReply
 			})
 		}
 
-		// Call the route handler
 		await routeHandler(mockRequest, mockReply)
 
-		// Verify timestamp is valid ISO 8601 format
 		const timestamp = new Date(capturedData!.timestamp)
 		expect(timestamp).toBeInstanceOf(Date)
 		expect(isNaN(timestamp.getTime())).toBe(false)
 		expect(capturedData!.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/)
 	})
+})
+
+afterAll(() => {
+	mock.restore()
 })

--- a/tests/config/routes/metrics.test.ts
+++ b/tests/config/routes/metrics.test.ts
@@ -1,6 +1,6 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { FastifyRequest } from 'fastify'
 import Fastify from 'fastify'
-import { mock } from 'jest-mock-extended'
 
 import {
 	DEFAULT_PERFORMANCE_CONFIG,
@@ -8,9 +8,6 @@ import {
 	setPerformanceConfig
 } from '#config/performance'
 import { isIpAllowed, parseEnvArray, registerMetricsRoute } from '#config/routes/metrics'
-
-const isBun = 'Bun' in globalThis
-const describeOrSkip = isBun ? describe.skip : describe
 
 const createTestConfig = (overrides: Partial<PerformanceConfig>): PerformanceConfig => ({
 	USE_PARALLEL_SCHEDULER: false,
@@ -26,7 +23,7 @@ const createTestConfig = (overrides: Partial<PerformanceConfig>): PerformanceCon
 	...overrides
 })
 
-describeOrSkip('Metrics Route - Authentication', () => {
+describe('Metrics Route - Authentication', () => {
 	let originalAuthToken: string | undefined
 	let originalAllowedIps: string | undefined
 
@@ -126,7 +123,6 @@ describeOrSkip('Metrics Route - Authentication', () => {
 		})
 
 		it('parseEnvArray returns undefined for whitespace-only commas', () => {
-			// Test the missing-entries branch: when all entries are whitespace/empty after split
 			const result = parseEnvArray(' , ,  ')
 			expect(result).toBeUndefined()
 		})
@@ -142,7 +138,6 @@ describeOrSkip('Metrics Route - Authentication', () => {
 		})
 
 		it('returns 200 when METRICS_ALLOWED_IPS is whitespace-only (triggers fallback)', async () => {
-			// When parseEnvArray returns undefined due to empty result, auth fallback should allow access
 			process.env.METRICS_ALLOWED_IPS = ' , ,  '
 			delete process.env.METRICS_AUTH_TOKEN
 			setPerformanceConfig(createTestConfig({ METRICS_ENABLED: true }))
@@ -156,13 +151,11 @@ describeOrSkip('Metrics Route - Authentication', () => {
 				url: '/metrics'
 			})
 
-			// Should return 200 because parseEnvArray returns undefined and no auth token is set
 			expect(response.statusCode).toBe(200)
 			await fastify.close()
 		})
 
 		it('returns 403 when METRICS_ALLOWED_IPS is whitespace-only but METRICS_AUTH_TOKEN is set', async () => {
-			// When parseEnvArray returns undefined but auth token is set, should check token
 			process.env.METRICS_ALLOWED_IPS = ' , ,  '
 			process.env.METRICS_AUTH_TOKEN = 'test-token'
 			setPerformanceConfig(createTestConfig({ METRICS_ENABLED: true }))
@@ -177,7 +170,6 @@ describeOrSkip('Metrics Route - Authentication', () => {
 				headers: { 'x-metrics-token': 'wrong-token' }
 			})
 
-			// Should return 403 because token doesn't match
 			expect(response.statusCode).toBe(403)
 			await fastify.close()
 		})
@@ -351,10 +343,10 @@ describe('isIpAllowed', () => {
 		ip: string | undefined,
 		forwardedFor: string | string[] | undefined
 	): FastifyRequest => {
-		const mockReq = mock<FastifyRequest>()
-		;(mockReq as unknown as { ip: string | undefined }).ip = ip
-		;(mockReq as unknown as { headers: Record<string, string | string[]> }).headers =
-			forwardedFor !== undefined ? { 'x-forwarded-for': forwardedFor } : {}
+		const mockReq = {
+			ip,
+			headers: forwardedFor !== undefined ? { 'x-forwarded-for': forwardedFor } : {}
+		} as unknown as FastifyRequest
 		return mockReq
 	}
 
@@ -518,10 +510,10 @@ describe('isIpAllowed', () => {
 
 			const invalidInputs = [
 				'invalid-cidr',
-				'192.168.1/24', // malformed CIDR
+				'192.168.1/24',
 				'not-a-valid-ip',
-				'999.999.999.999', // invalid IP
-				'string/cidr' // non-numeric CIDR
+				'999.999.999.999',
+				'string/cidr'
 			]
 
 			for (const invalidInput of invalidInputs) {

--- a/tests/config/routes/metrics.test.ts
+++ b/tests/config/routes/metrics.test.ts
@@ -123,6 +123,7 @@ describe('Metrics Route - Authentication', () => {
 		})
 
 		it('parseEnvArray returns undefined for whitespace-only commas', () => {
+		// Test the missing-entries branch: when all entries are whitespace/empty after split
 			const result = parseEnvArray(' , ,  ')
 			expect(result).toBeUndefined()
 		})
@@ -133,6 +134,7 @@ describe('Metrics Route - Authentication', () => {
 		})
 
 		it('parseEnvArray returns undefined for only commas', () => {
+		// When parseEnvArray returns undefined due to empty result, auth fallback should allow access
 			const result = parseEnvArray(',,,')
 			expect(result).toBeUndefined()
 		})
@@ -156,6 +158,7 @@ describe('Metrics Route - Authentication', () => {
 		})
 
 		it('returns 403 when METRICS_ALLOWED_IPS is whitespace-only but METRICS_AUTH_TOKEN is set', async () => {
+		// When parseEnvArray returns undefined but auth token is set, should check token
 			process.env.METRICS_ALLOWED_IPS = ' , ,  '
 			process.env.METRICS_AUTH_TOKEN = 'test-token'
 			setPerformanceConfig(createTestConfig({ METRICS_ENABLED: true }))
@@ -271,6 +274,7 @@ describe('Metrics Route - Authentication', () => {
 
 	describe('validateMetricsAuth fallback', () => {
 		it('returns 200 when neither env var is set', async () => {
+		// Should return 200 because parseEnvArray returns undefined and no auth token is set
 			delete process.env.METRICS_AUTH_TOKEN
 			delete process.env.METRICS_ALLOWED_IPS
 			setPerformanceConfig(createTestConfig({ METRICS_ENABLED: true }))

--- a/tests/database/papr/audible/PaprAudibleAuthorHelper.test.ts
+++ b/tests/database/papr/audible/PaprAudibleAuthorHelper.test.ts
@@ -1,14 +1,37 @@
-jest.mock('#config/models/Author')
-jest.mock('#helpers/utils/shared')
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
+
+import { createMockLogger } from '#tests/setup/mockLogger'
+
+const mockUpdateOne = mock()
+const mockFindOne = mock()
+const mockInsertOne = mock()
+const mockDeleteOne = mock()
+const mockFind = mock()
+
+mock.module('#config/models/Author', () => ({
+	default: {
+		updateOne: mockUpdateOne,
+		findOne: mockFindOne,
+		insertOne: mockInsertOne,
+		deleteOne: mockDeleteOne,
+		find: mockFind
+	}
+}))
+
+const mockIsEqualData = mock()
+
+mock.module('#helpers/utils/shared', () => ({
+	default: class SharedHelper {
+		isEqualData = mockIsEqualData
+	}
+}))
 
 import type { FastifyBaseLogger } from 'fastify'
-import { mock } from 'jest-mock-extended'
 
-import AuthorModel, { AuthorDocument } from '#config/models/Author'
+import type { AuthorDocument } from '#config/models/Author'
 import { ApiQueryString } from '#config/types'
 import * as checkers from '#config/typing/checkers'
 import PaprAudibleAuthorHelper from '#helpers/database/papr/audible/PaprAudibleAuthorHelper'
-import SharedHelper from '#helpers/utils/shared'
 import {
 	authorWithoutGenresWithoutProjection,
 	authorWithoutProjection,
@@ -16,11 +39,18 @@ import {
 	parsedAuthorWithoutGenres
 } from '#tests/datasets/helpers/authors'
 
+
 let asin: string
 let helper: PaprAudibleAuthorHelper
 let options: ApiQueryString
 
 beforeEach(() => {
+	mockUpdateOne.mockReset()
+	mockFindOne.mockReset()
+	mockInsertOne.mockReset()
+	mockDeleteOne.mockReset()
+	mockFind.mockReset()
+	mockIsEqualData.mockReset()
 	asin = parsedAuthor.asin
 	options = {
 		region: 'us',
@@ -28,16 +58,16 @@ beforeEach(() => {
 	}
 	helper = new PaprAudibleAuthorHelper(asin, options)
 
-	jest.spyOn(AuthorModel, 'updateOne').mockResolvedValue({
+	mockUpdateOne.mockResolvedValue({
 		acknowledged: true,
 		matchedCount: 1,
 		modifiedCount: 1,
 		upsertedCount: 0,
 		upsertedId: authorWithoutProjection._id
 	})
-	jest.spyOn(AuthorModel, 'findOne').mockResolvedValue(authorWithoutProjection)
-	jest.spyOn(AuthorModel, 'insertOne').mockResolvedValue(authorWithoutProjection)
-	jest.spyOn(checkers, 'isAuthorDocument').mockReturnValue(true)
+	mockFindOne.mockResolvedValue(authorWithoutProjection)
+	mockInsertOne.mockResolvedValue(authorWithoutProjection)
+	spyOn(checkers, 'isAuthorDocument').mockReturnValue(true)
 })
 
 describe('PaprAudibleAuthorHelper should', () => {
@@ -47,21 +77,21 @@ describe('PaprAudibleAuthorHelper should', () => {
 	})
 	test('create', async () => {
 		const obj = { data: parsedAuthor, modified: true }
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValue(parsedAuthor as unknown as AuthorDocument)
+		mockFindOne.mockResolvedValueOnce(parsedAuthor as unknown as AuthorDocument)
 		helper.setData(parsedAuthor)
 
 		await expect(helper.create()).resolves.toEqual(obj)
-		expect(AuthorModel.insertOne).toHaveBeenCalledWith(parsedAuthor)
-		expect(AuthorModel.findOne).toHaveBeenCalledWith({
+		expect(mockInsertOne).toHaveBeenCalledWith(parsedAuthor)
+		expect(mockFindOne).toHaveBeenCalledWith({
 			asin: asin,
 			$or: [{ region: { $exists: false } }, { region: options.region }]
 		})
 	})
 	test('delete', async () => {
 		const obj = { data: { acknowledged: true, deletedCount: 1 }, modified: true }
-		jest.spyOn(AuthorModel, 'deleteOne').mockResolvedValue(obj.data)
+		mockDeleteOne.mockResolvedValue(obj.data)
 		await expect(helper.delete()).resolves.toEqual(obj)
-		expect(AuthorModel.deleteOne).toHaveBeenCalledWith({
+		expect(mockDeleteOne).toHaveBeenCalledWith({
 			asin: asin,
 			$or: [{ region: { $exists: false } }, { region: options.region }]
 		})
@@ -69,43 +99,41 @@ describe('PaprAudibleAuthorHelper should', () => {
 	test('findByName', async () => {
 		helper = new PaprAudibleAuthorHelper('', { name: 'test', region: 'us' })
 		const obj = { data: [{ asin: asin, name: 'test' }], modified: false }
-		jest
-			.spyOn(AuthorModel, 'find')
-			.mockResolvedValue([{ asin: asin, name: 'test' }] as unknown as AuthorDocument[])
+		mockFind.mockResolvedValue([{ asin: asin, name: 'test' }] as unknown as AuthorDocument[])
 		await expect(helper.findByName()).resolves.toEqual(obj)
 	})
 	test('findOne', async () => {
 		const obj = { data: authorWithoutProjection, modified: false }
 		await expect(helper.findOne()).resolves.toEqual(obj)
-		expect(AuthorModel.findOne).toHaveBeenCalledWith({
+		expect(mockFindOne).toHaveBeenCalledWith({
 			asin: asin,
 			$or: [{ region: { $exists: false } }, { region: options.region }]
 		})
 	})
 	test('findOne returns null if it is not an AuthorDocument', async () => {
 		const obj = { data: null, modified: false }
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValue(null)
-		jest.spyOn(checkers, 'isAuthorDocument').mockReturnValue(false)
+		mockFindOne.mockResolvedValueOnce(null)
+		spyOn(checkers, 'isAuthorDocument').mockReturnValueOnce(false)
 		await expect(helper.findOne()).resolves.toEqual(obj)
-		expect(AuthorModel.findOne).toHaveBeenCalledWith({
+		expect(mockFindOne).toHaveBeenCalledWith({
 			asin: asin,
 			$or: [{ region: { $exists: false } }, { region: options.region }]
 		})
 	})
 	test('findOneWithProjection', async () => {
 		const obj = { data: parsedAuthor, modified: false }
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValue(parsedAuthor as unknown as AuthorDocument)
+		mockFindOne.mockResolvedValue(parsedAuthor as unknown as AuthorDocument)
 		await expect(helper.findOneWithProjection()).resolves.toEqual(obj)
-		expect(AuthorModel.findOne).toHaveBeenCalledWith({
+		expect(mockFindOne).toHaveBeenCalledWith({
 			asin: asin,
 			$or: [{ region: { $exists: false } }, { region: options.region }]
 		})
 	})
 	test('findOneWithProjection returns null if it is not an AuthorProfile', async () => {
 		const obj = { data: null, modified: false }
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValue(null)
+		mockFindOne.mockResolvedValueOnce(null)
 		await expect(helper.findOneWithProjection()).resolves.toEqual(obj)
-		expect(AuthorModel.findOne).toHaveBeenCalledWith({
+		expect(mockFindOne).toHaveBeenCalledWith({
 			asin: asin,
 			$or: [{ region: { $exists: false } }, { region: options.region }]
 		})
@@ -117,72 +145,65 @@ describe('PaprAudibleAuthorHelper should', () => {
 	})
 	test('createOrUpdate finds one to update', async () => {
 		const obj = { data: parsedAuthor, modified: true }
-		jest
-			.spyOn(AuthorModel, 'findOne')
+		mockFindOne
 			.mockResolvedValueOnce(parsedAuthor as unknown as AuthorDocument)
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValueOnce(authorWithoutProjection)
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValue(parsedAuthor as unknown as AuthorDocument)
+			.mockResolvedValueOnce(authorWithoutProjection)
+			.mockResolvedValue(parsedAuthor as unknown as AuthorDocument)
 		helper.setData(parsedAuthor)
 		await expect(helper.createOrUpdate()).resolves.toEqual(obj)
 	})
 	test('createOrUpdate finds identical update data', async () => {
 		const obj = { data: parsedAuthor, modified: false }
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValue(parsedAuthor as unknown as AuthorDocument)
-		jest.spyOn(SharedHelper.prototype, 'isEqualData').mockReturnValue(true)
+		mockFindOne.mockResolvedValue(parsedAuthor as unknown as AuthorDocument)
+		mockIsEqualData.mockReturnValue(true)
 		helper.setData(parsedAuthor)
 		await expect(helper.createOrUpdate()).resolves.toEqual(obj)
 	})
 	test('createOrUpdate needs to create', async () => {
 		const obj = { data: parsedAuthor, modified: true }
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValueOnce(null)
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValue(authorWithoutProjection)
+		mockFindOne.mockResolvedValueOnce(null)
+		mockFindOne.mockResolvedValue(authorWithoutProjection)
 		helper.setData(parsedAuthor)
 		await expect(helper.createOrUpdate()).resolves.toEqual(obj)
 	})
 	test('createOrUpdate difference in genres', async () => {
 		const obj = { data: parsedAuthor, modified: true }
-		jest.spyOn(SharedHelper.prototype, 'isEqualData').mockReturnValue(false)
-		jest
-			.spyOn(AuthorModel, 'findOne')
+		mockIsEqualData.mockReturnValue(false)
+		mockFindOne
 			.mockResolvedValueOnce(parsedAuthor as unknown as AuthorDocument)
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValueOnce(authorWithoutProjection)
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValue(parsedAuthor as unknown as AuthorDocument)
+			.mockResolvedValueOnce(authorWithoutProjection)
+			.mockResolvedValue(parsedAuthor as unknown as AuthorDocument)
 		helper.setData(parsedAuthor)
 		await expect(helper.createOrUpdate()).resolves.toEqual(obj)
 	})
 	test('createOrUpdate genres on old, but not on new', async () => {
 		const obj = { data: parsedAuthor, modified: false }
-		jest.spyOn(SharedHelper.prototype, 'isEqualData').mockReturnValue(false)
-		jest
-			.spyOn(AuthorModel, 'findOne')
+		mockIsEqualData.mockReturnValue(false)
+		mockFindOne
 			.mockResolvedValueOnce(parsedAuthor as unknown as AuthorDocument)
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValueOnce(authorWithoutProjection)
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValue(parsedAuthor as unknown as AuthorDocument)
+			.mockResolvedValueOnce(authorWithoutProjection)
+			.mockResolvedValue(parsedAuthor as unknown as AuthorDocument)
 		helper.setData(parsedAuthorWithoutGenres)
 		await expect(helper.createOrUpdate()).resolves.toEqual(obj)
 	})
 	test('createOrUpdate no genres on new or old', async () => {
 		const obj = { data: parsedAuthorWithoutGenres, modified: false }
-		jest.spyOn(SharedHelper.prototype, 'isEqualData').mockReturnValue(false)
-		jest
-			.spyOn(AuthorModel, 'findOne')
+		mockIsEqualData.mockReturnValue(false)
+		mockFindOne
 			.mockResolvedValueOnce(parsedAuthorWithoutGenres as unknown as AuthorDocument)
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValueOnce(authorWithoutGenresWithoutProjection)
-		jest
-			.spyOn(AuthorModel, 'findOne')
+			.mockResolvedValueOnce(authorWithoutGenresWithoutProjection)
 			.mockResolvedValue(parsedAuthorWithoutGenres as unknown as AuthorDocument)
 		helper.setData(parsedAuthorWithoutGenres)
 		await expect(helper.createOrUpdate()).resolves.toEqual(obj)
 	})
 	test('createOrUpdate logs info when updating', async () => {
-		const mockLogger = mock<FastifyBaseLogger>()
-		const helperWithLogger = new PaprAudibleAuthorHelper(asin, options, mockLogger)
-		jest.spyOn(SharedHelper.prototype, 'isEqualData').mockReturnValue(false)
-		jest
-			.spyOn(AuthorModel, 'findOne')
+		const mockLogger = createMockLogger()
+		const helperWithLogger = new PaprAudibleAuthorHelper(asin, options, mockLogger as unknown as FastifyBaseLogger)
+		mockIsEqualData.mockReturnValue(false)
+		mockFindOne
 			.mockResolvedValueOnce(parsedAuthor as unknown as AuthorDocument)
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValueOnce(authorWithoutProjection)
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValue(parsedAuthor as unknown as AuthorDocument)
+			.mockResolvedValueOnce(authorWithoutProjection)
+			.mockResolvedValue(parsedAuthor as unknown as AuthorDocument)
 		helperWithLogger.setData(parsedAuthor)
 		await helperWithLogger.createOrUpdate()
 		expect(mockLogger.info).toHaveBeenCalledWith(`Updating author ASIN ${asin}`)
@@ -190,10 +211,10 @@ describe('PaprAudibleAuthorHelper should', () => {
 	test('update', async () => {
 		const obj = { data: parsedAuthor, modified: true }
 		helper.setData(parsedAuthor)
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValueOnce(authorWithoutProjection)
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValue(parsedAuthor as unknown as AuthorDocument)
+		mockFindOne.mockResolvedValueOnce(authorWithoutProjection)
+		mockFindOne.mockResolvedValue(parsedAuthor as unknown as AuthorDocument)
 		await expect(helper.update()).resolves.toEqual(obj)
-		expect(AuthorModel.updateOne).toHaveBeenCalledWith(
+		expect(mockUpdateOne).toHaveBeenCalledWith(
 			{ asin: asin, $or: [{ region: { $exists: false } }, { region: options.region }] },
 			{
 				$set: { ...parsedAuthor, createdAt: authorWithoutProjection._id.getTimestamp() },
@@ -205,30 +226,30 @@ describe('PaprAudibleAuthorHelper should', () => {
 
 describe('PaprAudibleAuthorHelper should catch error when', () => {
 	test('create', async () => {
-		jest.spyOn(AuthorModel, 'insertOne').mockRejectedValue(new Error('error'))
+		mockInsertOne.mockRejectedValue(new Error('error'))
 		helper.setData(parsedAuthor)
 		await expect(helper.create()).rejects.toThrow(
 			`An error occurred while creating author ${asin} in the DB`
 		)
 	})
 	test('create logs error on failure', async () => {
-		const mockLogger = mock<FastifyBaseLogger>()
-		const helperWithLogger = new PaprAudibleAuthorHelper(asin, options, mockLogger)
-		jest.spyOn(AuthorModel, 'insertOne').mockRejectedValue(new Error('DB error'))
+		const mockLogger = createMockLogger()
+		const helperWithLogger = new PaprAudibleAuthorHelper(asin, options, mockLogger as unknown as FastifyBaseLogger)
+		mockInsertOne.mockRejectedValue(new Error('DB error'))
 		helperWithLogger.setData(parsedAuthor)
 		await expect(helperWithLogger.create()).rejects.toThrow()
 		expect(mockLogger.error).toHaveBeenCalledWith('DB error')
 	})
 	test('delete', async () => {
-		jest.spyOn(AuthorModel, 'deleteOne').mockRejectedValue(new Error('error'))
+		mockDeleteOne.mockRejectedValue(new Error('error'))
 		await expect(helper.delete()).rejects.toThrow(
 			`An error occurred while deleting author ${asin} in the DB`
 		)
 	})
 	test('delete logs error on failure', async () => {
-		const mockLogger = mock<FastifyBaseLogger>()
-		const helperWithLogger = new PaprAudibleAuthorHelper(asin, options, mockLogger)
-		jest.spyOn(AuthorModel, 'deleteOne').mockRejectedValue(new Error('DB error'))
+		const mockLogger = createMockLogger()
+		const helperWithLogger = new PaprAudibleAuthorHelper(asin, options, mockLogger as unknown as FastifyBaseLogger)
+		mockDeleteOne.mockRejectedValue(new Error('DB error'))
 		await expect(helperWithLogger.delete()).rejects.toThrow()
 		expect(mockLogger.error).toHaveBeenCalledWith('DB error')
 	})
@@ -236,26 +257,30 @@ describe('PaprAudibleAuthorHelper should catch error when', () => {
 		await expect(helper.findByName()).rejects.toThrow('Invalid search parameters')
 	})
 	test('update did not find existing', async () => {
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValueOnce(null)
+		mockFindOne.mockResolvedValueOnce(null)
 		helper.setData(parsedAuthor)
 		await expect(helper.update()).rejects.toThrow(
 			`An error occurred while updating author ${asin} in the DB`
 		)
 	})
 	test('update', async () => {
-		jest.spyOn(AuthorModel, 'updateOne').mockRejectedValue(new Error('error'))
+		mockUpdateOne.mockRejectedValue(new Error('error'))
 		helper.setData(parsedAuthor)
 		await expect(helper.update()).rejects.toThrow(
 			`An error occurred while updating author ${asin} in the DB`
 		)
 	})
 	test('update logs error on failure', async () => {
-		const mockLogger = mock<FastifyBaseLogger>()
-		const helperWithLogger = new PaprAudibleAuthorHelper(asin, options, mockLogger)
-		jest.spyOn(AuthorModel, 'findOne').mockResolvedValueOnce(authorWithoutProjection)
-		jest.spyOn(AuthorModel, 'updateOne').mockRejectedValue(new Error('DB error'))
+		const mockLogger = createMockLogger()
+		const helperWithLogger = new PaprAudibleAuthorHelper(asin, options, mockLogger as unknown as FastifyBaseLogger)
+		mockFindOne.mockResolvedValueOnce(authorWithoutProjection)
+		mockUpdateOne.mockRejectedValue(new Error('DB error'))
 		helperWithLogger.setData(parsedAuthor)
 		await expect(helperWithLogger.update()).rejects.toThrow()
 		expect(mockLogger.error).toHaveBeenCalledWith('DB error')
 	})
+})
+
+afterAll(() => {
+	mock.restore()
 })

--- a/tests/database/papr/audible/PaprAudibleBookHelper.test.ts
+++ b/tests/database/papr/audible/PaprAudibleBookHelper.test.ts
@@ -1,13 +1,37 @@
-jest.mock('#config/models/Book')
-jest.mock('#helpers/utils/shared')
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
+
+import { createMockLogger } from '#tests/setup/mockLogger'
+
+const mockUpdateOne = mock()
+const mockFindOne = mock()
+const mockInsertOne = mock()
+const mockDeleteOne = mock()
+const mockFind = mock()
+
+mock.module('#config/models/Book', () => ({
+	default: {
+		updateOne: mockUpdateOne,
+		findOne: mockFindOne,
+		insertOne: mockInsertOne,
+		deleteOne: mockDeleteOne,
+		find: mockFind
+	}
+}))
+
+const mockIsEqualData = mock()
+
+mock.module('#helpers/utils/shared', () => ({
+	default: class SharedHelper {
+		isEqualData = mockIsEqualData
+	}
+}))
 
 import type { FastifyBaseLogger } from 'fastify'
 
-import BookModel, { BookDocument } from '#config/models/Book'
+import type { BookDocument } from '#config/models/Book'
 import { ApiQueryString } from '#config/types'
 import * as checkers from '#config/typing/checkers'
 import PaprAudibleBookHelper from '#helpers/database/papr/audible/PaprAudibleBookHelper'
-import SharedHelper from '#helpers/utils/shared'
 import {
 	bookWithoutGenresWithoutProjection,
 	bookWithoutProjection,
@@ -15,11 +39,18 @@ import {
 	parsedBookWithoutGenres
 } from '#tests/datasets/helpers/books'
 
+
 let asin: string
 let helper: PaprAudibleBookHelper
 let options: ApiQueryString
 
 beforeEach(() => {
+	mockUpdateOne.mockReset()
+	mockFindOne.mockReset()
+	mockInsertOne.mockReset()
+	mockDeleteOne.mockReset()
+	mockFind.mockReset()
+	mockIsEqualData.mockReset()
 	asin = parsedBook.asin
 	options = {
 		region: 'us',
@@ -28,16 +59,16 @@ beforeEach(() => {
 	}
 	helper = new PaprAudibleBookHelper(asin, options)
 
-	jest.spyOn(BookModel, 'updateOne').mockResolvedValue({
+	mockUpdateOne.mockResolvedValue({
 		acknowledged: true,
 		matchedCount: 1,
 		modifiedCount: 1,
 		upsertedCount: 0,
 		upsertedId: bookWithoutProjection._id
 	})
-	jest.spyOn(BookModel, 'findOne').mockResolvedValue(bookWithoutProjection)
-	jest.spyOn(BookModel, 'insertOne').mockResolvedValue(bookWithoutProjection)
-	jest.spyOn(checkers, 'isBookDocument').mockReturnValue(true)
+	mockFindOne.mockResolvedValue(bookWithoutProjection)
+	mockInsertOne.mockResolvedValue(bookWithoutProjection)
+	spyOn(checkers, 'isBookDocument').mockReturnValue(true)
 })
 
 describe('PaprAudibleBookHelper should', () => {
@@ -47,21 +78,21 @@ describe('PaprAudibleBookHelper should', () => {
 	})
 	test('create', async () => {
 		const obj = { data: parsedBook, modified: true }
-		jest.spyOn(BookModel, 'findOne').mockResolvedValue(parsedBook as unknown as BookDocument)
+		mockFindOne.mockResolvedValueOnce(parsedBook as unknown as BookDocument)
 		helper.setData(parsedBook)
 
 		await expect(helper.create()).resolves.toEqual(obj)
-		expect(BookModel.insertOne).toHaveBeenCalledWith(parsedBook)
-		expect(BookModel.findOne).toHaveBeenCalledWith({
+		expect(mockInsertOne).toHaveBeenCalledWith(parsedBook)
+		expect(mockFindOne).toHaveBeenCalledWith({
 			asin: asin,
 			$or: [{ region: { $exists: false } }, { region: options.region }]
 		})
 	})
 	test('delete', async () => {
 		const obj = { data: { acknowledged: true, deletedCount: 1 }, modified: true }
-		jest.spyOn(BookModel, 'deleteOne').mockResolvedValue(obj.data)
+		mockDeleteOne.mockResolvedValue(obj.data)
 		await expect(helper.delete()).resolves.toEqual(obj)
-		expect(BookModel.deleteOne).toHaveBeenCalledWith({
+		expect(mockDeleteOne).toHaveBeenCalledWith({
 			asin: asin,
 			$or: [{ region: { $exists: false } }, { region: options.region }]
 		})
@@ -69,35 +100,35 @@ describe('PaprAudibleBookHelper should', () => {
 	test('findOne', async () => {
 		const obj = { data: bookWithoutProjection, modified: false }
 		await expect(helper.findOne()).resolves.toEqual(obj)
-		expect(BookModel.findOne).toHaveBeenCalledWith({
+		expect(mockFindOne).toHaveBeenCalledWith({
 			asin: asin,
 			$or: [{ region: { $exists: false } }, { region: options.region }]
 		})
 	})
 	test('findOne returns null if it is not a BookDocument', async () => {
 		const obj = { data: null, modified: false }
-		jest.spyOn(BookModel, 'findOne').mockResolvedValueOnce(null)
-		jest.spyOn(checkers, 'isBookDocument').mockReturnValueOnce(false)
+		mockFindOne.mockResolvedValueOnce(null)
+		spyOn(checkers, 'isBookDocument').mockReturnValueOnce(false)
 		await expect(helper.findOne()).resolves.toEqual(obj)
-		expect(BookModel.findOne).toHaveBeenCalledWith({
+		expect(mockFindOne).toHaveBeenCalledWith({
 			asin: asin,
 			$or: [{ region: { $exists: false } }, { region: options.region }]
 		})
 	})
 	test('findOneWithProjection', async () => {
 		const obj = { data: parsedBook, modified: false }
-		jest.spyOn(BookModel, 'findOne').mockResolvedValue(parsedBook as unknown as BookDocument)
+		mockFindOne.mockResolvedValue(parsedBook as unknown as BookDocument)
 		await expect(helper.findOneWithProjection()).resolves.toEqual(obj)
-		expect(BookModel.findOne).toHaveBeenCalledWith({
+		expect(mockFindOne).toHaveBeenCalledWith({
 			asin: asin,
 			$or: [{ region: { $exists: false } }, { region: options.region }]
 		})
 	})
 	test('findOneWithProjection returns null if it is not a Book', async () => {
 		const obj = { data: null, modified: false }
-		jest.spyOn(BookModel, 'findOne').mockResolvedValueOnce(null)
+		mockFindOne.mockResolvedValueOnce(null)
 		await expect(helper.findOneWithProjection()).resolves.toEqual(obj)
-		expect(BookModel.findOne).toHaveBeenCalledWith({
+		expect(mockFindOne).toHaveBeenCalledWith({
 			asin: asin,
 			$or: [{ region: { $exists: false } }, { region: options.region }]
 		})
@@ -109,53 +140,53 @@ describe('PaprAudibleBookHelper should', () => {
 	})
 	test('createOrUpdate finds one to update', async () => {
 		const obj = { data: parsedBook, modified: true }
-		jest.spyOn(BookModel, 'findOne').mockResolvedValueOnce(parsedBook as unknown as BookDocument)
-		jest.spyOn(BookModel, 'findOne').mockResolvedValueOnce(bookWithoutProjection)
-		jest.spyOn(BookModel, 'findOne').mockResolvedValue(parsedBook as unknown as BookDocument)
+		mockFindOne
+			.mockResolvedValueOnce(parsedBook as unknown as BookDocument)
+			.mockResolvedValueOnce(bookWithoutProjection)
+			.mockResolvedValue(parsedBook as unknown as BookDocument)
 		helper.setData(parsedBook)
 		await expect(helper.createOrUpdate()).resolves.toEqual(obj)
 	})
 	test('createOrUpdate finds identical update data', async () => {
 		const obj = { data: parsedBook, modified: false }
-		jest.spyOn(BookModel, 'findOne').mockResolvedValue(parsedBook as unknown as BookDocument)
-		jest.spyOn(SharedHelper.prototype, 'isEqualData').mockReturnValue(true)
+		mockFindOne.mockResolvedValue(parsedBook as unknown as BookDocument)
+		mockIsEqualData.mockReturnValue(true)
 		helper.setData(parsedBook)
 		await expect(helper.createOrUpdate()).resolves.toEqual(obj)
 	})
 	test('createOrUpdate needs to create', async () => {
 		const obj = { data: parsedBook, modified: true }
-		jest.spyOn(BookModel, 'findOne').mockResolvedValueOnce(null)
-		jest.spyOn(BookModel, 'findOne').mockResolvedValue(bookWithoutProjection)
+		mockFindOne.mockResolvedValueOnce(null)
+		mockFindOne.mockResolvedValue(bookWithoutProjection)
 		helper.setData(parsedBook)
 		await expect(helper.createOrUpdate()).resolves.toEqual(obj)
 	})
 	test('createOrUpdate difference in genres', async () => {
 		const obj = { data: parsedBook, modified: true }
-		jest.spyOn(SharedHelper.prototype, 'isEqualData').mockReturnValue(false)
-		jest.spyOn(BookModel, 'findOne').mockResolvedValueOnce(parsedBook as unknown as BookDocument)
-		jest.spyOn(BookModel, 'findOne').mockResolvedValueOnce(bookWithoutProjection)
-		jest.spyOn(BookModel, 'findOne').mockResolvedValue(parsedBook as unknown as BookDocument)
+		mockIsEqualData.mockReturnValue(false)
+		mockFindOne
+			.mockResolvedValueOnce(parsedBook as unknown as BookDocument)
+			.mockResolvedValueOnce(bookWithoutProjection)
+			.mockResolvedValue(parsedBook as unknown as BookDocument)
 		helper.setData(parsedBook)
 		await expect(helper.createOrUpdate()).resolves.toEqual(obj)
 	})
 	test('createOrUpdate genres on old, but not on new', async () => {
 		const obj = { data: parsedBook, modified: false }
-		jest.spyOn(SharedHelper.prototype, 'isEqualData').mockReturnValue(false)
-		jest.spyOn(BookModel, 'findOne').mockResolvedValueOnce(parsedBook as unknown as BookDocument)
-		jest.spyOn(BookModel, 'findOne').mockResolvedValueOnce(bookWithoutProjection)
-		jest.spyOn(BookModel, 'findOne').mockResolvedValue(parsedBook as unknown as BookDocument)
+		mockIsEqualData.mockReturnValue(false)
+		mockFindOne
+			.mockResolvedValueOnce(parsedBook as unknown as BookDocument)
+			.mockResolvedValueOnce(bookWithoutProjection)
+			.mockResolvedValue(parsedBook as unknown as BookDocument)
 		helper.setData(parsedBookWithoutGenres)
 		await expect(helper.createOrUpdate()).resolves.toEqual(obj)
 	})
 	test('createOrUpdate no genres on new or old', async () => {
 		const obj = { data: parsedBookWithoutGenres, modified: false }
-		jest.spyOn(SharedHelper.prototype, 'isEqualData').mockReturnValue(false)
-		jest
-			.spyOn(BookModel, 'findOne')
+		mockIsEqualData.mockReturnValue(false)
+		mockFindOne
 			.mockResolvedValueOnce(parsedBookWithoutGenres as unknown as BookDocument)
-		jest.spyOn(BookModel, 'findOne').mockResolvedValueOnce(bookWithoutGenresWithoutProjection)
-		jest
-			.spyOn(BookModel, 'findOne')
+			.mockResolvedValueOnce(bookWithoutGenresWithoutProjection)
 			.mockResolvedValue(parsedBookWithoutGenres as unknown as BookDocument)
 		helper.setData(parsedBookWithoutGenres)
 		await expect(helper.createOrUpdate()).resolves.toEqual(obj)
@@ -163,13 +194,13 @@ describe('PaprAudibleBookHelper should', () => {
 	test('update', async () => {
 		const obj = { data: parsedBook, modified: true }
 		helper.setData(parsedBook)
-		jest.spyOn(BookModel, 'findOne').mockResolvedValueOnce(bookWithoutProjection)
-		jest.spyOn(BookModel, 'findOne').mockResolvedValue(parsedBook as unknown as BookDocument)
+		mockFindOne.mockResolvedValueOnce(bookWithoutProjection)
+		mockFindOne.mockResolvedValue(parsedBook as unknown as BookDocument)
 		await expect(helper.update()).resolves.toEqual(obj)
-		expect(BookModel.updateOne).toHaveBeenCalledWith(
+		expect(mockUpdateOne).toHaveBeenCalledWith(
 			{ asin: asin, $or: [{ region: { $exists: false } }, { region: options.region }] },
 			{
-				$set: { ...parsedBook, createdAt: bookWithoutProjection?._id.getTimestamp() },
+				$set: { ...parsedBook, createdAt: bookWithoutProjection._id.getTimestamp() },
 				$currentDate: { updatedAt: true }
 			}
 		)
@@ -178,27 +209,27 @@ describe('PaprAudibleBookHelper should', () => {
 
 describe('PaprAudibleBookHelper should catch error when', () => {
 	test('create', async () => {
-		jest.spyOn(BookModel, 'insertOne').mockRejectedValue(new Error('error'))
+		mockInsertOne.mockRejectedValue(new Error('error'))
 		helper.setData(parsedBook)
 		await expect(helper.create()).rejects.toThrow(
 			`An error occurred while creating book ${asin} in the DB`
 		)
 	})
 	test('delete', async () => {
-		jest.spyOn(BookModel, 'deleteOne').mockRejectedValue(new Error('error'))
+		mockDeleteOne.mockRejectedValue(new Error('error'))
 		await expect(helper.delete()).rejects.toThrow(
 			`An error occurred while deleting book ${asin} in the DB`
 		)
 	})
 	test('update did not find existing', async () => {
-		jest.spyOn(BookModel, 'findOne').mockResolvedValueOnce(null)
+		mockFindOne.mockResolvedValueOnce(null)
 		helper.setData(parsedBook)
 		await expect(helper.update()).rejects.toThrow(
 			`An error occurred while updating book ${asin} in the DB`
 		)
 	})
 	test('update', async () => {
-		jest.spyOn(BookModel, 'updateOne').mockRejectedValue(new Error('error'))
+		mockUpdateOne.mockRejectedValue(new Error('error'))
 		helper.setData(parsedBook)
 		await expect(helper.update()).rejects.toThrow(
 			`An error occurred while updating book ${asin} in the DB`
@@ -208,14 +239,14 @@ describe('PaprAudibleBookHelper should catch error when', () => {
 
 describe('PaprAudibleBookHelper should log error when', () => {
 	test('create logs error on BookModel.insertOne failure', async () => {
-		const mockLogger = { error: jest.fn(), info: jest.fn() }
+		const mockLogger = createMockLogger()
 		const helperWithLogger = new PaprAudibleBookHelper(
 			asin,
 			options,
 			mockLogger as unknown as FastifyBaseLogger
 		)
 		helperWithLogger.setData(parsedBook)
-		jest.spyOn(BookModel, 'insertOne').mockRejectedValue(new Error('DB error'))
+		mockInsertOne.mockRejectedValue(new Error('DB error'))
 		await expect(helperWithLogger.create()).rejects.toThrow(
 			`An error occurred while creating book ${asin} in the DB`
 		)
@@ -223,13 +254,13 @@ describe('PaprAudibleBookHelper should log error when', () => {
 	})
 
 	test('delete logs error on BookModel.deleteOne failure', async () => {
-		const mockLogger = { error: jest.fn(), info: jest.fn() }
+		const mockLogger = createMockLogger()
 		const helperWithLogger = new PaprAudibleBookHelper(
 			asin,
 			options,
 			mockLogger as unknown as FastifyBaseLogger
 		)
-		jest.spyOn(BookModel, 'deleteOne').mockRejectedValue(new Error('DB error'))
+		mockDeleteOne.mockRejectedValue(new Error('DB error'))
 		await expect(helperWithLogger.delete()).rejects.toThrow(
 			`An error occurred while deleting book ${asin} in the DB`
 		)
@@ -237,14 +268,14 @@ describe('PaprAudibleBookHelper should log error when', () => {
 	})
 
 	test('update logs error when BookModel.findOne returns null (not found)', async () => {
-		const mockLogger = { error: jest.fn(), info: jest.fn() }
+		const mockLogger = createMockLogger()
 		const helperWithLogger = new PaprAudibleBookHelper(
 			asin,
 			options,
 			mockLogger as unknown as FastifyBaseLogger
 		)
 		helperWithLogger.setData(parsedBook)
-		jest.spyOn(BookModel, 'findOne').mockResolvedValueOnce(null)
+		mockFindOne.mockResolvedValueOnce(null)
 		await expect(helperWithLogger.update()).rejects.toThrow(
 			`An error occurred while updating book ${asin} in the DB`
 		)
@@ -252,15 +283,15 @@ describe('PaprAudibleBookHelper should log error when', () => {
 	})
 
 	test('update logs error on BookModel.updateOne failure', async () => {
-		const mockLogger = { error: jest.fn(), info: jest.fn() }
+		const mockLogger = createMockLogger()
 		const helperWithLogger = new PaprAudibleBookHelper(
 			asin,
 			options,
 			mockLogger as unknown as FastifyBaseLogger
 		)
 		helperWithLogger.setData(parsedBook)
-		jest.spyOn(BookModel, 'findOne').mockResolvedValueOnce(bookWithoutProjection)
-		jest.spyOn(BookModel, 'updateOne').mockRejectedValue(new Error('DB error'))
+		mockFindOne.mockResolvedValueOnce(bookWithoutProjection)
+		mockUpdateOne.mockRejectedValue(new Error('DB error'))
 		await expect(helperWithLogger.update()).rejects.toThrow(
 			`An error occurred while updating book ${asin} in the DB`
 		)
@@ -270,30 +301,29 @@ describe('PaprAudibleBookHelper should log error when', () => {
 
 describe('PaprAudibleBookHelper should log info when', () => {
 	test('createOrUpdate logs NoticeUpdateAsin when update=1, data differs, and genres non-empty', async () => {
-		const mockLogger = { error: jest.fn(), info: jest.fn() }
+		const mockLogger = createMockLogger()
 		const helperWithLogger = new PaprAudibleBookHelper(
 			asin,
 			options,
 			mockLogger as unknown as FastifyBaseLogger
 		)
 
-		// Setup: data differs (isEqual returns false)
-		jest.spyOn(SharedHelper.prototype, 'isEqualData').mockReturnValue(false)
+		mockIsEqualData.mockReturnValue(false)
 
-		// Setup: findOneWithProjection returns book with genres (existing book)
-		jest.spyOn(BookModel, 'findOne').mockResolvedValueOnce(parsedBook as unknown as BookDocument)
-		// Setup: findOne for update returns bookWithoutProjection
-		jest.spyOn(BookModel, 'findOne').mockResolvedValueOnce(bookWithoutProjection)
-		// Setup: findOneWithProjection after update returns parsedBook
-		jest.spyOn(BookModel, 'findOne').mockResolvedValue(parsedBook as unknown as BookDocument)
+		mockFindOne
+			.mockResolvedValueOnce(parsedBook as unknown as BookDocument)
+			.mockResolvedValueOnce(bookWithoutProjection)
+			.mockResolvedValue(parsedBook as unknown as BookDocument)
 
-		// Set data with genres (non-empty)
 		helperWithLogger.setData(parsedBook)
 
 		const result = await helperWithLogger.createOrUpdate()
 
-		// Verify logger.info was called with NoticeUpdateAsin result
 		expect(mockLogger.info).toHaveBeenCalledWith(`Updating book ASIN ${asin}`)
 		expect(result.modified).toBe(true)
 	})
+})
+
+afterAll(() => {
+	mock.restore()
 })

--- a/tests/database/papr/audible/PaprAudibleChapterHelper.test.ts
+++ b/tests/database/papr/audible/PaprAudibleChapterHelper.test.ts
@@ -1,15 +1,39 @@
-jest.mock('#config/models/Chapter')
-jest.mock('#helpers/utils/shared')
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
 
-import { FastifyBaseLogger } from 'fastify'
-import { mock } from 'jest-mock-extended'
+import { createMockLogger } from '#tests/setup/mockLogger'
 
-import ChapterModel, { ChapterDocument } from '#config/models/Chapter'
+const mockUpdateOne = mock()
+const mockFindOne = mock()
+const mockInsertOne = mock()
+const mockDeleteOne = mock()
+const mockFind = mock()
+
+mock.module('#config/models/Chapter', () => ({
+	default: {
+		updateOne: mockUpdateOne,
+		findOne: mockFindOne,
+		insertOne: mockInsertOne,
+		deleteOne: mockDeleteOne,
+		find: mockFind
+	}
+}))
+
+const mockIsEqualData = mock()
+
+mock.module('#helpers/utils/shared', () => ({
+	default: class SharedHelper {
+		isEqualData = mockIsEqualData
+	}
+}))
+
+import type { FastifyBaseLogger } from 'fastify'
+
+import type { ChapterDocument } from '#config/models/Chapter'
 import { ApiQueryString } from '#config/types'
 import * as checkers from '#config/typing/checkers'
 import PaprAudibleChapterHelper from '#helpers/database/papr/audible/PaprAudibleChapterHelper'
-import SharedHelper from '#helpers/utils/shared'
 import { chaptersWithoutProjection, parsedChapters } from '#tests/datasets/helpers/chapters'
+
 
 let asin: string
 let helper: PaprAudibleChapterHelper
@@ -24,16 +48,16 @@ beforeEach(() => {
 	}
 	helper = new PaprAudibleChapterHelper(asin, options)
 
-	jest.spyOn(ChapterModel, 'updateOne').mockResolvedValue({
+	mockUpdateOne.mockResolvedValue({
 		acknowledged: true,
 		matchedCount: 1,
 		modifiedCount: 1,
 		upsertedCount: 0,
 		upsertedId: chaptersWithoutProjection._id
 	})
-	jest.spyOn(ChapterModel, 'findOne').mockResolvedValue(chaptersWithoutProjection)
-	jest.spyOn(ChapterModel, 'insertOne').mockResolvedValue(chaptersWithoutProjection)
-	jest.spyOn(checkers, 'isChapterDocument').mockReturnValue(true)
+	mockFindOne.mockResolvedValue(chaptersWithoutProjection)
+	mockInsertOne.mockResolvedValue(chaptersWithoutProjection)
+	spyOn(checkers, 'isChapterDocument').mockReturnValue(true)
 })
 
 describe('PaprAudibleChapterHelper should', () => {
@@ -43,23 +67,21 @@ describe('PaprAudibleChapterHelper should', () => {
 	})
 	test('create', async () => {
 		const obj = { data: parsedChapters, modified: true }
-		jest
-			.spyOn(ChapterModel, 'findOne')
-			.mockResolvedValue(parsedChapters as unknown as ChapterDocument)
+		mockFindOne.mockResolvedValueOnce(parsedChapters as unknown as ChapterDocument)
 		helper.setData(parsedChapters)
 
 		await expect(helper.create()).resolves.toEqual(obj)
-		expect(ChapterModel.insertOne).toHaveBeenCalledWith(parsedChapters)
-		expect(ChapterModel.findOne).toHaveBeenCalledWith({
+		expect(mockInsertOne).toHaveBeenCalledWith(parsedChapters)
+		expect(mockFindOne).toHaveBeenCalledWith({
 			asin: asin,
 			$or: [{ region: { $exists: false } }, { region: options.region }]
 		})
 	})
 	test('delete', async () => {
 		const obj = { data: { acknowledged: true, deletedCount: 1 }, modified: true }
-		jest.spyOn(ChapterModel, 'deleteOne').mockResolvedValue(obj.data)
+		mockDeleteOne.mockResolvedValue(obj.data)
 		await expect(helper.delete()).resolves.toEqual(obj)
-		expect(ChapterModel.deleteOne).toHaveBeenCalledWith({
+		expect(mockDeleteOne).toHaveBeenCalledWith({
 			asin: asin,
 			$or: [{ region: { $exists: false } }, { region: options.region }]
 		})
@@ -67,37 +89,35 @@ describe('PaprAudibleChapterHelper should', () => {
 	test('findOne', async () => {
 		const obj = { data: chaptersWithoutProjection, modified: false }
 		await expect(helper.findOne()).resolves.toEqual(obj)
-		expect(ChapterModel.findOne).toHaveBeenCalledWith({
+		expect(mockFindOne).toHaveBeenCalledWith({
 			asin: asin,
 			$or: [{ region: { $exists: false } }, { region: options.region }]
 		})
 	})
 	test('findOne returns null if it is not a ChapterDocument', async () => {
 		const obj = { data: null, modified: false }
-		jest.spyOn(ChapterModel, 'findOne').mockResolvedValueOnce(null)
-		jest.spyOn(checkers, 'isChapterDocument').mockReturnValueOnce(false)
+		mockFindOne.mockResolvedValueOnce(null)
+		spyOn(checkers, 'isChapterDocument').mockReturnValueOnce(false)
 		await expect(helper.findOne()).resolves.toEqual(obj)
-		expect(ChapterModel.findOne).toHaveBeenCalledWith({
+		expect(mockFindOne).toHaveBeenCalledWith({
 			asin: asin,
 			$or: [{ region: { $exists: false } }, { region: options.region }]
 		})
 	})
 	test('findOneWithProjection', async () => {
 		const obj = { data: parsedChapters, modified: false }
-		jest
-			.spyOn(ChapterModel, 'findOne')
-			.mockResolvedValue(parsedChapters as unknown as ChapterDocument)
+		mockFindOne.mockResolvedValue(parsedChapters as unknown as ChapterDocument)
 		await expect(helper.findOneWithProjection()).resolves.toEqual(obj)
-		expect(ChapterModel.findOne).toHaveBeenCalledWith({
+		expect(mockFindOne).toHaveBeenCalledWith({
 			asin: asin,
 			$or: [{ region: { $exists: false } }, { region: options.region }]
 		})
 	})
 	test('findOneWithProjection returns null if it is not a ApiChapter', async () => {
 		const obj = { data: null, modified: false }
-		jest.spyOn(ChapterModel, 'findOne').mockResolvedValueOnce(null)
+		mockFindOne.mockResolvedValueOnce(null)
 		await expect(helper.findOneWithProjection()).resolves.toEqual(obj)
-		expect(ChapterModel.findOne).toHaveBeenCalledWith({
+		expect(mockFindOne).toHaveBeenCalledWith({
 			asin: asin,
 			$or: [{ region: { $exists: false } }, { region: options.region }]
 		})
@@ -109,54 +129,44 @@ describe('PaprAudibleChapterHelper should', () => {
 	})
 	test('createOrUpdate finds one to update', async () => {
 		const obj = { data: parsedChapters, modified: true }
-		jest
-			.spyOn(ChapterModel, 'findOne')
+		mockFindOne
 			.mockResolvedValueOnce(parsedChapters as unknown as ChapterDocument)
-		jest.spyOn(ChapterModel, 'findOne').mockResolvedValueOnce(chaptersWithoutProjection)
-		jest
-			.spyOn(ChapterModel, 'findOne')
+			.mockResolvedValueOnce(chaptersWithoutProjection)
 			.mockResolvedValue(parsedChapters as unknown as ChapterDocument)
 		helper.setData(parsedChapters)
 		await expect(helper.createOrUpdate()).resolves.toEqual(obj)
 	})
 	test('createOrUpdate finds no one to update', async () => {
 		const obj = { data: parsedChapters, modified: false }
-		jest
-			.spyOn(ChapterModel, 'findOne')
-			.mockResolvedValue(parsedChapters as unknown as ChapterDocument)
+		mockFindOne.mockResolvedValue(parsedChapters as unknown as ChapterDocument)
 		const test = { ...parsedChapters }
 		test.chapters = []
 		helper.setData(test)
-		jest.spyOn(SharedHelper.prototype, 'isEqualData').mockReturnValue(false)
+		mockIsEqualData.mockReturnValue(false)
 		await expect(helper.createOrUpdate()).resolves.toEqual(obj)
 	})
 	test('createOrUpdate finds identical update data', async () => {
 		const obj = { data: parsedChapters, modified: false }
-		jest
-			.spyOn(ChapterModel, 'findOne')
-			.mockResolvedValue(parsedChapters as unknown as ChapterDocument)
-		jest.spyOn(SharedHelper.prototype, 'isEqualData').mockReturnValue(true)
+		mockFindOne.mockResolvedValue(parsedChapters as unknown as ChapterDocument)
+		mockIsEqualData.mockReturnValue(true)
 		helper.setData(parsedChapters)
 		await expect(helper.createOrUpdate()).resolves.toEqual(obj)
 	})
 	test('createOrUpdate needs to create', async () => {
 		const obj = { data: parsedChapters, modified: true }
-		jest.spyOn(ChapterModel, 'findOne').mockResolvedValueOnce(null)
-		jest.spyOn(ChapterModel, 'findOne').mockResolvedValue(chaptersWithoutProjection)
+		mockFindOne.mockResolvedValueOnce(null)
+		mockFindOne.mockResolvedValue(chaptersWithoutProjection)
 		helper.setData(parsedChapters)
 		await expect(helper.createOrUpdate()).resolves.toEqual(obj)
 	})
 	test('createOrUpdate logs info when updating', async () => {
-		const mockLogger = mock<FastifyBaseLogger>()
-		const helperWithLogger = new PaprAudibleChapterHelper(asin, options, mockLogger)
-		jest
-			.spyOn(ChapterModel, 'findOne')
+		const mockLogger = createMockLogger()
+		const helperWithLogger = new PaprAudibleChapterHelper(asin, options, mockLogger as unknown as FastifyBaseLogger)
+		mockFindOne
 			.mockResolvedValueOnce(parsedChapters as unknown as ChapterDocument)
-		jest.spyOn(ChapterModel, 'findOne').mockResolvedValueOnce(chaptersWithoutProjection)
-		jest
-			.spyOn(ChapterModel, 'findOne')
+			.mockResolvedValueOnce(chaptersWithoutProjection)
 			.mockResolvedValue(parsedChapters as unknown as ChapterDocument)
-		jest.spyOn(SharedHelper.prototype, 'isEqualData').mockReturnValue(false)
+		mockIsEqualData.mockReturnValue(false)
 		helperWithLogger.setData(parsedChapters)
 		await helperWithLogger.createOrUpdate()
 		expect(mockLogger.info).toHaveBeenCalledWith(
@@ -165,13 +175,11 @@ describe('PaprAudibleChapterHelper should', () => {
 	})
 	test('update', async () => {
 		const obj = { data: parsedChapters, modified: true }
-		jest.spyOn(ChapterModel, 'findOne').mockResolvedValueOnce(chaptersWithoutProjection)
-		jest
-			.spyOn(ChapterModel, 'findOne')
-			.mockResolvedValue(parsedChapters as unknown as ChapterDocument)
+		mockFindOne.mockResolvedValueOnce(chaptersWithoutProjection)
+		mockFindOne.mockResolvedValue(parsedChapters as unknown as ChapterDocument)
 		helper.setData(parsedChapters)
 		await expect(helper.update()).resolves.toEqual(obj)
-		expect(ChapterModel.updateOne).toHaveBeenCalledWith(
+		expect(mockUpdateOne).toHaveBeenCalledWith(
 			{ asin: asin, $or: [{ region: { $exists: false } }, { region: options.region }] },
 			{
 				$set: { ...parsedChapters, createdAt: chaptersWithoutProjection._id.getTimestamp() },
@@ -183,62 +191,66 @@ describe('PaprAudibleChapterHelper should', () => {
 
 describe('PaprAudibleChapterHelper should catch error when', () => {
 	test('create', async () => {
-		jest.spyOn(ChapterModel, 'insertOne').mockRejectedValue(new Error('error'))
+		mockInsertOne.mockRejectedValue(new Error('error'))
 		helper.setData(parsedChapters)
 		await expect(helper.create()).rejects.toThrow(
 			`An error occurred while creating chapter ${asin} in the DB`
 		)
 	})
 	test('create logs error on failure', async () => {
-		const mockLogger = mock<FastifyBaseLogger>()
-		const helperWithLogger = new PaprAudibleChapterHelper(asin, options, mockLogger)
-		jest.spyOn(ChapterModel, 'insertOne').mockRejectedValue(new Error('DB error'))
+		const mockLogger = createMockLogger()
+		const helperWithLogger = new PaprAudibleChapterHelper(asin, options, mockLogger as unknown as FastifyBaseLogger)
+		mockInsertOne.mockRejectedValue(new Error('DB error'))
 		helperWithLogger.setData(parsedChapters)
 		await expect(helperWithLogger.create()).rejects.toThrow()
 		expect(mockLogger.error).toHaveBeenCalledWith('DB error')
 	})
 	test('delete', async () => {
-		jest.spyOn(ChapterModel, 'deleteOne').mockRejectedValue(new Error('error'))
+		mockDeleteOne.mockRejectedValue(new Error('error'))
 		await expect(helper.delete()).rejects.toThrow(
 			`An error occurred while deleting chapter ${asin} in the DB`
 		)
 	})
 	test('delete logs error on failure', async () => {
-		const mockLogger = mock<FastifyBaseLogger>()
-		const helperWithLogger = new PaprAudibleChapterHelper(asin, options, mockLogger)
-		jest.spyOn(ChapterModel, 'deleteOne').mockRejectedValue(new Error('DB error'))
+		const mockLogger = createMockLogger()
+		const helperWithLogger = new PaprAudibleChapterHelper(asin, options, mockLogger as unknown as FastifyBaseLogger)
+		mockDeleteOne.mockRejectedValue(new Error('DB error'))
 		await expect(helperWithLogger.delete()).rejects.toThrow()
 		expect(mockLogger.error).toHaveBeenCalledWith('DB error')
 	})
 	test('update did not find existing', async () => {
-		jest.spyOn(ChapterModel, 'findOne').mockResolvedValueOnce(null)
+		mockFindOne.mockResolvedValueOnce(null)
 		helper.setData(parsedChapters)
 		await expect(helper.update()).rejects.toThrow(
 			`An error occurred while updating chapter ${asin} in the DB`
 		)
 	})
 	test('update did not find existing logs error', async () => {
-		const mockLogger = mock<FastifyBaseLogger>()
-		const helperWithLogger = new PaprAudibleChapterHelper(asin, options, mockLogger)
-		jest.spyOn(ChapterModel, 'findOne').mockResolvedValueOnce(null)
+		const mockLogger = createMockLogger()
+		const helperWithLogger = new PaprAudibleChapterHelper(asin, options, mockLogger as unknown as FastifyBaseLogger)
+		mockFindOne.mockResolvedValueOnce(null)
 		helperWithLogger.setData(parsedChapters)
 		await expect(helperWithLogger.update()).rejects.toThrow()
 		expect(mockLogger.error).toHaveBeenCalledWith(`Chapter ${asin} not found in the DB for update`)
 	})
 	test('update', async () => {
-		jest.spyOn(ChapterModel, 'updateOne').mockRejectedValue(new Error('error'))
+		mockUpdateOne.mockRejectedValue(new Error('error'))
 		helper.setData(parsedChapters)
 		await expect(helper.update()).rejects.toThrow(
 			`An error occurred while updating chapter ${asin} in the DB`
 		)
 	})
 	test('update logs error on failure', async () => {
-		const mockLogger = mock<FastifyBaseLogger>()
-		const helperWithLogger = new PaprAudibleChapterHelper(asin, options, mockLogger)
-		jest.spyOn(ChapterModel, 'findOne').mockResolvedValueOnce(chaptersWithoutProjection)
-		jest.spyOn(ChapterModel, 'updateOne').mockRejectedValue(new Error('DB error'))
+		const mockLogger = createMockLogger()
+		const helperWithLogger = new PaprAudibleChapterHelper(asin, options, mockLogger as unknown as FastifyBaseLogger)
+		mockFindOne.mockResolvedValueOnce(chaptersWithoutProjection)
+		mockUpdateOne.mockRejectedValue(new Error('DB error'))
 		helperWithLogger.setData(parsedChapters)
 		await expect(helperWithLogger.update()).rejects.toThrow()
 		expect(mockLogger.error).toHaveBeenCalledWith('DB error')
 	})
+})
+
+afterAll(() => {
+	mock.restore()
 })

--- a/tests/database/papr/audible/PaprAudibleChapterHelper.test.ts
+++ b/tests/database/papr/audible/PaprAudibleChapterHelper.test.ts
@@ -40,6 +40,12 @@ let helper: PaprAudibleChapterHelper
 let options: ApiQueryString
 
 beforeEach(() => {
+	mockUpdateOne.mockReset()
+	mockFindOne.mockReset()
+	mockInsertOne.mockReset()
+	mockDeleteOne.mockReset()
+	mockFind.mockReset()
+	mockIsEqualData.mockReset()
 	asin = parsedChapters.asin
 	options = {
 		region: 'us',

--- a/tests/database/papr/initialize.test.ts
+++ b/tests/database/papr/initialize.test.ts
@@ -1,3 +1,12 @@
+mock.module('mongodb', () => {
+	return {
+		MongoClient: mock().mockImplementation(() => ({
+			connect: mock().mockResolvedValue(undefined),
+			db: mock().mockReturnValue({ collection: mock() }),
+			close: mock().mockResolvedValue(undefined)
+		}))
+	}
+})
 import { beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import { Db } from 'mongodb'
 
@@ -23,9 +32,10 @@ describe('Papr should', () => {
 		await expect(initialize(ctx)).resolves.toBeUndefined()
 		expect(ctx.client.db).toHaveBeenCalledWith('audnexus')
 	})
-	test('initialize with real', async () => {
+	test('initialize with mock client via createDefaultContext', async () => {
 		ctx = createDefaultContext('mongodb://localhost:27017')
-		// Just verify initialize doesn't throw with a real client
+		// Verify initialize works when called via createDefaultContext (mongodb module is mocked)
 		await expect(initialize(ctx)).resolves.toBeUndefined()
+		expect(ctx.client.db).toHaveBeenCalledWith('audnexus')
 	})
 })

--- a/tests/database/papr/initialize.test.ts
+++ b/tests/database/papr/initialize.test.ts
@@ -1,4 +1,4 @@
-jest.mock('mongodb')
+import { beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import { Db } from 'mongodb'
 
 import { Context, createDefaultContext } from '#config/context'
@@ -8,15 +8,14 @@ import { createMockContext, MockContext } from '#config/test-context'
 let mockCtx: MockContext
 let ctx: Context
 
-// Create context
 beforeEach(() => {
 	mockCtx = createMockContext()
 	ctx = mockCtx as unknown as Context
 	const mockDbInstance = {
-		collection: jest.fn()
+		collection: mock()
 	} as unknown as Db
-	jest.spyOn(ctx.client, 'db').mockReturnValue(mockDbInstance)
-	jest.spyOn(ctx.client, 'connect').mockResolvedValue(ctx.client)
+	spyOn(ctx.client, 'db').mockReturnValue(mockDbInstance)
+	spyOn(ctx.client, 'connect').mockResolvedValue(ctx.client)
 })
 
 describe('Papr should', () => {
@@ -26,7 +25,7 @@ describe('Papr should', () => {
 	})
 	test('initialize with real', async () => {
 		ctx = createDefaultContext('mongodb://localhost:27017')
+		// Just verify initialize doesn't throw with a real client
 		await expect(initialize(ctx)).resolves.toBeUndefined()
-		expect(ctx.client.db).toHaveBeenCalledWith('audnexus')
 	})
 })

--- a/tests/database/redis/RedisHelper.test.ts
+++ b/tests/database/redis/RedisHelper.test.ts
@@ -1,14 +1,14 @@
-jest.mock('@fastify/redis')
 import type { FastifyRedis } from '@fastify/redis'
+import { beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import type { FastifyBaseLogger } from 'fastify'
-import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
 
 import RedisHelper from '#helpers/database/redis/RedisHelper'
 import { parsedAuthor } from '#tests/datasets/helpers/authors'
 import { parsedBook } from '#tests/datasets/helpers/books'
+import { createMockLogger } from '#tests/setup/mockLogger'
 
 type MockContext = {
-	client: DeepMockProxy<FastifyRedis>
+	client: FastifyRedis
 }
 
 let asin: string
@@ -18,9 +18,27 @@ let region: string
 
 const createMockContext = (): MockContext => {
 	return {
-		client: mockDeep<FastifyRedis>()
+		client: {
+			del: mock(),
+			get: mock(),
+			set: mock(),
+			expire: mock(),
+			connect: mock(),
+			disconnect: mock(),
+			quit: mock(),
+			sendCommand: mock(),
+			subscribe: mock(),
+			unsubscribe: mock(),
+			psubscribe: mock(),
+			punsubscribe: mock(),
+			duplicate: mock(),
+			monitor: mock(),
+			INFO: mock(),
+			CLIENT: mock()
+		} as unknown as FastifyRedis
 	}
 }
+
 
 beforeEach(() => {
 	asin = 'B079LRSMNN'
@@ -39,40 +57,40 @@ describe('RedisHelper should', () => {
 		await expect(helper.setOne(parsedBook)).resolves.toBeUndefined()
 	})
 	test('deleteOne book', async () => {
-		jest.spyOn(ctx.client, 'del').mockResolvedValue(1)
+		ctx.client.del.mockResolvedValue(1)
 		await expect(helper.deleteOne()).resolves.toBe(true)
 		expect(ctx.client.del).toHaveBeenCalledWith(`${region}-book-${asin}`)
 	})
 	test('did not deleteOne book', async () => {
-		jest.spyOn(ctx.client, 'del').mockResolvedValue(0)
+		ctx.client.del.mockResolvedValue(0)
 		await expect(helper.deleteOne()).resolves.toBe(false)
 		expect(ctx.client.del).toHaveBeenCalledWith(`${region}-book-${asin}`)
 	})
 	test('findOne book and return it', async () => {
-		jest.spyOn(ctx.client, 'get').mockResolvedValue(JSON.stringify(parsedBook))
+		ctx.client.get.mockResolvedValue(JSON.stringify(parsedBook))
 		await expect(helper.findOne()).resolves.toEqual(parsedBook)
 		expect(ctx.client.get).toHaveBeenCalledWith(`${region}-book-${asin}`)
 	})
 	test('did not findOne book and return undefined', async () => {
-		jest.spyOn(ctx.client, 'get').mockResolvedValue('')
+		ctx.client.get.mockResolvedValue('')
 		await expect(helper.findOne()).resolves.toBeUndefined()
 		expect(ctx.client.get).toHaveBeenCalledWith(`${region}-book-${asin}`)
 	})
 	test('findOne Author and return it', async () => {
 		asin = parsedAuthor.asin
 		helper = new RedisHelper(ctx.client, 'author', asin, region)
-		jest.spyOn(ctx.client, 'get').mockResolvedValue(JSON.stringify(parsedAuthor))
+		ctx.client.get.mockResolvedValue(JSON.stringify(parsedAuthor))
 		await expect(helper.findOne()).resolves.toEqual(parsedAuthor)
 		expect(ctx.client.get).toHaveBeenCalledWith(`${region}-author-${asin}`)
 	})
 	test('findOrCreate book and return it', async () => {
-		jest.spyOn(ctx.client, 'get').mockResolvedValue(JSON.stringify(parsedBook))
+		ctx.client.get.mockResolvedValue(JSON.stringify(parsedBook))
 		await expect(helper.findOrCreate(parsedBook)).resolves.toEqual(parsedBook)
 		expect(ctx.client.get).toHaveBeenCalledWith(`${region}-book-${asin}`)
 	})
 	test('findOrCreate book and create it', async () => {
-		jest.spyOn(ctx.client, 'get').mockResolvedValue('')
-		jest.spyOn(ctx.client, 'set').mockResolvedValue('OK')
+		ctx.client.get.mockResolvedValue('')
+		ctx.client.set.mockResolvedValue('OK')
 		await expect(helper.findOrCreate(parsedBook)).resolves.toEqual(parsedBook)
 		expect(ctx.client.get).toHaveBeenCalledWith(`${region}-book-${asin}`)
 		expect(ctx.client.set).toHaveBeenCalledWith(
@@ -81,7 +99,7 @@ describe('RedisHelper should', () => {
 		)
 	})
 	test('setExpiration', async () => {
-		jest.spyOn(ctx.client, 'expire').mockResolvedValue(1)
+		ctx.client.expire.mockResolvedValue(1)
 		await expect(helper.setExpiration()).resolves.toBeUndefined()
 		expect(ctx.client.expire).toHaveBeenCalledWith(`${region}-book-${asin}`, 432000)
 	})
@@ -89,25 +107,25 @@ describe('RedisHelper should', () => {
 
 describe('RedisHelper should catch error when', () => {
 	test('deleteOne book', async () => {
-		jest.spyOn(ctx.client, 'del').mockRejectedValue(new Error('Redis error'))
+		ctx.client.del.mockRejectedValue(new Error('Redis error'))
 		await expect(helper.deleteOne()).rejects.toThrow(
 			`An error occurred while deleting ${region}-book-${asin} in redis`
 		)
 		expect(ctx.client.del).toHaveBeenCalledWith(`${region}-book-${asin}`)
 	})
 	test('findOne get rejects', async () => {
-		jest.spyOn(ctx.client, 'get').mockRejectedValue(new Error('Error'))
+		ctx.client.get.mockRejectedValue(new Error('Error'))
 		await expect(helper.findOne()).resolves.toBeUndefined()
 		expect(ctx.client.get).toHaveBeenCalledWith(`${region}-book-${asin}`)
 	})
 	test('findOrCreate get rejects', async () => {
-		jest.spyOn(ctx.client, 'get').mockRejectedValue(new Error('Error'))
+		ctx.client.get.mockRejectedValue(new Error('Error'))
 		await expect(helper.findOrCreate(parsedBook)).resolves.toBe(parsedBook)
 		expect(ctx.client.get).toHaveBeenCalledWith(`${region}-book-${asin}`)
 	})
 	test('findOrCreate set rejects', async () => {
-		jest.spyOn(ctx.client, 'get').mockResolvedValue('')
-		jest.spyOn(ctx.client, 'set').mockRejectedValue(new Error('Error'))
+		ctx.client.get.mockResolvedValue('')
+		ctx.client.set.mockRejectedValue(new Error('Error'))
 		await expect(helper.findOrCreate(parsedBook)).rejects.toThrow(
 			`An error occurred while setting ${region}-book-${asin} in redis`
 		)
@@ -118,14 +136,11 @@ describe('RedisHelper should catch error when', () => {
 		)
 	})
 	test('setExpiration rejects', async () => {
-		const mockLogger = mockDeep<FastifyBaseLogger>()
-		// Create helper with mock logger
-		const helperWithLogger = new RedisHelper(ctx.client, 'book', asin, region, mockLogger)
-		jest
-			.spyOn(ctx.client, 'expire')
-			.mockRejectedValue(
-				new Error(`An error occurred while setting expiration for ${region}-book-${asin} in redis`)
-			)
+		const mockLogger = createMockLogger()
+		const helperWithLogger = new RedisHelper(ctx.client, 'book', asin, region, mockLogger as unknown as FastifyBaseLogger)
+		ctx.client.expire.mockRejectedValue(
+			new Error(`An error occurred while setting expiration for ${region}-book-${asin} in redis`)
+		)
 		await expect(helperWithLogger.setExpiration()).resolves.toBeUndefined()
 		expect(ctx.client.expire).toHaveBeenCalledWith(`${region}-book-${asin}`, 432000)
 		expect(mockLogger.error).toHaveBeenCalledWith(
@@ -136,25 +151,19 @@ describe('RedisHelper should catch error when', () => {
 
 describe('RedisHelper fallbackLogger', () => {
 	test('should use fallbackLogger.error when Redis operation fails without external logger', async () => {
-		// Create helper without logger - uses fallbackLogger
 		const helperWithoutLogger = new RedisHelper(ctx.client, 'book', asin, region)
 
-		// Spy on console.error to verify it's called
-		const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation()
+		const consoleErrorSpy = spyOn(console, 'error').mockImplementation()
 
 		try {
-			// Mock redis instance to reject on get
-			jest.spyOn(ctx.client, 'get').mockRejectedValue(new Error('Redis connection failed'))
+			ctx.client.get.mockRejectedValue(new Error('Redis connection failed'))
 
-			// Call findOne which should trigger the error path
 			await expect(helperWithoutLogger.findOne()).resolves.toBeUndefined()
 
-			// Assert console.error was called via fallbackLogger.error with the actual error message
 			expect(consoleErrorSpy).toHaveBeenCalledWith(
 				expect.stringContaining('Redis connection failed')
 			)
 		} finally {
-			// Cleanup - ensure spy is always restored even if test fails
 			consoleErrorSpy.mockRestore()
 		}
 	})

--- a/tests/datasets/audible/books/scrape.ts
+++ b/tests/datasets/audible/books/scrape.ts
@@ -94,3 +94,36 @@ export const mockHtmlB08C6YJ1LS = `
 </body>
 </html>
 `
+
+// Mock HTML for a book with NO genres
+export const mockHtmlNoGenres = `
+<html>
+<body>
+	<div class="product-details">
+		<h1>Book with No Genres</h1>
+	</div>
+</body>
+</html>
+`
+// Mock HTML for a book with only 1 genre
+export const mockHtmlSingleGenre = `
+<html>
+<body>
+	<ul>
+		<li class="categoriesLabel">
+			<a href="/tag/Science-Fiction-Fantasy-Audiobooks/18580606011">Science Fiction & Fantasy</a>
+		</li>
+	</ul>
+</body>
+</html>
+`
+
+export const parsedSingleGenre: HtmlBook = {
+	genres: [
+		{
+			asin: '18580606011',
+			name: 'Science Fiction & Fantasy',
+			type: 'genre'
+		}
+	]
+}

--- a/tests/helpers/authors/audible/ScrapeHelper.test.ts
+++ b/tests/helpers/authors/audible/ScrapeHelper.test.ts
@@ -1,4 +1,5 @@
 import type { AxiosResponse } from 'axios'
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import * as cheerio from 'cheerio'
 
 import { baseAsin10Regex } from '#config/types'
@@ -15,8 +16,25 @@ import {
 	similarUnsorted
 } from '#tests/datasets/helpers/authors'
 
-jest.mock('#helpers/utils/fetchPlus')
-jest.mock('#helpers/utils/shared')
+mock.module('#helpers/utils/fetchPlus', () => {
+	return { default: mock() }
+})
+
+mock.module('#helpers/utils/shared', () => {
+	return {
+		default: class SharedHelper {
+			buildUrl() { return '' }
+			getAsinFromUrl(url: string) { return url.match(baseAsin10Regex)?.[0] }
+			collectGenres() { return [] }
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			sortObjectByKeys(obj: any) { return obj }
+			isEqualData() { return false }
+			isRecentlyUpdated() { return false }
+			getParamString() { return '' }
+			getGenreAsinFromUrl() { return undefined }
+		}
+	}
+})
 
 let asin: string
 let helper: ScrapeHelper
@@ -27,28 +45,23 @@ let url: string
 const deepCopy = (obj: unknown) => JSON.parse(JSON.stringify(obj))
 
 beforeEach(() => {
-	// Variables
 	asin = 'B012DQ3BCM'
 	mockResponse = deepCopy(htmlResponseMinified)
 	cheerioHtml = cheerio.load(mockResponse)
 	region = 'us'
 	url = `https://www.audible.com/author/${asin}/`
-	// Set up spys
-	jest.spyOn(SharedHelper.prototype, 'buildUrl').mockReturnValue(url)
-	jest.spyOn(SharedHelper.prototype, 'getAsinFromUrl').mockImplementation((url: string) => {
+	spyOn(SharedHelper.prototype, 'buildUrl').mockReturnValue(url)
+	spyOn(SharedHelper.prototype, 'getAsinFromUrl').mockImplementation((url: string) => {
 		return url.match(baseAsin10Regex)?.[0]
 	})
-	// Set up helpers
 	helper = new ScrapeHelper(asin, region)
 })
 
 describe('ScrapeHelper should', () => {
 	beforeEach(() => {
-		jest
-			.spyOn(fetchPlus, 'default')
-			.mockImplementation(() =>
-				Promise.resolve({ data: mockResponse, status: 200 } as AxiosResponse)
-			)
+		spyOn(fetchPlus, 'default').mockImplementation(() =>
+			Promise.resolve({ data: mockResponse, status: 200 } as AxiosResponse)
+		)
 	})
 	test('setup constructor correctly', () => {
 		expect(helper.asin).toBe(asin)
@@ -98,12 +111,12 @@ describe('ScrapeHelper should', () => {
 
 	test('throw NotFoundError when dom throws for getName', () => {
 		const mockDom = {
-			first: jest.fn().mockReturnThis(),
-			text: jest.fn().mockImplementation(() => {
+			first: mock().mockReturnThis(),
+			text: mock().mockImplementation(() => {
 				throw new Error('DOM error')
 			})
 		}
-		const mockCheerio = jest.fn().mockReturnValue(mockDom) as unknown as cheerio.CheerioAPI
+		const mockCheerio = mock().mockReturnValue(mockDom) as unknown as cheerio.CheerioAPI
 		expect.assertions(2)
 		try {
 			helper.getName(mockCheerio)
@@ -125,7 +138,7 @@ describe('ScrapeHelper should', () => {
 	})
 
 	test('return sorted similar when no similar authors', () => {
-		jest.spyOn(helper, 'getSimilarAuthors').mockReturnValue([])
+		spyOn(helper, 'getSimilarAuthors').mockReturnValue([])
 		const similar = helper.getSimilarAuthors(cheerioHtml)
 		const sorted = helper.sortSimilarAuthors(similar)
 		expect(sorted).toEqual([])
@@ -137,7 +150,7 @@ describe('ScrapeHelper should', () => {
 	})
 
 	test('return a name when author has no bio, genres or image', async () => {
-		jest.spyOn(SharedHelper.prototype, 'collectGenres').mockReturnValue([])
+		spyOn(SharedHelper.prototype, 'collectGenres').mockReturnValue([])
 		const html = cheerio.load(htmlResponseNameOnly)
 		await expect(helper.parseResponse(html)).resolves.toEqual({
 			asin: 'B012DQ3BCM',
@@ -163,8 +176,8 @@ describe('ScrapeHelper should throw error when', () => {
 	test('no author', async () => {
 		asin = asin.slice(0, -1)
 		helper = new ScrapeHelper(asin, region)
-		jest.restoreAllMocks()
-		jest.spyOn(fetchPlus, 'default').mockImplementation(() =>
+		mock.restore()
+		spyOn(fetchPlus, 'default').mockImplementation(() =>
 			Promise.reject({
 				status: 404
 			})
@@ -175,14 +188,14 @@ describe('ScrapeHelper should throw error when', () => {
 	})
 
 	test('parse response fails validation', async () => {
-		jest.spyOn(helper, 'getName').mockReturnValue('')
+		spyOn(helper, 'getName').mockReturnValue('')
 		await expect(helper.parseResponse(cheerio.load(mockResponse))).rejects.toThrow(
 			`Item not available in region '${region}' for ASIN: ${asin}`
 		)
 	})
 
 	test('parse response throws ContentTypeMismatchError when book page detected', async () => {
-		jest.spyOn(helper, 'getName').mockReturnValue('')
+		spyOn(helper, 'getName').mockReturnValue('')
 		expect.assertions(3)
 		const bookPageHtml = mockResponse.replace(
 			'<body>',
@@ -212,4 +225,8 @@ describe('ScrapeHelper should throw error when', () => {
 			`Item not available in region '${region}' for ASIN: ${asin}`
 		)
 	})
+})
+
+afterAll(() => {
+	mock.restore()
 })

--- a/tests/helpers/authors/audible/SeedHelper.test.ts
+++ b/tests/helpers/authors/audible/SeedHelper.test.ts
@@ -7,6 +7,7 @@ import { ApiBook } from '#config/types'
 import SeedHelper from '#helpers/authors/audible/SeedHelper'
 import * as fetchPlus from '#helpers/utils/fetchPlus'
 import { parsedBook } from '#tests/datasets/helpers/books'
+import { createMockLogger } from '#tests/setup/mockLogger'
 
 mock.module('#helpers/utils/fetchPlus', () => {
 	return { default: mock() }
@@ -51,22 +52,7 @@ describe('SeedHelper should', () => {
 	})
 
 	test('return empty array and log error when Promise.all rejects', async () => {
-		const mockLogger = {
-			error: mock(),
-			info: mock(),
-			warn: mock(),
-			debug: mock(),
-			fatal: mock(),
-			trace: mock(),
-			child: mock().mockReturnValue({
-				error: mock(),
-				info: mock(),
-				warn: mock(),
-				debug: mock(),
-				fatal: mock(),
-				trace: mock()
-			} as FastifyBaseLogger)
-		} as unknown as FastifyBaseLogger
+		const mockLogger = createMockLogger() as unknown as FastifyBaseLogger
 		helper = new SeedHelper(mockResponse, mockLogger)
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tests/helpers/authors/audible/SeedHelper.test.ts
+++ b/tests/helpers/authors/audible/SeedHelper.test.ts
@@ -1,25 +1,26 @@
+ 
 import type { AxiosResponse } from 'axios'
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import type { FastifyBaseLogger } from 'fastify'
-import { mock } from 'jest-mock-extended'
 
 import { ApiBook } from '#config/types'
 import SeedHelper from '#helpers/authors/audible/SeedHelper'
 import * as fetchPlus from '#helpers/utils/fetchPlus'
 import { parsedBook } from '#tests/datasets/helpers/books'
 
-jest.mock('#helpers/utils/fetchPlus')
+mock.module('#helpers/utils/fetchPlus', () => {
+	return { default: mock() }
+})
 
 let helper: SeedHelper
 let mockResponse: ApiBook
 const deepCopy = (obj: unknown) => JSON.parse(JSON.stringify(obj))
 
 beforeEach(() => {
-	// Variables
 	mockResponse = deepCopy(parsedBook)
-	jest
-		.spyOn(fetchPlus, 'default')
-		.mockImplementation(() => Promise.resolve({ status: 200 } as AxiosResponse))
-	// Set up helpers
+	spyOn(fetchPlus, 'default').mockImplementation(() =>
+		Promise.resolve({ status: 200 } as AxiosResponse)
+	)
 	helper = new SeedHelper(mockResponse)
 })
 
@@ -40,7 +41,7 @@ describe('SeedHelper should', () => {
 	})
 
 	test('log error if http error', async () => {
-		jest.spyOn(fetchPlus, 'default').mockImplementation(() => Promise.reject({ status: 400 }))
+		spyOn(fetchPlus, 'default').mockImplementation(() => Promise.reject({ status: 400 }))
 		await expect(helper.seedAll()).resolves.toEqual([false, false])
 	})
 
@@ -50,14 +51,28 @@ describe('SeedHelper should', () => {
 	})
 
 	test('return empty array and log error when Promise.all rejects', async () => {
-		const mockLogger = mock<FastifyBaseLogger>()
+		const mockLogger = {
+			error: mock(),
+			info: mock(),
+			warn: mock(),
+			debug: mock(),
+			fatal: mock(),
+			trace: mock(),
+			child: mock().mockReturnValue({
+				error: mock(),
+				info: mock(),
+				warn: mock(),
+				debug: mock(),
+				fatal: mock(),
+				trace: mock()
+			} as FastifyBaseLogger)
+		} as unknown as FastifyBaseLogger
 		helper = new SeedHelper(mockResponse, mockLogger)
 
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const promiseAllSpy = jest
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			.spyOn(Promise, 'all' as any)
-			.mockRejectedValue(new Error('Promise.all failed'))
+		const promiseAllSpy = spyOn(Promise, 'all' as any).mockRejectedValue(
+			new Error('Promise.all failed')
+		)
 
 		try {
 			const result = await helper.seedAll()
@@ -68,4 +83,8 @@ describe('SeedHelper should', () => {
 			promiseAllSpy.mockRestore()
 		}
 	})
+})
+
+afterAll(() => {
+	mock.restore()
 })

--- a/tests/helpers/books/audible/ApiHelper.test.ts
+++ b/tests/helpers/books/audible/ApiHelper.test.ts
@@ -1,4 +1,3 @@
- 
 import type { AxiosResponse } from 'axios'
 import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import type { FastifyBaseLogger } from 'fastify'
@@ -33,8 +32,12 @@ mock.module('#helpers/utils/fetchPlus', () => {
 mock.module('#helpers/utils/shared', () => {
 	return {
 		default: class SharedHelper {
-			getParamString() { return '' }
-			buildUrl() { return '' }
+			getParamString() {
+				return ''
+			}
+			buildUrl() {
+				return ''
+			}
 		}
 	}
 })
@@ -67,7 +70,13 @@ describe('ApiHelper should', () => {
 		expect(helper.requestUrl).toBe(url)
 	})
 
-	test.todo('check required keys')
+	test('check required keys on parse', async () => {
+		const invalidResponse = deepCopy(mockResponse)
+		delete (invalidResponse.product as Record<string, unknown>).asin
+		await expect(helper.parseResponse(invalidResponse)).rejects.toThrow(
+			/Required key 'asin' does not exist/
+		)
+	})
 
 	test('get copyright year', async () => {
 		helper.audibleResponse = mockResponse.product
@@ -145,7 +154,21 @@ describe('ApiHelper should', () => {
 		})
 	})
 
-	test.todo('get series without position')
+	test('get series without position', async () => {
+		expect(mockResponse.product.content_delivery_type).toBe('MultiPartBook')
+		helper.audibleResponse = mockResponse.product
+		const seriesWithoutPosition = {
+			asin: 'B079YXK1GL',
+			title: "Galaxy's Edge Series",
+			url: '/pd/Galaxys-Edge-Series-Audiobook/B079YXK1GL'
+		}
+		const result = helper.getSeries(seriesWithoutPosition)
+		expect(result).toEqual({
+			asin: 'B079YXK1GL',
+			name: "Galaxy's Edge Series"
+		})
+		expect(result).not.toHaveProperty('position')
+	})
 
 	test('fetch book data', async () => {
 		const data = await helper.fetchBook()
@@ -330,7 +353,7 @@ describe('ApiHelper edge cases should', () => {
 	test('parses book with unknown content_delivery_type successfully', async () => {
 		const unknownTypeResponse = deepCopy(mockResponse)
 		unknownTypeResponse.product.content_delivery_type = 'UnknownType'
-const mockLogger = createMockLogger()
+		const mockLogger = createMockLogger()
 		helper = new ApiHelper(asin, region, mockLogger as unknown as FastifyBaseLogger)
 		const data = await helper.parseResponse(unknownTypeResponse)
 		expect(data.asin).toBe(asin)
@@ -366,27 +389,27 @@ const mockLogger = createMockLogger()
 		fetchProductStateSpy.mockRestore()
 	})
 
-	test.each([
-		['AVAILABLE'],
-		[undefined],
-		['SOME_OTHER_STATE']
-	] as const)('throws REGION_UNAVAILABLE when fetchProductState returns %s', async (state) => {
-		const fetchProductStateSpy = spyOn(ApiHelper.prototype, 'fetchProductState').mockResolvedValue(
-			state
-		)
-		const emptyProductResponse = { product: {} } as AudibleProduct
-		await expect(helper.parseResponse(emptyProductResponse)).rejects.toBeInstanceOf(NotFoundError)
-		await expect(helper.parseResponse(emptyProductResponse)).rejects.toMatchObject({
-			name: 'NotFoundError',
-			statusCode: 404,
-			message: `Item not available in region '${region}' for ASIN: ${asin}`,
-			details: {
-				asin,
-				code: 'REGION_UNAVAILABLE'
-			}
-		})
-		fetchProductStateSpy.mockRestore()
-	})
+	test.each([['AVAILABLE'], [undefined], ['SOME_OTHER_STATE']] as const)(
+		'throws REGION_UNAVAILABLE when fetchProductState returns %s',
+		async (state) => {
+			const fetchProductStateSpy = spyOn(
+				ApiHelper.prototype,
+				'fetchProductState'
+			).mockResolvedValue(state)
+			const emptyProductResponse = { product: {} } as AudibleProduct
+			await expect(helper.parseResponse(emptyProductResponse)).rejects.toBeInstanceOf(NotFoundError)
+			await expect(helper.parseResponse(emptyProductResponse)).rejects.toMatchObject({
+				name: 'NotFoundError',
+				statusCode: 404,
+				message: `Item not available in region '${region}' for ASIN: ${asin}`,
+				details: {
+					asin,
+					code: 'REGION_UNAVAILABLE'
+				}
+			})
+			fetchProductStateSpy.mockRestore()
+		}
+	)
 	test('throws NotFoundError with statusCode 404 for unavailable region', async () => {
 		const emptyProductResponse = { product: {} } as AudibleProduct
 		await expect(helper.parseResponse(emptyProductResponse)).rejects.toBeInstanceOf(NotFoundError)

--- a/tests/helpers/books/audible/ApiHelper.test.ts
+++ b/tests/helpers/books/audible/ApiHelper.test.ts
@@ -24,6 +24,7 @@ import {
 	podcastWithoutProgramParticipation
 } from '#tests/datasets/audible/books/api'
 import { apiResponse, parsedBook, parsedBookWithoutNarrators } from '#tests/datasets/helpers/books'
+import { createMockLogger } from '#tests/setup/mockLogger'
 
 mock.module('#helpers/utils/fetchPlus', () => {
 	return { default: mock() }
@@ -329,7 +330,7 @@ describe('ApiHelper edge cases should', () => {
 	test('parses book with unknown content_delivery_type successfully', async () => {
 		const unknownTypeResponse = deepCopy(mockResponse)
 		unknownTypeResponse.product.content_delivery_type = 'UnknownType'
-		const mockLogger = { warn: mock() }
+const mockLogger = createMockLogger()
 		helper = new ApiHelper(asin, region, mockLogger as unknown as FastifyBaseLogger)
 		const data = await helper.parseResponse(unknownTypeResponse)
 		expect(data.asin).toBe(asin)

--- a/tests/helpers/books/audible/ApiHelper.test.ts
+++ b/tests/helpers/books/audible/ApiHelper.test.ts
@@ -1,5 +1,6 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
+ 
 import type { AxiosResponse } from 'axios'
+import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import type { FastifyBaseLogger } from 'fastify'
 
 import {
@@ -24,8 +25,18 @@ import {
 } from '#tests/datasets/audible/books/api'
 import { apiResponse, parsedBook, parsedBookWithoutNarrators } from '#tests/datasets/helpers/books'
 
-jest.mock('#helpers/utils/fetchPlus')
-jest.mock('#helpers/utils/shared')
+mock.module('#helpers/utils/fetchPlus', () => {
+	return { default: mock() }
+})
+
+mock.module('#helpers/utils/shared', () => {
+	return {
+		default: class SharedHelper {
+			getParamString() { return '' }
+			buildUrl() { return '' }
+		}
+	}
+})
 
 let asin: string
 let helper: ApiHelper
@@ -35,20 +46,17 @@ let url: string
 const deepCopy = (obj: unknown) => JSON.parse(JSON.stringify(obj))
 
 beforeEach(async () => {
-	// Variables
 	asin = 'B079LRSMNN'
 	region = 'us'
 	const params =
 		'category_ladders,contributors,product_desc,product_extended_attrs,product_attrs,media,rating,series&image_sizes=500,1024'
 	url = `https://api.audible.com/1.0/catalog/products/${asin}/?response_groups=` + params
 	mockResponse = AudibleProductSchema.parse(deepCopy(apiResponse))
-	// Set up spys
-	jest.spyOn(SharedHelper.prototype, 'getParamString').mockReturnValue(params)
-	jest.spyOn(SharedHelper.prototype, 'buildUrl').mockReturnValue(url)
-	jest
-		.spyOn(fetchPlus, 'default')
-		.mockImplementation(() => Promise.resolve({ data: mockResponse, status: 200 } as AxiosResponse))
-	// Set up helpers
+	spyOn(SharedHelper.prototype, 'getParamString').mockReturnValue(params)
+	spyOn(SharedHelper.prototype, 'buildUrl').mockReturnValue(url)
+	spyOn(fetchPlus, 'default').mockImplementation(() =>
+		Promise.resolve({ data: mockResponse, status: 200 } as AxiosResponse)
+	)
 	helper = new ApiHelper(asin, region)
 })
 
@@ -76,10 +84,8 @@ describe('ApiHelper should', () => {
 	})
 
 	test('get series', async () => {
-		// Make lint happy
 		if (mockResponse.product.content_delivery_type !== 'MultiPartBook') return undefined
 		helper.audibleResponse = mockResponse.product
-		// Should return undefined if no series title
 		expect(helper.getSeries({ asin: '123', title: '', sequence: '1', url: '' })).toBeUndefined()
 		expect(helper.getSeries(mockResponse.product.series![0])).toEqual({
 			asin: 'B079YXK1GL',
@@ -89,10 +95,8 @@ describe('ApiHelper should', () => {
 	})
 
 	test('get series primary', async () => {
-		// Make lint happy
 		if (mockResponse.product.content_delivery_type !== 'MultiPartBook') return undefined
 		helper.audibleResponse = mockResponse.product
-		// Should return undefined if no series name
 		expect(
 			helper.getSeriesPrimary([{ asin: '123', title: '', sequence: '1', url: '' }])
 		).toBeUndefined()
@@ -113,10 +117,8 @@ describe('ApiHelper should', () => {
 	})
 
 	test('get series secondary', async () => {
-		// Make lint happy
 		if (mockResponse.product.content_delivery_type !== 'MultiPartBook') return undefined
 		helper.audibleResponse = mockResponse.product
-		// Should return undefined if no series name
 		expect(
 			helper.getSeriesSecondary([{ asin: '123', title: '', sequence: '1', url: '' }])
 		).toBeUndefined()
@@ -196,9 +198,12 @@ describe('ApiHelper should', () => {
 })
 
 describe('ApiHelper edge cases should', () => {
+	afterEach(() => {
+		mock.restore()
+	})
+
 	test('parse a book with no narrators', async () => {
 		const data = await helper.fetchBook()
-		// Directly set inputjson
 		helper.audibleResponse = data.product
 		helper.audibleResponse!.narrators = undefined
 
@@ -285,7 +290,6 @@ describe('ApiHelper edge cases should', () => {
 	})
 
 	test('parse a book with 2 series', async () => {
-		// Make lint happy
 		if (B017V4IM1G.product.content_delivery_type !== 'MultiPartBook') return undefined
 		helper = new ApiHelper('B017V4IM1G', region)
 		const data = await helper.parseResponse(B017V4IM1G)
@@ -325,7 +329,7 @@ describe('ApiHelper edge cases should', () => {
 	test('parses book with unknown content_delivery_type successfully', async () => {
 		const unknownTypeResponse = deepCopy(mockResponse)
 		unknownTypeResponse.product.content_delivery_type = 'UnknownType'
-		const mockLogger = { warn: jest.fn() }
+		const mockLogger = { warn: mock() }
 		helper = new ApiHelper(asin, region, mockLogger as unknown as FastifyBaseLogger)
 		const data = await helper.parseResponse(unknownTypeResponse)
 		expect(data.asin).toBe(asin)
@@ -336,7 +340,6 @@ describe('ApiHelper edge cases should', () => {
 	})
 
 	test('throws region unavailable when baseShape also fails', async () => {
-		// Create a response with empty product (missing required baseShape fields)
 		const emptyProductResponse = { product: {} } as AudibleProduct
 		await expect(helper.parseResponse(emptyProductResponse)).rejects.toThrow(
 			`Item not available in region '${region}' for ASIN: ${asin}`
@@ -344,9 +347,9 @@ describe('ApiHelper edge cases should', () => {
 	})
 
 	test('throws PRODUCT_DELISTED when fetchProductState returns NOT_AVAILABLE_FOR_PURCHASE', async () => {
-		const fetchProductStateSpy = jest
-			.spyOn(ApiHelper.prototype, 'fetchProductState')
-			.mockResolvedValue('NOT_AVAILABLE_FOR_PURCHASE')
+		const fetchProductStateSpy = spyOn(ApiHelper.prototype, 'fetchProductState').mockResolvedValue(
+			'NOT_AVAILABLE_FOR_PURCHASE'
+		)
 		const emptyProductResponse = { product: {} } as AudibleProduct
 		await expect(helper.parseResponse(emptyProductResponse)).rejects.toBeInstanceOf(NotFoundError)
 		await expect(helper.parseResponse(emptyProductResponse)).rejects.toMatchObject({
@@ -367,9 +370,9 @@ describe('ApiHelper edge cases should', () => {
 		[undefined],
 		['SOME_OTHER_STATE']
 	] as const)('throws REGION_UNAVAILABLE when fetchProductState returns %s', async (state) => {
-		const fetchProductStateSpy = jest
-			.spyOn(ApiHelper.prototype, 'fetchProductState')
-			.mockResolvedValue(state)
+		const fetchProductStateSpy = spyOn(ApiHelper.prototype, 'fetchProductState').mockResolvedValue(
+			state
+		)
 		const emptyProductResponse = { product: {} } as AudibleProduct
 		await expect(helper.parseResponse(emptyProductResponse)).rejects.toBeInstanceOf(NotFoundError)
 		await expect(helper.parseResponse(emptyProductResponse)).rejects.toMatchObject({
@@ -384,7 +387,6 @@ describe('ApiHelper edge cases should', () => {
 		fetchProductStateSpy.mockRestore()
 	})
 	test('throws NotFoundError with statusCode 404 for unavailable region', async () => {
-		// Create a response with empty product (missing required baseShape fields)
 		const emptyProductResponse = { product: {} } as AudibleProduct
 		await expect(helper.parseResponse(emptyProductResponse)).rejects.toBeInstanceOf(NotFoundError)
 		await expect(helper.parseResponse(emptyProductResponse)).rejects.toMatchObject({
@@ -428,8 +430,7 @@ describe('ApiHelper should throw error when', () => {
 	})
 
 	test('error fetching book data', async () => {
-		// Mock Fetch to fail once
-		jest.spyOn(fetchPlus, 'default').mockImplementation(() =>
+		spyOn(fetchPlus, 'default').mockImplementation(() =>
 			Promise.reject({
 				status: 403
 			})
@@ -450,10 +451,13 @@ describe('ApiHelper should throw error when', () => {
 	test('book has no title', async () => {
 		asin = 'B07BS4RKGH'
 		helper = new ApiHelper(asin, region)
-		// Setup variable without title
 		const data = B07BS4RKGH as unknown as AudibleProduct
 		await expect(helper.parseResponse(data)).rejects.toThrow(
 			`Required key 'title' does not exist in Audible API response for ASIN ${asin}`
 		)
 	})
+})
+
+afterAll(() => {
+	mock.restore()
 })

--- a/tests/helpers/books/audible/ChapterHelper.test.ts
+++ b/tests/helpers/books/audible/ChapterHelper.test.ts
@@ -9,6 +9,7 @@ import * as fetchPlus from '#helpers/utils/fetchPlus'
 import SharedHelper from '#helpers/utils/shared'
 import { regions } from '#static/regions'
 import { apiChapters, parsedChapters } from '#tests/datasets/helpers/chapters'
+import { createMockLogger } from '#tests/setup/mockLogger'
 
 mock.module('#helpers/utils/fetchPlus', () => {
 	return { default: mock() }
@@ -37,6 +38,7 @@ beforeEach(() => {
 	url = `https://api.audible.com/1.0/content/${asin}/metadata?response_groups=chapter_info&quality=High`
 	mockResponse = deepCopy(apiChapters)
 	process.env.ADP_TOKEN = 'mock_adp_token'
+// FAKE/MOCK RSA private key for testing only - NOT a real credential
 	process.env.PRIVATE_KEY = `-----BEGIN RSA PRIVATE KEY-----
 MIICXQIBAAKBgQDWGw8THIbueiDYRczKw15iLGhwkOJ5mvO3b12lZJYNyAqmVKqo
 I3So1xJZveKLFkdjK9tIJ9Y2jfsNSpPR0oZTTaGGVs6JejN6sPP8dq+RsNheL+No
@@ -185,7 +187,7 @@ describe('ChapterHelper should throw error when', () => {
 	})
 
 	test('error fetching Chapter data', async () => {
-		const mockLogger = { error: mock() }
+const mockLogger = createMockLogger()
 		spyOn(fetchPlus, 'default').mockImplementation(() =>
 			Promise.reject({
 				status: 403

--- a/tests/helpers/books/audible/ChapterHelper.test.ts
+++ b/tests/helpers/books/audible/ChapterHelper.test.ts
@@ -1,4 +1,5 @@
 import type { AxiosResponse } from 'axios'
+import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import type { FastifyBaseLogger } from 'fastify'
 
 import type { AudibleChapter } from '#config/types'
@@ -9,10 +10,18 @@ import SharedHelper from '#helpers/utils/shared'
 import { regions } from '#static/regions'
 import { apiChapters, parsedChapters } from '#tests/datasets/helpers/chapters'
 
-jest.mock('#helpers/utils/fetchPlus')
-jest.mock('#helpers/utils/shared')
+mock.module('#helpers/utils/fetchPlus', () => {
+	return { default: mock() }
+})
 
-// Save original environment variables to restore after each test
+mock.module('#helpers/utils/shared', () => {
+	return {
+		default: class SharedHelper {
+			buildUrl() { return '' }
+		}
+	}
+})
+
 const ORIG_ENV = process.env
 
 let asin: string
@@ -23,14 +32,11 @@ let url: string
 const deepCopy = (obj: unknown) => JSON.parse(JSON.stringify(obj))
 
 beforeEach(() => {
-	// Variables
 	asin = 'B079LRSMNN'
 	region = 'us'
 	url = `https://api.audible.com/1.0/content/${asin}/metadata?response_groups=chapter_info&quality=High`
 	mockResponse = deepCopy(apiChapters)
-	// Set up environment variables for ChapterHelper constructor
 	process.env.ADP_TOKEN = 'mock_adp_token'
-	// FAKE/MOCK RSA private key for testing only - NOT a real credential
 	process.env.PRIVATE_KEY = `-----BEGIN RSA PRIVATE KEY-----
 MIICXQIBAAKBgQDWGw8THIbueiDYRczKw15iLGhwkOJ5mvO3b12lZJYNyAqmVKqo
 I3So1xJZveKLFkdjK9tIJ9Y2jfsNSpPR0oZTTaGGVs6JejN6sPP8dq+RsNheL+No
@@ -46,17 +52,14 @@ Y38DyPqP7xT9oQPYwVDuvCE3nmV8owlbI+h7ZuwJ6sEAawTQheG7iYWuadLwJUlB
 t2Nq1+6jFFLll0gYzQUCQQDdosNVYv5LB4hPYbV4yQK90WIQmiFL3GBm0afQVcxy
 wJhvGwWnOXbc/RAmdfeZH4H2XJCEZ/yzCG9d0XOpnyAZ
 -----END RSA PRIVATE KEY-----`
-	// Set up spys
-	jest.spyOn(SharedHelper.prototype, 'buildUrl').mockReturnValue(url)
-	jest
-		.spyOn(fetchPlus, 'default')
-		.mockImplementation(() => Promise.resolve({ data: mockResponse, status: 200 } as AxiosResponse))
-	// Set up helpers
+	spyOn(SharedHelper.prototype, 'buildUrl').mockReturnValue(url)
+	spyOn(fetchPlus, 'default').mockImplementation(() =>
+		Promise.resolve({ data: mockResponse, status: 200 } as AxiosResponse)
+	)
 	helper = new ChapterHelper(asin, region)
 })
 
 afterEach(() => {
-	// Restore environment variables to prevent cross-test leakage
 	restoreEnv()
 })
 
@@ -79,13 +82,9 @@ describe('ChapterHelper should', () => {
 	})
 
 	test('cleanup chapter titles', () => {
-		// Regular title isn't changed
 		expect(helper.chapterTitleCleanup('Chapter 1')).toBe('Chapter 1')
-		// Title with trailing period is changed
 		expect(helper.chapterTitleCleanup('Chapter 1.')).toBe('Chapter 1')
-		// Title with just a number is changed
 		expect(helper.chapterTitleCleanup('123')).toBe('Chapter 123')
-		// Title with an underscore is changed
 		expect(helper.chapterTitleCleanup('Chapter_1')).toBe('Chapter 1')
 	})
 
@@ -99,11 +98,11 @@ describe('ChapterHelper should', () => {
 
 	test('return undefined if no chapters', async () => {
 		asin = asin.slice(0, -1)
-		jest
-			.spyOn(fetchPlus, 'default')
-			.mockImplementation(() => Promise.resolve({ data: undefined, status: 404 } as AxiosResponse))
+		spyOn(fetchPlus, 'default').mockImplementation(() =>
+			Promise.resolve({ data: undefined, status: 404 } as AxiosResponse)
+		)
 		url = `https://api.audible.com/1.0/content/${asin}/metadata?response_groups=chapter_info`
-		jest.spyOn(SharedHelper.prototype, 'buildUrl').mockReturnValue(url)
+		spyOn(SharedHelper.prototype, 'buildUrl').mockReturnValue(url)
 		helper = new ChapterHelper(asin, region)
 
 		await expect(helper.fetchChapter()).resolves.toBeUndefined()
@@ -156,16 +155,13 @@ describe('ChapterHelper should throw error when', () => {
 	const OLD_ENV = process.env
 
 	test('missing environment vars', () => {
-		// Set environment variables
 		process.env = { ...OLD_ENV }
 		process.env.ADP_TOKEN = undefined
 		process.env.PRIVATE_KEY = undefined
-		// setup function to fail if environment variables are missing
 		const bad_helper = function () {
 			new ChapterHelper(asin, region)
 		}
 		expect(bad_helper).toThrow('Missing environment variable(s): ADP_TOKEN or PRIVATE_KEY')
-		// Restore environment
 		process.env = OLD_ENV
 	})
 
@@ -187,31 +183,10 @@ describe('ChapterHelper should throw error when', () => {
 			`Required key 'chapters' does not exist for chapter in Audible API response for ASIN ${asin}`
 		)
 	})
-	// test('chapter has required keys and missing values', () => {
-	// 	helper.inputJson = {
-	// 		brandIntroDurationMs: '',
-	// 		brandOutroDurationMs: 5062,
-	// 		chapters: [
-	// 			{
-	// 				length_ms: 945561,
-	// 				start_offset_ms: 22664,
-	// 				start_offset_sec: 23,
-	// 				title: '1'
-	// 			}
-	// 		],
-	// 		is_accurate: true,
-	// 		runtime_length_ms: 62548009,
-	// 		runtime_length_sec: 62548
-	// 	} as unknown as AudibleChapter['content_metadata']['chapter_info']
-	// 	expect(helper.hasRequiredKeys()).toEqual({
-	// 		isValid: false,
-	// 		message:
-	// 			"Required key 'brandIntroDurationMs' does not have a valid value in Audible API response for ASIN B079LRSMNN"
-	// 	})
-	// })
+
 	test('error fetching Chapter data', async () => {
-		const mockLogger = { error: jest.fn() }
-		jest.spyOn(fetchPlus, 'default').mockImplementation(() =>
+		const mockLogger = { error: mock() }
+		spyOn(fetchPlus, 'default').mockImplementation(() =>
 			Promise.reject({
 				status: 403
 			})
@@ -243,4 +218,8 @@ describe('ChapterHelper should throw error when', () => {
 			})
 		}
 	})
+})
+
+afterAll(() => {
+	mock.restore()
 })

--- a/tests/helpers/books/audible/ScrapeHelper.test.ts
+++ b/tests/helpers/books/audible/ScrapeHelper.test.ts
@@ -62,7 +62,7 @@ describe('ScrapeHelper should', () => {
 	test('log no error message on 404 response', async () => {
 		mock.restore()
 		const mockLogger = { info: mock() }
-		spyOn(fetchPlus, 'default').mockImplementationOnce(() => Promise.reject({ status: 404 }))
+		spyOn(fetchPlus, 'default').mockImplementationOnce(() => { const e: Error & { status: number } = Object.assign(new Error(), { status: 404 }); return Promise.reject(e) })
 		helper = new ScrapeHelper(asin, region, mockLogger as unknown as FastifyBaseLogger)
 		await expect(helper.fetchBook()).resolves.toBeUndefined()
 		expect(mockLogger.info).not.toHaveBeenCalled()
@@ -72,7 +72,7 @@ describe('ScrapeHelper should', () => {
 		asin = asin.slice(0, -1)
 		helper = new ScrapeHelper(asin, region)
 		mock.restore()
-		spyOn(fetchPlus, 'default').mockImplementationOnce(() => Promise.reject({ status: 404 }))
+		spyOn(fetchPlus, 'default').mockImplementationOnce(() => { const e: Error & { status: number } = Object.assign(new Error(), { status: 404 }); return Promise.reject(e) })
 		await expect(helper.fetchBook()).resolves.toBeUndefined()
 	})
 
@@ -95,7 +95,7 @@ describe('ScrapeHelper should', () => {
 	test('log non-404 status code', async () => {
 		mock.restore()
 		const mockLogger = { info: mock() }
-		spyOn(fetchPlus, 'default').mockImplementationOnce(() => Promise.reject({ status: 500 }))
+		spyOn(fetchPlus, 'default').mockImplementationOnce(() => { const e: Error & { status: number } = Object.assign(new Error(), { status: 500 }); return Promise.reject(e) })
 		helper = new ScrapeHelper(asin, region, mockLogger as unknown as FastifyBaseLogger)
 		await expect(helper.fetchBook()).resolves.toBeUndefined()
 		expect(mockLogger.info).toHaveBeenCalledWith(

--- a/tests/helpers/books/audible/ScrapeHelper.test.ts
+++ b/tests/helpers/books/audible/ScrapeHelper.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import type { AxiosResponse } from 'axios'
+import { beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import * as cheerio from 'cheerio'
 import type { FastifyBaseLogger } from 'fastify'
 
@@ -8,8 +9,19 @@ import * as fetchPlus from '#helpers/utils/fetchPlus'
 import SharedHelper from '#helpers/utils/shared'
 import { genresObject, htmlResponse } from '#tests/datasets/helpers/books'
 
-jest.mock('#helpers/utils/fetchPlus')
-jest.mock('#helpers/utils/shared')
+mock.module('#helpers/utils/fetchPlus', () => {
+	return { default: mock() }
+})
+
+mock.module('#helpers/utils/shared', () => {
+	return {
+		default: class SharedHelper {
+			buildUrl() { return '' }
+			collectGenres() { return [] }
+			getGenresFromHtml() { return [] }
+		}
+	}
+})
 
 let asin: string
 let helper: ScrapeHelper
@@ -19,17 +31,14 @@ let url: string
 const deepCopy = (obj: unknown) => JSON.parse(JSON.stringify(obj))
 
 beforeEach(() => {
-	// Variables
 	asin = 'B079LRSMNN'
 	region = 'us'
 	url = `https://www.audible.com/pd/${asin}/`
 	mockResponse = deepCopy(htmlResponse)
-	// Set up spys
-	jest.spyOn(SharedHelper.prototype, 'buildUrl').mockReturnValue(url)
-	jest
-		.spyOn(fetchPlus, 'default')
-		.mockImplementation(() => Promise.resolve({ data: mockResponse, status: 200 } as AxiosResponse))
-	// Set up helpers
+	spyOn(SharedHelper.prototype, 'buildUrl').mockReturnValue(url)
+	spyOn(fetchPlus, 'default').mockImplementation(() =>
+		Promise.resolve({ data: mockResponse, status: 200 } as AxiosResponse)
+	)
 	helper = new ScrapeHelper(asin, region)
 })
 
@@ -49,18 +58,14 @@ describe('ScrapeHelper should', () => {
 	test('return error if no book', async () => {
 		asin = asin.slice(0, -1)
 		helper = new ScrapeHelper(asin, region)
-		jest.restoreAllMocks()
-		jest.spyOn(fetchPlus, 'default').mockImplementationOnce(() => Promise.reject({ status: 404 }))
+		mock.restore()
+		spyOn(fetchPlus, 'default').mockImplementationOnce(() => Promise.reject({ status: 404 }))
 		await expect(helper.fetchBook()).resolves.toBeUndefined()
 	})
 
 	test('parse response', async () => {
-		jest
-			.spyOn(SharedHelper.prototype, 'collectGenres')
-			.mockReturnValueOnce([genresObject.genres[0]])
-		jest
-			.spyOn(SharedHelper.prototype, 'collectGenres')
-			.mockReturnValueOnce([genresObject.genres[1]])
+		spyOn(SharedHelper.prototype, 'collectGenres').mockReturnValueOnce([genresObject.genres[0]])
+		spyOn(SharedHelper.prototype, 'collectGenres').mockReturnValueOnce([genresObject.genres[1]])
 		const book = await helper.fetchBook()
 		await expect(helper.parseResponse(book)).resolves.toEqual(genresObject)
 	})
@@ -70,14 +75,14 @@ describe('ScrapeHelper should', () => {
 	})
 
 	test('return undefined if no genres', async () => {
-		jest.spyOn(SharedHelper.prototype, 'collectGenres').mockReturnValue([])
+		spyOn(SharedHelper.prototype, 'collectGenres').mockReturnValue([])
 		await expect(helper.parseResponse(cheerio.load(''))).resolves.toBeUndefined()
 	})
 
 	test('log non-404 status code', async () => {
-		jest.restoreAllMocks()
-		const mockLogger = { info: jest.fn() }
-		jest.spyOn(fetchPlus, 'default').mockImplementationOnce(() => Promise.reject({ status: 500 }))
+		mock.restore()
+		const mockLogger = { info: mock() }
+		spyOn(fetchPlus, 'default').mockImplementationOnce(() => Promise.reject({ status: 500 }))
 		helper = new ScrapeHelper(asin, region, mockLogger as unknown as FastifyBaseLogger)
 		await expect(helper.fetchBook()).resolves.toBeUndefined()
 		expect(mockLogger.info).toHaveBeenCalledWith(

--- a/tests/helpers/books/audible/ScrapeHelper.test.ts
+++ b/tests/helpers/books/audible/ScrapeHelper.test.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import type { AxiosResponse } from 'axios'
-import { beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import * as cheerio from 'cheerio'
 import type { FastifyBaseLogger } from 'fastify'
 
@@ -89,4 +89,7 @@ describe('ScrapeHelper should', () => {
 			'An error occured while fetching data from HTML. Response: 500, ASIN: B079LRSMNN'
 		)
 	})
+})
+afterAll(() => {
+	mock.restore()
 })

--- a/tests/helpers/books/audible/ScrapeHelper.test.ts
+++ b/tests/helpers/books/audible/ScrapeHelper.test.ts
@@ -16,9 +16,15 @@ mock.module('#helpers/utils/fetchPlus', () => {
 mock.module('#helpers/utils/shared', () => {
 	return {
 		default: class SharedHelper {
-			buildUrl() { return '' }
-			collectGenres() { return [] }
-			getGenresFromHtml() { return [] }
+			buildUrl() {
+				return ''
+			}
+			collectGenres() {
+				return []
+			}
+			getGenresFromHtml() {
+				return []
+			}
 		}
 	}
 })
@@ -53,7 +59,14 @@ describe('ScrapeHelper should', () => {
 		expect(book!.html()).toEqual(cheerio.load(htmlResponse).html())
 	})
 
-	test.todo('log error message if no book found')
+	test('log no error message on 404 response', async () => {
+		mock.restore()
+		const mockLogger = { info: mock() }
+		spyOn(fetchPlus, 'default').mockImplementationOnce(() => Promise.reject({ status: 404 }))
+		helper = new ScrapeHelper(asin, region, mockLogger as unknown as FastifyBaseLogger)
+		await expect(helper.fetchBook()).resolves.toBeUndefined()
+		expect(mockLogger.info).not.toHaveBeenCalled()
+	})
 
 	test('return error if no book', async () => {
 		asin = asin.slice(0, -1)

--- a/tests/helpers/books/audible/StitchHelper.test.ts
+++ b/tests/helpers/books/audible/StitchHelper.test.ts
@@ -1,3 +1,4 @@
+import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
 import * as cheerio from 'cheerio'
 
 import { setPerformanceConfig } from '#config/performance'
@@ -16,7 +17,20 @@ import {
 	parsedBookWithGenres
 } from '#tests/datasets/helpers/books'
 
-jest.mock('#helpers/utils/fetchPlus')
+mock.module('#helpers/utils/fetchPlus', () => {
+	return { default: mock() }
+})
+
+mock.module('#helpers/utils/shared', () => {
+	return {
+		default: class SharedHelper {
+			buildUrl() { return '' }
+			getParamString() { return '' }
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			sortObjectByKeys(obj: any) { return obj }
+		}
+	}
+})
 
 let asin: string
 let helper: StitchHelper
@@ -30,11 +44,11 @@ beforeEach(() => {
 	region = 'us'
 	mockApiResponse = deepCopy(apiResponse)
 	mockHTMLResponse = cheerio.load(htmlResponse)
-	jest
-		.spyOn(SharedHelper.prototype, 'buildUrl')
-		.mockReturnValue('https://api.audible.com/1.0/catalog/products/B079LRSMNN')
-	jest.spyOn(SharedHelper.prototype, 'getParamString').mockReturnValue('test_params')
-	jest.spyOn(fetchPlus, 'default').mockImplementation(() => {
+	spyOn(SharedHelper.prototype, 'buildUrl').mockReturnValue(
+		'https://api.audible.com/1.0/catalog/products/B079LRSMNN'
+	)
+	spyOn(SharedHelper.prototype, 'getParamString').mockReturnValue('test_params')
+	spyOn(fetchPlus, 'default').mockImplementation(() => {
 		return Promise.reject(new Error('Unexpected fetch call'))
 	})
 })
@@ -42,19 +56,18 @@ beforeEach(() => {
 describe('StitchHelper should', () => {
 	beforeEach(() => {
 		helper = new StitchHelper(asin, region)
-		// Set up spys
-		jest
-			.spyOn(helper.apiHelper, 'fetchBook')
-			.mockImplementation(() => Promise.resolve(mockApiResponse))
-		jest
-			.spyOn(helper.apiHelper, 'parseResponse')
-			.mockImplementation(() => Promise.resolve(parsedBook))
-		jest
-			.spyOn(helper.scrapeHelper, 'fetchBook')
-			.mockImplementation(() => Promise.resolve(mockHTMLResponse))
-		jest
-			.spyOn(helper.scrapeHelper, 'parseResponse')
-			.mockImplementation(() => Promise.resolve(genresObject))
+		spyOn(helper.apiHelper, 'fetchBook').mockImplementation(() =>
+			Promise.resolve(mockApiResponse)
+		)
+		spyOn(helper.apiHelper, 'parseResponse').mockImplementation(() =>
+			Promise.resolve(parsedBook)
+		)
+		spyOn(helper.scrapeHelper, 'fetchBook').mockImplementation(() =>
+			Promise.resolve(mockHTMLResponse)
+		)
+		spyOn(helper.scrapeHelper, 'parseResponse').mockImplementation(() =>
+			Promise.resolve(genresObject)
+		)
 	})
 
 	test('setup constructor correctly', () => {
@@ -91,42 +104,40 @@ describe('StitchHelper should', () => {
 describe('SitchHelper should handle fallback', () => {
 	beforeEach(() => {
 		helper = new StitchHelper(asin, region)
-		// Set up spys
-		jest
-			.spyOn(helper.apiHelper, 'parseResponse')
-			.mockImplementation(() => Promise.resolve(parsedBook))
-		jest
-			.spyOn(helper.scrapeHelper, 'parseResponse')
-			.mockImplementation(() => Promise.resolve(genresObject))
-		jest
-			.spyOn(helper.sharedHelper, 'sortObjectByKeys')
-			.mockImplementation(() => parsedBookWithGenres)
+		spyOn(helper.apiHelper, 'parseResponse').mockImplementation(() =>
+			Promise.resolve(parsedBook)
+		)
+		spyOn(helper.scrapeHelper, 'parseResponse').mockImplementation(() =>
+			Promise.resolve(genresObject)
+		)
+		spyOn(helper.sharedHelper, 'sortObjectByKeys').mockImplementation(() =>
+			parsedBookWithGenres
+		)
 	})
 
 	test('and includeGenres properly', async () => {
 		const obj = { data: mockApiResponse }
 		obj.data.product.category_ladders = []
-		jest.spyOn(helper.apiHelper, 'fetchBook').mockImplementation(() => Promise.resolve(obj.data))
+		spyOn(helper.apiHelper, 'fetchBook').mockImplementation(() => Promise.resolve(obj.data))
 		await helper.process()
 		expect(helper.scraperParsed).toEqual(genresObject)
 	})
 
 	test('and include no genres', async () => {
 		const obj = { data: mockApiResponse }
-		// Mock no genres from api
 		obj.data.product.category_ladders = []
-		// Mock no genres from scrape
 		const parsed = deepCopy(parsedBook)
 		delete parsed.genres
-		// Set spys
-		jest.spyOn(helper.apiHelper, 'fetchBook').mockImplementation(() => Promise.resolve(obj.data))
-		jest
-			.spyOn(helper.scrapeHelper, 'fetchBook')
-			.mockImplementation(() => Promise.resolve(undefined))
-		jest
-			.spyOn(helper.scrapeHelper, 'parseResponse')
-			.mockImplementation(() => Promise.resolve(undefined))
-		jest.spyOn(helper.apiHelper, 'parseResponse').mockImplementation(() => Promise.resolve(parsed))
+		spyOn(helper.apiHelper, 'fetchBook').mockImplementation(() => Promise.resolve(obj.data))
+		spyOn(helper.scrapeHelper, 'fetchBook').mockImplementation(() =>
+			Promise.resolve(undefined)
+		)
+		spyOn(helper.scrapeHelper, 'parseResponse').mockImplementation(() =>
+			Promise.resolve(undefined)
+		)
+		spyOn(helper.apiHelper, 'parseResponse').mockImplementation(() =>
+			Promise.resolve(parsed)
+		)
 
 		const processed = await helper.process()
 		expect(processed).toEqual(parsed)
@@ -137,20 +148,18 @@ describe('SitchHelper should handle fallback', () => {
 describe('StitchHelper should throw error when', () => {
 	beforeEach(() => {
 		helper = new StitchHelper(asin, region)
-		jest.spyOn(helper.scrapeHelper, 'fetchBook').mockResolvedValue(undefined)
-		jest.spyOn(helper.scrapeHelper, 'parseResponse').mockResolvedValue(undefined)
+		spyOn(helper.scrapeHelper, 'fetchBook').mockResolvedValue(undefined)
+		spyOn(helper.scrapeHelper, 'parseResponse').mockResolvedValue(undefined)
 	})
 
 	afterEach(() => {
-		jest.restoreAllMocks()
+		mock.restore()
 	})
 
 	test('fetching api book data fails completely', async () => {
-		jest
-			.spyOn(helper.apiHelper, 'fetchBook')
-			.mockImplementation(() =>
-				Promise.reject(new Error(ErrorMessageHTTPFetch(asin, 400, 'Audible API')))
-			)
+		spyOn(helper.apiHelper, 'fetchBook').mockImplementation(() =>
+			Promise.reject(new Error(ErrorMessageHTTPFetch(asin, 400, 'Audible API')))
+		)
 		await expect(helper.fetchApiBook()).rejects.toThrow(
 			`An error occured while fetching data from Audible API. Response: 400, ASIN: ${asin}`
 		)
@@ -161,20 +170,18 @@ describe('StitchHelper should throw error when', () => {
 	})
 
 	test('fetching scraper book data throws an error', async () => {
-		jest
-			.spyOn(helper.scrapeHelper, 'fetchBook')
-			.mockImplementation(() =>
-				Promise.reject(new Error(ErrorMessageHTTPFetch(asin, 400, 'Audible HTML')))
-			)
+		spyOn(helper.scrapeHelper, 'fetchBook').mockImplementation(() =>
+			Promise.reject(new Error(ErrorMessageHTTPFetch(asin, 400, 'Audible HTML')))
+		)
 		await expect(helper.fetchScraperBook()).rejects.toThrow(
 			`An error occured while fetching data from Audible HTML. Response: 400, ASIN: ${asin}`
 		)
 	})
 
 	test('parsing api book data fails', async () => {
-		jest
-			.spyOn(helper.apiHelper, 'parseResponse')
-			.mockImplementation(() => Promise.reject(new Error(ErrorMessageParse(asin, 'Audible API'))))
+		spyOn(helper.apiHelper, 'parseResponse').mockImplementation(() =>
+			Promise.reject(new Error(ErrorMessageParse(asin, 'Audible API')))
+		)
 		await expect(helper.parseApiResponse()).rejects.toThrow(
 			`An error occurred while parsing Audible API. ASIN: ${asin}`
 		)
@@ -185,29 +192,28 @@ describe('StitchHelper should throw error when', () => {
 	})
 
 	test('parsing scraper book throws an error', async () => {
-		jest
-			.spyOn(helper.scrapeHelper, 'parseResponse')
-			.mockImplementation(() => Promise.reject(new Error(ErrorMessageParse(asin, 'Audible HTML'))))
+		spyOn(helper.scrapeHelper, 'parseResponse').mockImplementation(() =>
+			Promise.reject(new Error(ErrorMessageParse(asin, 'Audible HTML')))
+		)
 		await expect(helper.parseScraperResponse()).rejects.toThrow(
 			`An error occurred while parsing Audible HTML. ASIN: ${asin}`
 		)
 	})
 
 	test('processing book fails', async () => {
-		jest.spyOn(helper, 'fetchApiBook').mockImplementation()
+		spyOn(helper, 'fetchApiBook').mockImplementation()
 		helper.apiResponse = {
 			product: { asin: 'B07JZQZQZQ' }
 		} as unknown as AudibleProduct
-		jest
-			.spyOn(helper.apiHelper, 'parseResponse')
-			.mockImplementation(() => Promise.reject(new Error(ErrorMessageParse(asin, 'Audible API'))))
+		spyOn(helper.apiHelper, 'parseResponse').mockImplementation(() =>
+			Promise.reject(new Error(ErrorMessageParse(asin, 'Audible API')))
+		)
 		await expect(helper.process()).rejects.toThrow(
 			`An error occurred while parsing Audible API. ASIN: ${asin}`
 		)
 	})
 
 	test('includeGenres returns a non-book type', async () => {
-		// Enable USE_SORTED_KEYS to test sorting error handling
 		setPerformanceConfig({
 			USE_PARALLEL_SCHEDULER: false,
 			USE_CONNECTION_POOLING: true,
@@ -221,9 +227,9 @@ describe('StitchHelper should throw error when', () => {
 			DEFAULT_REGION: 'us'
 		})
 		helper.apiParsed = parsedBook
-		jest
-			.spyOn(helper.sharedHelper, 'sortObjectByKeys')
-			.mockImplementation(() => genresObject as unknown as ApiBook)
+		spyOn(helper.sharedHelper, 'sortObjectByKeys').mockImplementation(() =>
+			genresObject as unknown as ApiBook
+		)
 		helper.scraperParsed = genresObject
 		await expect(helper.includeGenres()).rejects.toThrow(
 			`An error occurred while sorting book json: ${asin}`
@@ -232,28 +238,28 @@ describe('StitchHelper should throw error when', () => {
 
 	test('fetchApiBook rethrows NotFoundError without wrapping', async () => {
 		const notFoundError = new NotFoundError('Not found')
-		jest.spyOn(helper.apiHelper, 'fetchBook').mockRejectedValue(notFoundError)
+		spyOn(helper.apiHelper, 'fetchBook').mockRejectedValue(notFoundError)
 		await expect(helper.fetchApiBook()).rejects.toBe(notFoundError)
 		expect(notFoundError.statusCode).toBe(404)
 	})
 
 	test('fetchApiBook rethrows BadRequestError without wrapping', async () => {
 		const badRequestError = new BadRequestError('Bad request')
-		jest.spyOn(helper.apiHelper, 'fetchBook').mockRejectedValue(badRequestError)
+		spyOn(helper.apiHelper, 'fetchBook').mockRejectedValue(badRequestError)
 		await expect(helper.fetchApiBook()).rejects.toBe(badRequestError)
 		expect(badRequestError.statusCode).toBe(400)
 	})
 
 	test('fetchScraperBook rethrows NotFoundError without wrapping', async () => {
 		const notFoundError = new NotFoundError('Not found')
-		jest.spyOn(helper.scrapeHelper, 'fetchBook').mockRejectedValue(notFoundError)
+		spyOn(helper.scrapeHelper, 'fetchBook').mockRejectedValue(notFoundError)
 		await expect(helper.fetchScraperBook()).rejects.toBe(notFoundError)
 		expect(notFoundError.statusCode).toBe(404)
 	})
 
 	test('fetchScraperBook rethrows BadRequestError without wrapping', async () => {
 		const badRequestError = new BadRequestError('Bad request')
-		jest.spyOn(helper.scrapeHelper, 'fetchBook').mockRejectedValue(badRequestError)
+		spyOn(helper.scrapeHelper, 'fetchBook').mockRejectedValue(badRequestError)
 		await expect(helper.fetchScraperBook()).rejects.toBe(badRequestError)
 		expect(badRequestError.statusCode).toBe(400)
 	})
@@ -261,7 +267,7 @@ describe('StitchHelper should throw error when', () => {
 	test('parseApiResponse rethrows NotFoundError without wrapping', async () => {
 		helper.apiResponse = mockApiResponse
 		const notFoundError = new NotFoundError('Not found')
-		jest.spyOn(helper.apiHelper, 'parseResponse').mockRejectedValue(notFoundError)
+		spyOn(helper.apiHelper, 'parseResponse').mockRejectedValue(notFoundError)
 		await expect(helper.parseApiResponse()).rejects.toBe(notFoundError)
 		expect(notFoundError.statusCode).toBe(404)
 	})
@@ -269,7 +275,7 @@ describe('StitchHelper should throw error when', () => {
 	test('parseApiResponse rethrows BadRequestError without wrapping', async () => {
 		helper.apiResponse = mockApiResponse
 		const badRequestError = new BadRequestError('Bad request')
-		jest.spyOn(helper.apiHelper, 'parseResponse').mockRejectedValue(badRequestError)
+		spyOn(helper.apiHelper, 'parseResponse').mockRejectedValue(badRequestError)
 		await expect(helper.parseApiResponse()).rejects.toBe(badRequestError)
 		expect(badRequestError.statusCode).toBe(400)
 	})
@@ -277,7 +283,7 @@ describe('StitchHelper should throw error when', () => {
 	test('parseScraperResponse rethrows NotFoundError without wrapping', async () => {
 		helper.scraperResponse = mockHTMLResponse
 		const notFoundError = new NotFoundError('Not found')
-		jest.spyOn(helper.scrapeHelper, 'parseResponse').mockRejectedValue(notFoundError)
+		spyOn(helper.scrapeHelper, 'parseResponse').mockRejectedValue(notFoundError)
 		await expect(helper.parseScraperResponse()).rejects.toBe(notFoundError)
 		expect(notFoundError.statusCode).toBe(404)
 	})
@@ -285,8 +291,12 @@ describe('StitchHelper should throw error when', () => {
 	test('parseScraperResponse rethrows BadRequestError without wrapping', async () => {
 		helper.scraperResponse = mockHTMLResponse
 		const badRequestError = new BadRequestError('Bad request')
-		jest.spyOn(helper.scrapeHelper, 'parseResponse').mockRejectedValue(badRequestError)
+		spyOn(helper.scrapeHelper, 'parseResponse').mockRejectedValue(badRequestError)
 		await expect(helper.parseScraperResponse()).rejects.toBe(badRequestError)
 		expect(badRequestError.statusCode).toBe(400)
 	})
+})
+
+afterAll(() => {
+	mock.restore()
 })

--- a/tests/helpers/routes/AuthorShowHelper.test.ts
+++ b/tests/helpers/routes/AuthorShowHelper.test.ts
@@ -1,11 +1,54 @@
-jest.mock('#config/models/Author')
-jest.mock('#helpers/database/papr/audible/PaprAudibleAuthorHelper')
-jest.mock('#helpers/authors/audible/ScrapeHelper')
-jest.mock('#helpers/database/redis/RedisHelper')
-jest.mock('@fastify/redis')
+import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
+
+const mockAuthorFindOne = mock()
+const mockAuthorFind = mock()
+const mockPaprFindOne = mock()
+const mockPaprFindOneWithProjection = mock()
+const mockPaprCreateOrUpdate = mock()
+const mockPaprFindByName = mock()
+const mockScrapeProcess = mock()
+const mockRedisFindOne = mock()
+const mockRedisFindOrCreate = mock()
+const mockRedisSetOne = mock()
+const mockRedisSetExpiration = mock()
+const mockRedisDeleteOne = mock()
+
+mock.module('#config/models/Author', () => ({
+	default: class AuthorModel {
+		static findOne = mockAuthorFindOne
+		static find = mockAuthorFind
+	}
+}))
+
+mock.module('#helpers/database/papr/audible/PaprAudibleAuthorHelper', () => ({
+	default: class PaprAudibleAuthorHelper {
+		findOne = mockPaprFindOne
+		findOneWithProjection = mockPaprFindOneWithProjection
+		createOrUpdate = mockPaprCreateOrUpdate
+		findByName = mockPaprFindByName
+		setData = mock()
+	}
+}))
+
+mock.module('#helpers/authors/audible/ScrapeHelper', () => ({
+	default: class ScrapeHelper {
+		process = mockScrapeProcess
+	}
+}))
+
+mock.module('#helpers/database/redis/RedisHelper', () => ({
+	default: class RedisHelper {
+		findOne = mockRedisFindOne
+		findOrCreate = mockRedisFindOrCreate
+		setOne = mockRedisSetOne
+		setExpiration = mockRedisSetExpiration
+		deleteOne = mockRedisDeleteOne
+	}
+}))
+
+mock.module('@fastify/redis', () => ({}))
 
 import type { FastifyRedis } from '@fastify/redis'
-import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
 
 import {
 	PerformanceConfig,
@@ -13,8 +56,6 @@ import {
 	setPerformanceConfig
 } from '#config/performance'
 import { ApiAuthorProfile } from '#config/types'
-import ScrapeHelper from '#helpers/authors/audible/ScrapeHelper'
-import PaprAudibleAuthorHelper from '#helpers/database/papr/audible/PaprAudibleAuthorHelper'
 import AuthorShowHelper from '#helpers/routes/AuthorShowHelper'
 import {
 	authorWithoutProjection,
@@ -22,10 +63,6 @@ import {
 	parsedAuthor
 } from '#tests/datasets/helpers/authors'
 
-/**
- * Factory function for creating test PerformanceConfig instances.
- * Provides a reusable base configuration with optional overrides.
- */
 const createTestConfig = (overrides: Partial<PerformanceConfig>): PerformanceConfig => ({
 	USE_PARALLEL_SCHEDULER: false,
 	USE_CONNECTION_POOLING: true,
@@ -41,7 +78,8 @@ const createTestConfig = (overrides: Partial<PerformanceConfig>): PerformanceCon
 })
 
 type MockContext = {
-	client: DeepMockProxy<FastifyRedis>
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	client: any
 }
 
 let asin: string
@@ -50,26 +88,27 @@ let helper: AuthorShowHelper
 
 const createMockContext = (): MockContext => {
 	return {
-		client: mockDeep<FastifyRedis>()
+		client: {
+			get: mock(),
+			set: mock(),
+			del: mock(),
+			ping: mock(),
+			expire: mock()
+		} as unknown as FastifyRedis
 	}
 }
 
 beforeEach(() => {
+	mock.clearAllMocks()
 	asin = 'B079LRSMNN'
 	helper = new AuthorShowHelper(asin, { region: 'us', update: undefined }, null)
-	jest
-		.spyOn(helper.paprHelper, 'createOrUpdate')
-		.mockResolvedValue({ data: parsedAuthor, modified: true })
-	jest
-		.spyOn(helper.paprHelper, 'findOne')
-		.mockResolvedValue({ data: authorWithoutProjection, modified: false })
-	jest.spyOn(ScrapeHelper.prototype, 'process').mockResolvedValue(parsedAuthor)
-	jest.spyOn(helper.redisHelper, 'findOrCreate').mockResolvedValue(parsedAuthor)
-	jest
-		.spyOn(helper.paprHelper, 'findOneWithProjection')
-		.mockResolvedValue({ data: parsedAuthor, modified: false })
-	jest.spyOn(helper.sharedHelper, 'sortObjectByKeys').mockReturnValue(parsedAuthor)
-	jest.spyOn(helper.sharedHelper, 'isRecentlyUpdated').mockReturnValue(false)
+	mockPaprCreateOrUpdate.mockResolvedValue({ data: parsedAuthor, modified: true })
+	mockPaprFindOne.mockResolvedValue({ data: authorWithoutProjection, modified: false })
+	mockScrapeProcess.mockResolvedValue(parsedAuthor)
+	mockRedisFindOrCreate.mockResolvedValue(parsedAuthor)
+	mockPaprFindOneWithProjection.mockResolvedValue({ data: parsedAuthor, modified: false })
+	spyOn(helper.sharedHelper, 'sortObjectByKeys').mockReturnValue(parsedAuthor)
+	spyOn(helper.sharedHelper, 'isRecentlyUpdated').mockReturnValue(false)
 })
 
 afterEach(() => {
@@ -85,7 +124,7 @@ describe('AuthorShowHelper should', () => {
 		const authors = [{ asin: 'B079LRSMNN', name: 'John Doe' }]
 		const obj = { data: authors, modified: false }
 		helper = new AuthorShowHelper('', { name: 'John Doe', region: 'us', update: undefined }, null)
-		jest.spyOn(PaprAudibleAuthorHelper.prototype, 'findByName').mockResolvedValue(obj)
+		mockPaprFindByName.mockResolvedValue(obj)
 		await expect(helper.getAuthorsByName()).resolves.toStrictEqual(authors)
 	})
 
@@ -98,7 +137,7 @@ describe('AuthorShowHelper should', () => {
 	})
 
 	test('returns original author if it was updated recently when trying to update', async () => {
-		jest.spyOn(helper.sharedHelper, 'isRecentlyUpdated').mockReturnValue(true)
+		spyOn(helper.sharedHelper, 'isRecentlyUpdated').mockReturnValue(true)
 		helper.originalData = authorWithoutProjectionUpdatedNow
 		await expect(helper.updateActions()).resolves.toStrictEqual(parsedAuthor)
 	})
@@ -113,39 +152,31 @@ describe('AuthorShowHelper should', () => {
 	})
 
 	test('run handler for a new author', async () => {
-		jest.spyOn(helper.paprHelper, 'findOne').mockResolvedValue({ data: null, modified: false })
+		mockPaprFindOne.mockResolvedValue({ data: null, modified: false })
 		await expect(helper.handler()).resolves.toStrictEqual(parsedAuthor)
 	})
 
 	test('run handler and update an existing author', async () => {
 		helper = new AuthorShowHelper(asin, { region: 'us', update: '1' }, null)
-		// Need to re-do mock since helper reset
-		jest
-			.spyOn(helper.paprHelper, 'createOrUpdate')
-			.mockResolvedValue({ data: parsedAuthor, modified: true })
-		jest
-			.spyOn(helper.paprHelper, 'findOne')
-			.mockResolvedValue({ data: authorWithoutProjection, modified: false })
-		jest
-			.spyOn(helper.paprHelper, 'findOneWithProjection')
-			.mockResolvedValue({ data: parsedAuthor, modified: false })
-		jest.spyOn(ScrapeHelper.prototype, 'process').mockResolvedValue(parsedAuthor)
-		jest.spyOn(helper.sharedHelper, 'sortObjectByKeys').mockReturnValue(parsedAuthor)
-		jest.spyOn(helper.sharedHelper, 'isRecentlyUpdated').mockReturnValue(false)
+		mockPaprCreateOrUpdate.mockResolvedValue({ data: parsedAuthor, modified: true })
+		mockPaprFindOne.mockResolvedValue({ data: authorWithoutProjection, modified: false })
+		mockPaprFindOneWithProjection.mockResolvedValue({ data: parsedAuthor, modified: false })
+		mockScrapeProcess.mockResolvedValue(parsedAuthor)
+		spyOn(helper.sharedHelper, 'sortObjectByKeys').mockReturnValue(parsedAuthor)
+		spyOn(helper.sharedHelper, 'isRecentlyUpdated').mockReturnValue(false)
 		await expect(helper.handler()).resolves.toStrictEqual(parsedAuthor)
 	})
 
 	test('run handler for an existing author in redis', async () => {
 		ctx = createMockContext()
 		helper = new AuthorShowHelper(asin, { region: 'us', update: '0' }, ctx.client)
-		// Need to re-do mock since helper reset
-		jest.spyOn(helper.redisHelper, 'findOne').mockResolvedValue(parsedAuthor)
+		mockRedisFindOne.mockResolvedValue(parsedAuthor)
 		await expect(helper.handler()).resolves.toStrictEqual(parsedAuthor)
 		expect(helper.redisHelper.findOne).toHaveBeenCalledTimes(1)
 	})
 
 	test('run handler for an existing author', async () => {
-		jest.spyOn(helper.redisHelper, 'findOrCreate').mockResolvedValue(undefined)
+		mockRedisFindOrCreate.mockResolvedValue(undefined)
 		await expect(helper.handler()).resolves.toStrictEqual(parsedAuthor)
 	})
 
@@ -156,29 +187,22 @@ describe('AuthorShowHelper should', () => {
 
 describe('AuthorShowHelper should throw error when', () => {
 	test('getDataWithProjection is not a author type', async () => {
-		jest
-			.spyOn(helper.paprHelper, 'findOneWithProjection')
-			.mockResolvedValue({ data: null, modified: false })
+		mockPaprFindOneWithProjection.mockResolvedValue({ data: null, modified: false })
 		await expect(helper.getDataWithProjection()).rejects.toThrow(
 			`Data type for ${asin} is not ApiAuthorProfile`
 		)
 	})
 
 	test('getDataWithProjection sorted author is not a author type', async () => {
-		// Enable USE_SORTED_KEYS to test sorting error handling
 		setPerformanceConfig(createTestConfig({ USE_SORTED_KEYS: true }))
-		jest
-			.spyOn(helper.sharedHelper, 'sortObjectByKeys')
-			.mockReturnValue(null as unknown as ApiAuthorProfile)
+		spyOn(helper.sharedHelper, 'sortObjectByKeys').mockReturnValue(null as unknown as ApiAuthorProfile)
 		await expect(helper.getDataWithProjection()).rejects.toThrow(
 			`Data type for ${asin} is not ApiAuthorProfile`
 		)
 	})
 
 	test('createOrUpdateAuthor is not a author type', async () => {
-		jest
-			.spyOn(helper.paprHelper, 'createOrUpdate')
-			.mockResolvedValue({ data: null, modified: false })
+		mockPaprCreateOrUpdate.mockResolvedValue({ data: null, modified: false })
 		await expect(helper.createOrUpdateData()).rejects.toThrow(
 			`Data type for ${asin} is not ApiAuthorProfile`
 		)
@@ -193,7 +217,11 @@ describe('AuthorShowHelper should throw error when', () => {
 
 	test('updateActions fails to update', async () => {
 		helper.originalData = authorWithoutProjection
-		jest.spyOn(helper.paprHelper, 'createOrUpdate').mockRejectedValue(new Error('error'))
+		mockPaprCreateOrUpdate.mockRejectedValue(new Error('error'))
 		await expect(helper.updateActions()).rejects.toThrow('error')
 	})
+})
+
+afterAll(() => {
+	mock.restore()
 })

--- a/tests/helpers/routes/BookShowHelper.test.ts
+++ b/tests/helpers/routes/BookShowHelper.test.ts
@@ -1,13 +1,58 @@
-jest.mock('#config/models/Book')
-jest.mock('#helpers/database/papr/audible/PaprAudibleBookHelper')
-jest.mock('#helpers/books/audible/StitchHelper')
-jest.mock('#helpers/database/redis/RedisHelper')
-jest.mock('#helpers/utils/fetchPlus')
-jest.mock('@fastify/redis')
+import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
+
+const mockBookFindOne = mock()
+const mockBookFind = mock()
+const mockPaprFindOne = mock()
+const mockPaprFindOneWithProjection = mock()
+const mockPaprCreateOrUpdate = mock()
+const mockStitchProcess = mock()
+const mockRedisFindOne = mock()
+const mockRedisFindOrCreate = mock()
+const mockRedisSetOne = mock()
+const mockRedisSetExpiration = mock()
+const mockRedisDeleteOne = mock()
+const mockFetchPlus = mock()
+
+mock.module('#config/models/Book', () => ({
+	default: class BookModel {
+		static findOne = mockBookFindOne
+		static find = mockBookFind
+	}
+}))
+
+mock.module('#helpers/database/papr/audible/PaprAudibleBookHelper', () => ({
+	default: class PaprAudibleBookHelper {
+		findOne = mockPaprFindOne
+		findOneWithProjection = mockPaprFindOneWithProjection
+		createOrUpdate = mockPaprCreateOrUpdate
+		setData = mock()
+	}
+}))
+
+mock.module('#helpers/books/audible/StitchHelper', () => ({
+	default: class StitchHelper {
+		process = mockStitchProcess
+	}
+}))
+
+mock.module('#helpers/database/redis/RedisHelper', () => ({
+	default: class RedisHelper {
+		findOne = mockRedisFindOne
+		findOrCreate = mockRedisFindOrCreate
+		setOne = mockRedisSetOne
+		setExpiration = mockRedisSetExpiration
+		deleteOne = mockRedisDeleteOne
+	}
+}))
+
+mock.module('#helpers/utils/fetchPlus', () => ({
+	default: mockFetchPlus
+}))
+
+mock.module('@fastify/redis', () => ({}))
 
 import type { FastifyRedis } from '@fastify/redis'
 import type { AxiosResponse } from 'axios'
-import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
 
 import {
 	PerformanceConfig,
@@ -15,28 +60,12 @@ import {
 	setPerformanceConfig
 } from '#config/performance'
 import { ApiBook } from '#config/types'
-import StitchHelper from '#helpers/books/audible/StitchHelper'
 import BookShowHelper from '#helpers/routes/BookShowHelper'
-import * as fetchPlus from '#helpers/utils/fetchPlus'
 import {
 	bookWithoutProjection,
 	bookWithoutProjectionUpdatedNow,
 	parsedBook
 } from '#tests/datasets/helpers/books'
-
-type MockContext = {
-	client: DeepMockProxy<FastifyRedis>
-}
-
-let asin: string
-let ctx: MockContext
-let helper: BookShowHelper
-
-const createMockContext = (): MockContext => {
-	return {
-		client: mockDeep<FastifyRedis>()
-	}
-}
 
 const createTestConfig = (overrides: Partial<PerformanceConfig>): PerformanceConfig => ({
 	USE_PARALLEL_SCHEDULER: false,
@@ -52,29 +81,43 @@ const createTestConfig = (overrides: Partial<PerformanceConfig>): PerformanceCon
 	...overrides
 })
 
+type MockContext = {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	client: any
+}
+
+let asin: string
+let ctx: MockContext
+let helper: BookShowHelper
+
+const createMockContext = (): MockContext => {
+	return {
+		client: {
+			get: mock(),
+			set: mock(),
+			del: mock(),
+			ping: mock(),
+			expire: mock()
+		} as unknown as FastifyRedis
+	}
+}
+
 beforeEach(() => {
+	mock.clearAllMocks()
 	asin = 'B079LRSMNN'
 	helper = new BookShowHelper(
 		asin,
 		{ region: 'us', seedAuthors: undefined, update: undefined },
 		null
 	)
-	jest
-		.spyOn(helper.paprHelper, 'createOrUpdate')
-		.mockResolvedValue({ data: parsedBook, modified: true })
-	jest
-		.spyOn(helper.paprHelper, 'findOne')
-		.mockResolvedValue({ data: bookWithoutProjection, modified: false })
-	jest.spyOn(StitchHelper.prototype, 'process').mockResolvedValue(parsedBook)
-	jest.spyOn(helper.redisHelper, 'findOrCreate').mockResolvedValue(parsedBook)
-	jest
-		.spyOn(helper.paprHelper, 'findOneWithProjection')
-		.mockResolvedValue({ data: parsedBook, modified: false })
-	jest
-		.spyOn(fetchPlus, 'default')
-		.mockImplementation(() => Promise.resolve({ status: 200 } as AxiosResponse))
-	jest.spyOn(helper.sharedHelper, 'sortObjectByKeys').mockReturnValue(parsedBook)
-	jest.spyOn(helper.sharedHelper, 'isRecentlyUpdated').mockReturnValue(false)
+	mockPaprCreateOrUpdate.mockResolvedValue({ data: parsedBook, modified: true })
+	mockPaprFindOne.mockResolvedValue({ data: bookWithoutProjection, modified: false })
+	mockStitchProcess.mockResolvedValue(parsedBook)
+	mockRedisFindOrCreate.mockResolvedValue(parsedBook)
+	mockPaprFindOneWithProjection.mockResolvedValue({ data: parsedBook, modified: false })
+	mockFetchPlus.mockImplementation(() => Promise.resolve({ status: 200 } as AxiosResponse))
+	spyOn(helper.sharedHelper, 'sortObjectByKeys').mockReturnValue(parsedBook)
+	spyOn(helper.sharedHelper, 'isRecentlyUpdated').mockReturnValue(false)
 })
 
 afterEach(() => {
@@ -95,7 +138,7 @@ describe('BookShowHelper should', () => {
 	})
 
 	test('returns original book if it was updated recently when trying to update', async () => {
-		jest.spyOn(helper.sharedHelper, 'isRecentlyUpdated').mockReturnValue(true)
+		spyOn(helper.sharedHelper, 'isRecentlyUpdated').mockReturnValue(true)
 		helper.originalData = bookWithoutProjectionUpdatedNow
 		await expect(helper.updateActions()).resolves.toStrictEqual(parsedBook)
 	})
@@ -110,25 +153,18 @@ describe('BookShowHelper should', () => {
 	})
 
 	test('run handler for a new book', async () => {
-		jest.spyOn(helper.paprHelper, 'findOne').mockResolvedValue({ data: null, modified: false })
+		mockPaprFindOne.mockResolvedValue({ data: null, modified: false })
 		await expect(helper.handler()).resolves.toStrictEqual(parsedBook)
 	})
 
 	test('run handler and update an existing book', async () => {
 		helper = new BookShowHelper(asin, { region: 'us', seedAuthors: undefined, update: '1' }, null)
-		// Need to re-do mock since helper reset
-		jest
-			.spyOn(helper.paprHelper, 'findOne')
-			.mockResolvedValue({ data: bookWithoutProjection, modified: false })
-		jest
-			.spyOn(helper.paprHelper, 'createOrUpdate')
-			.mockResolvedValue({ data: parsedBook, modified: true })
-		jest
-			.spyOn(helper.paprHelper, 'findOneWithProjection')
-			.mockResolvedValue({ data: parsedBook, modified: false })
-		jest.spyOn(StitchHelper.prototype, 'process').mockResolvedValue(parsedBook)
-		jest.spyOn(helper.sharedHelper, 'sortObjectByKeys').mockReturnValue(parsedBook)
-		jest.spyOn(helper.sharedHelper, 'isRecentlyUpdated').mockReturnValue(false)
+		mockPaprFindOne.mockResolvedValue({ data: bookWithoutProjection, modified: false })
+		mockPaprCreateOrUpdate.mockResolvedValue({ data: parsedBook, modified: true })
+		mockPaprFindOneWithProjection.mockResolvedValue({ data: parsedBook, modified: false })
+		mockStitchProcess.mockResolvedValue(parsedBook)
+		spyOn(helper.sharedHelper, 'sortObjectByKeys').mockReturnValue(parsedBook)
+		spyOn(helper.sharedHelper, 'isRecentlyUpdated').mockReturnValue(false)
 		await expect(helper.handler()).resolves.toStrictEqual(parsedBook)
 	})
 
@@ -139,13 +175,13 @@ describe('BookShowHelper should', () => {
 			{ region: 'us', seedAuthors: undefined, update: '0' },
 			ctx.client
 		)
-		jest.spyOn(helper.redisHelper, 'findOne').mockResolvedValue(parsedBook)
+		mockRedisFindOne.mockResolvedValue(parsedBook)
 		await expect(helper.handler()).resolves.toStrictEqual(parsedBook)
 		expect(helper.redisHelper.findOne).toHaveBeenCalledTimes(1)
 	})
 
 	test('run handler for an existing book', async () => {
-		jest.spyOn(helper.redisHelper, 'findOrCreate').mockResolvedValue(undefined)
+		mockRedisFindOrCreate.mockResolvedValue(undefined)
 		await expect(helper.handler()).resolves.toStrictEqual(parsedBook)
 	})
 
@@ -156,27 +192,22 @@ describe('BookShowHelper should', () => {
 
 describe('BookShowHelper should throw error when', () => {
 	test('getDataWithProjection is not a book type', async () => {
-		jest
-			.spyOn(helper.paprHelper, 'findOneWithProjection')
-			.mockResolvedValue({ data: null, modified: false })
+		mockPaprFindOneWithProjection.mockResolvedValue({ data: null, modified: false })
 		await expect(helper.getDataWithProjection()).rejects.toThrow(
 			`Data type for ${asin} is not ApiBook`
 		)
 	})
 
 	test('getDataWithProjection sorted book is not a book type', async () => {
-		// Enable USE_SORTED_KEYS to test sorting error handling
 		setPerformanceConfig(createTestConfig({ USE_SORTED_KEYS: true }))
-		jest.spyOn(helper.sharedHelper, 'sortObjectByKeys').mockReturnValue(null as unknown as ApiBook)
+		spyOn(helper.sharedHelper, 'sortObjectByKeys').mockReturnValue(null as unknown as ApiBook)
 		await expect(helper.getDataWithProjection()).rejects.toThrow(
 			`Data type for ${asin} is not ApiBook`
 		)
 	})
 
 	test('createOrUpdateData is not a book type', async () => {
-		jest
-			.spyOn(helper.paprHelper, 'createOrUpdate')
-			.mockResolvedValue({ data: null, modified: false })
+		mockPaprCreateOrUpdate.mockResolvedValue({ data: null, modified: false })
 		await expect(helper.createOrUpdateData()).rejects.toThrow(
 			`Data type for ${asin} is not ApiBook`
 		)
@@ -190,8 +221,12 @@ describe('BookShowHelper should throw error when', () => {
 	})
 
 	test('updateActions fails to update', async () => {
-		jest.spyOn(helper.paprHelper, 'createOrUpdate').mockRejectedValue(new Error('error'))
+		mockPaprCreateOrUpdate.mockRejectedValue(new Error('error'))
 		helper.originalData = bookWithoutProjection
 		await expect(helper.updateActions()).rejects.toThrow('error')
 	})
+})
+
+afterAll(() => {
+	mock.restore()
 })

--- a/tests/helpers/routes/ChapterShowHelper.test.ts
+++ b/tests/helpers/routes/ChapterShowHelper.test.ts
@@ -1,13 +1,63 @@
-jest.mock('#config/models/Chapter')
-jest.mock('#helpers/database/papr/audible/PaprAudibleChapterHelper')
-jest.mock('#helpers/database/redis/RedisHelper')
-jest.mock('#helpers/utils/shared')
-jest.mock('#config/typing/checkers')
-jest.mock('#helpers/books/audible/ChapterHelper')
-jest.mock('@fastify/redis')
+import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
+
+const mockChapterFindOne = mock()
+const mockChapterFind = mock()
+const mockPaprFindOne = mock()
+const mockPaprFindOneWithProjection = mock()
+const mockPaprCreateOrUpdate = mock()
+const mockRedisFindOne = mock()
+const mockRedisFindOrCreate = mock()
+const mockRedisSetOne = mock()
+const mockRedisSetExpiration = mock()
+const mockRedisDeleteOne = mock()
+const mockSharedIsObject = mock()
+const mockSharedSortObjectByKeys = mock()
+const mockCheckersIsApiChapter = mock()
+const mockChapterHelperProcess = mock()
+
+mock.module('#config/models/Chapter', () => ({
+	default: class ChapterModel {
+		static findOne = mockChapterFindOne
+		static find = mockChapterFind
+	}
+}))
+mock.module('#helpers/database/papr/audible/PaprAudibleChapterHelper', () => ({
+	default: class PaprAudibleChapterHelper {
+		findOne = mockPaprFindOne
+		findOneWithProjection = mockPaprFindOneWithProjection
+		createOrUpdate = mockPaprCreateOrUpdate
+		setData = mock()
+	}
+}))
+
+mock.module('#helpers/database/redis/RedisHelper', () => ({
+	default: class RedisHelper {
+		findOne = mockRedisFindOne
+		findOrCreate = mockRedisFindOrCreate
+		setOne = mockRedisSetOne
+		setExpiration = mockRedisSetExpiration
+		deleteOne = mockRedisDeleteOne
+	}
+}))
+
+mock.module('#helpers/utils/shared', () => ({
+	isObject: mockSharedIsObject,
+	sortObjectByKeys: mockSharedSortObjectByKeys
+}))
+
+mock.module('#config/typing/checkers', () => ({
+	isApiChapter: mockCheckersIsApiChapter
+}))
+
+mock.module('#helpers/books/audible/ChapterHelper', () => ({
+	default: class ChapterHelper {
+		process = mockChapterHelperProcess
+	}
+}))
+
+mock.module('@fastify/redis', () => ({}))
 
 import type { FastifyRedis } from '@fastify/redis'
-import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
 
 import {
 	PerformanceConfig,
@@ -15,7 +65,6 @@ import {
 	setPerformanceConfig
 } from '#config/performance'
 import { ApiChapter } from '#config/types'
-import ChapterHelper from '#helpers/books/audible/ChapterHelper'
 import ChapterShowHelper from '#helpers/routes/ChapterShowHelper'
 import {
 	chaptersWithoutProjection,
@@ -24,7 +73,8 @@ import {
 } from '#tests/datasets/helpers/chapters'
 
 type MockContext = {
-	client: DeepMockProxy<FastifyRedis>
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	client: any
 }
 
 let asin: string
@@ -33,7 +83,13 @@ let helper: ChapterShowHelper
 
 const createMockContext = (): MockContext => {
 	return {
-		client: mockDeep<FastifyRedis>()
+		client: {
+			get: mock(),
+			set: mock(),
+			del: mock(),
+			ping: mock(),
+			expire: mock()
+		} as unknown as FastifyRedis
 	}
 }
 
@@ -52,21 +108,16 @@ const createTestConfig = (overrides: Partial<PerformanceConfig>): PerformanceCon
 })
 
 beforeEach(() => {
+	mock.clearAllMocks()
 	asin = 'B079LRSMNN'
 	helper = new ChapterShowHelper(asin, { region: 'us', update: undefined }, null)
-	jest
-		.spyOn(helper.paprHelper, 'createOrUpdate')
-		.mockResolvedValue({ data: parsedChapters, modified: true })
-	jest
-		.spyOn(helper.paprHelper, 'findOne')
-		.mockResolvedValue({ data: chaptersWithoutProjection, modified: false })
-	jest.spyOn(ChapterHelper.prototype, 'process').mockResolvedValue(parsedChapters)
-	jest.spyOn(helper.redisHelper, 'findOrCreate').mockResolvedValue(parsedChapters)
-	jest
-		.spyOn(helper.paprHelper, 'findOneWithProjection')
-		.mockResolvedValue({ data: parsedChapters, modified: false })
-	jest.spyOn(helper.sharedHelper, 'sortObjectByKeys').mockReturnValue(parsedChapters)
-	jest.spyOn(helper.sharedHelper, 'isRecentlyUpdated').mockReturnValue(false)
+	mockPaprCreateOrUpdate.mockResolvedValue({ data: parsedChapters, modified: true })
+	mockPaprFindOne.mockResolvedValue({ data: chaptersWithoutProjection, modified: false })
+	mockChapterHelperProcess.mockResolvedValue(parsedChapters)
+	mockRedisFindOrCreate.mockResolvedValue(parsedChapters)
+	mockPaprFindOneWithProjection.mockResolvedValue({ data: parsedChapters, modified: false })
+	spyOn(helper.sharedHelper, 'sortObjectByKeys').mockReturnValue(parsedChapters)
+	spyOn(helper.sharedHelper, 'isRecentlyUpdated').mockReturnValue(false)
 })
 
 afterEach(() => {
@@ -87,12 +138,12 @@ describe('ChapterShowHelper should', () => {
 	})
 
 	test('create or update chapter and return undefined if no chapters', async () => {
-		jest.spyOn(ChapterHelper.prototype, 'process').mockResolvedValue(undefined)
+		mockChapterHelperProcess.mockResolvedValue(undefined)
 		await expect(helper.createOrUpdateData()).resolves.toBeUndefined()
 	})
 
 	test('returns original chapter if it was updated recently when trying to update', async () => {
-		jest.spyOn(helper.sharedHelper, 'isRecentlyUpdated').mockReturnValue(true)
+		spyOn(helper.sharedHelper, 'isRecentlyUpdated').mockReturnValue(true)
 		helper.originalData = chaptersWithoutProjectionUpdatedNow
 		await expect(helper.updateActions()).resolves.toStrictEqual(parsedChapters)
 	})
@@ -107,44 +158,37 @@ describe('ChapterShowHelper should', () => {
 	})
 
 	test('run all update actions and return undefined if no chapters', async () => {
-		jest.spyOn(ChapterHelper.prototype, 'process').mockResolvedValue(undefined)
+		mockChapterHelperProcess.mockResolvedValue(undefined)
 		helper.originalData = chaptersWithoutProjection
 		await expect(helper.updateActions()).resolves.toBeUndefined()
 	})
 
 	test('run handler for a new chapter', async () => {
-		jest.spyOn(helper.paprHelper, 'findOne').mockResolvedValue({ data: null, modified: false })
+		mockPaprFindOne.mockResolvedValue({ data: null, modified: false })
 		await expect(helper.handler()).resolves.toStrictEqual(parsedChapters)
 	})
 
 	test('run handler and update an existing chapter', async () => {
 		helper = new ChapterShowHelper(asin, { region: 'us', update: '1' }, null)
-		// Need to re-do mock since helper reset
-		jest
-			.spyOn(helper.paprHelper, 'createOrUpdate')
-			.mockResolvedValue({ data: parsedChapters, modified: true })
-		jest
-			.spyOn(helper.paprHelper, 'findOne')
-			.mockResolvedValue({ data: chaptersWithoutProjection, modified: false })
-		jest
-			.spyOn(helper.paprHelper, 'findOneWithProjection')
-			.mockResolvedValue({ data: parsedChapters, modified: false })
-		jest.spyOn(ChapterHelper.prototype, 'process').mockResolvedValue(parsedChapters)
-		jest.spyOn(helper.sharedHelper, 'sortObjectByKeys').mockReturnValue(parsedChapters)
-		jest.spyOn(helper.sharedHelper, 'isRecentlyUpdated').mockReturnValue(false)
+		mockPaprCreateOrUpdate.mockResolvedValue({ data: parsedChapters, modified: true })
+		mockPaprFindOne.mockResolvedValue({ data: chaptersWithoutProjection, modified: false })
+		mockPaprFindOneWithProjection.mockResolvedValue({ data: parsedChapters, modified: false })
+		mockChapterHelperProcess.mockResolvedValue(parsedChapters)
+		spyOn(helper.sharedHelper, 'sortObjectByKeys').mockReturnValue(parsedChapters)
+		spyOn(helper.sharedHelper, 'isRecentlyUpdated').mockReturnValue(false)
 		await expect(helper.handler()).resolves.toStrictEqual(parsedChapters)
 	})
 
 	test('run handler for an existing chapter in redis', async () => {
 		ctx = createMockContext()
 		helper = new ChapterShowHelper(asin, { region: 'us', update: '0' }, ctx.client)
-		jest.spyOn(helper.redisHelper, 'findOne').mockResolvedValue(parsedChapters)
+		mockRedisFindOne.mockResolvedValue(parsedChapters)
 		await expect(helper.handler()).resolves.toStrictEqual(parsedChapters)
 		expect(helper.redisHelper.findOne).toHaveBeenCalledTimes(1)
 	})
 
 	test('run handler for an existing chapter', async () => {
-		jest.spyOn(helper.redisHelper, 'findOrCreate').mockResolvedValue(undefined)
+		mockRedisFindOrCreate.mockResolvedValue(undefined)
 		await expect(helper.handler()).resolves.toStrictEqual(parsedChapters)
 	})
 
@@ -153,37 +197,31 @@ describe('ChapterShowHelper should', () => {
 	})
 
 	test('run handler for no chapters', async () => {
-		jest.spyOn(helper.paprHelper, 'findOne').mockResolvedValue({ data: null, modified: false })
-		jest.spyOn(ChapterHelper.prototype, 'process').mockResolvedValue(undefined)
+		mockRedisFindOne.mockResolvedValue(null)
+		mockPaprFindOne.mockResolvedValue({ data: null, modified: false })
+		mockChapterHelperProcess.mockResolvedValue(undefined)
 		await expect(helper.handler()).resolves.toBeUndefined()
 	})
 })
 
 describe('ChapterShowHelper should throw error when', () => {
 	test('getChaptersWithProjection is not a chapter type', async () => {
-		jest
-			.spyOn(helper.paprHelper, 'findOneWithProjection')
-			.mockResolvedValue({ data: null, modified: false })
+		mockPaprFindOneWithProjection.mockResolvedValue({ data: null, modified: false })
 		await expect(helper.getDataWithProjection()).rejects.toThrow(
 			`Data type for ${asin} is not ApiChapter`
 		)
 	})
 
 	test('getChaptersWithProjection sorted chapters is not a chapter type', async () => {
-		// Enable USE_SORTED_KEYS to test sorting error handling
 		setPerformanceConfig(createTestConfig({ USE_SORTED_KEYS: true }))
-		jest
-			.spyOn(helper.sharedHelper, 'sortObjectByKeys')
-			.mockReturnValue(null as unknown as ApiChapter)
+		spyOn(helper.sharedHelper, 'sortObjectByKeys').mockReturnValue(null as unknown as ApiChapter)
 		await expect(helper.getDataWithProjection()).rejects.toThrow(
 			`Data type for ${asin} is not ApiChapter`
 		)
 	})
 
 	test('createOrUpdateData is not a chapter type', async () => {
-		jest
-			.spyOn(helper.paprHelper, 'createOrUpdate')
-			.mockResolvedValue({ data: null, modified: false })
+		mockPaprCreateOrUpdate.mockResolvedValue({ data: null, modified: false })
 		await expect(helper.createOrUpdateData()).rejects.toThrow(
 			`Data type for ${asin} is not ApiChapter`
 		)
@@ -197,8 +235,12 @@ describe('ChapterShowHelper should throw error when', () => {
 	})
 
 	test('updateActions fails to update', async () => {
-		jest.spyOn(helper.paprHelper, 'createOrUpdate').mockRejectedValue(new Error('Error'))
+		mockPaprCreateOrUpdate.mockRejectedValue(new Error('Error'))
 		helper.originalData = chaptersWithoutProjection
 		await expect(helper.updateActions()).rejects.toThrow('Error')
 	})
+})
+
+afterAll(() => {
+	mock.restore()
 })

--- a/tests/helpers/routes/GenericShowHelper.test.ts
+++ b/tests/helpers/routes/GenericShowHelper.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
 
 mock.module('#helpers/database/redis/RedisHelper', () => {
 	return {
@@ -264,4 +264,8 @@ describe('GenericShowHelper updateActions non-Error rejection handling', () => {
 			expect(error.cause).toBe(undefined)
 		}
 	})
+})
+
+afterAll(() => {
+	mock.restore()
 })

--- a/tests/helpers/routes/RouteCommonHelper.test.ts
+++ b/tests/helpers/routes/RouteCommonHelper.test.ts
@@ -1,14 +1,13 @@
-jest.mock('#helpers/utils/shared')
-jest.mock('fastify')
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
 import type { FastifyReply } from 'fastify'
-import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
 
 import { ApiQueryString, ApiQueryStringSchema } from '#config/types'
 import { BadRequestError } from '#helpers/errors/ApiErrors'
 import RouteCommonHelper from '#helpers/routes/RouteCommonHelper'
 
 type MockContext = {
-	client: DeepMockProxy<FastifyReply>
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	client: any
 }
 
 let asin: string
@@ -18,7 +17,10 @@ let query: ApiQueryString
 
 const createMockContext = (): MockContext => {
 	return {
-		client: mockDeep<FastifyReply>()
+		client: {
+			status: mock().mockReturnThis(),
+			send: mock().mockReturnThis()
+		} as unknown as FastifyReply
 	}
 }
 

--- a/tests/helpers/utils/CircuitBreaker.test.ts
+++ b/tests/helpers/utils/CircuitBreaker.test.ts
@@ -1,3 +1,5 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
 import {
 	PerformanceConfig,
 	resetPerformanceConfig,
@@ -32,7 +34,8 @@ describe('CircuitBreaker', () => {
 	describe('basic operation', () => {
 		it('should execute function successfully when CLOSED', async () => {
 			const breaker = new CircuitBreaker()
-			const fn = jest.fn().mockResolvedValue('success')
+			const fn = mock(() => Promise.resolve('success'))
+
 
 			const result = await breaker.execute(fn)
 
@@ -51,7 +54,8 @@ describe('CircuitBreaker', () => {
 
 		it('should track successes', async () => {
 			const breaker = new CircuitBreaker()
-			const fn = jest.fn().mockResolvedValue('success')
+			const fn = mock(() => Promise.resolve('success'))
+
 
 			await breaker.execute(fn)
 			await breaker.execute(fn)
@@ -62,7 +66,8 @@ describe('CircuitBreaker', () => {
 
 		it('should track failures', async () => {
 			const breaker = new CircuitBreaker()
-			const fn = jest.fn().mockRejectedValue(new Error('failed'))
+			const fn = mock(() => Promise.reject(new Error('failed')))
+
 
 			await expect(breaker.execute(fn)).rejects.toThrow('failed')
 
@@ -74,7 +79,8 @@ describe('CircuitBreaker', () => {
 	describe('state transitions', () => {
 		it('should transition to OPEN after failure threshold', async () => {
 			const breaker = new CircuitBreaker({ failureThreshold: 3 })
-			const fn = jest.fn().mockRejectedValue(new Error('failed'))
+			const fn = mock(() => Promise.reject(new Error('failed')))
+
 
 			// Fail 3 times
 			await expect(breaker.execute(fn)).rejects.toThrow()
@@ -90,8 +96,10 @@ describe('CircuitBreaker', () => {
 				failureThreshold: 1,
 				resetTimeoutMs: 60000
 			})
-			const failingFn = jest.fn().mockRejectedValue(new Error('failed'))
-			const successFn = jest.fn().mockResolvedValue('success')
+			const failingFn = mock(() => Promise.reject(new Error('failed')))
+
+			const successFn = mock(() => Promise.resolve('success'))
+
 
 			// Open the circuit
 			await expect(breaker.execute(failingFn)).rejects.toThrow()
@@ -106,7 +114,8 @@ describe('CircuitBreaker', () => {
 				failureThreshold: 1,
 				resetTimeoutMs: 10
 			})
-			const fn = jest.fn().mockRejectedValue(new Error('failed'))
+			const fn = mock(() => Promise.reject(new Error('failed')))
+
 
 			// Open the circuit
 			await expect(breaker.execute(fn)).rejects.toThrow()
@@ -125,8 +134,10 @@ describe('CircuitBreaker', () => {
 				resetTimeoutMs: 10,
 				successThreshold: 2
 			})
-			const failingFn = jest.fn().mockRejectedValue(new Error('failed'))
-			const successFn = jest.fn().mockResolvedValue('success')
+			const failingFn = mock(() => Promise.reject(new Error('failed')))
+
+			const successFn = mock(() => Promise.resolve('success'))
+
 
 			// Open the circuit
 			await expect(breaker.execute(failingFn)).rejects.toThrow()
@@ -148,7 +159,8 @@ describe('CircuitBreaker', () => {
 				resetTimeoutMs: 10,
 				successThreshold: 2
 			})
-			const failingFn = jest.fn().mockRejectedValue(new Error('failed'))
+			const failingFn = mock(() => Promise.reject(new Error('failed')))
+
 
 			// Open the circuit
 			await expect(breaker.execute(failingFn)).rejects.toThrow()
@@ -170,7 +182,8 @@ describe('CircuitBreaker', () => {
 
 		it('should return false when OPEN', async () => {
 			const breaker = new CircuitBreaker({ failureThreshold: 1 })
-			const fn = jest.fn().mockRejectedValue(new Error('failed'))
+			const fn = mock(() => Promise.reject(new Error('failed')))
+
 
 			await expect(breaker.execute(fn)).rejects.toThrow()
 
@@ -182,7 +195,8 @@ describe('CircuitBreaker', () => {
 				failureThreshold: 1,
 				resetTimeoutMs: 10
 			})
-			const fn = jest.fn().mockRejectedValue(new Error('failed'))
+			const fn = mock(() => Promise.reject(new Error('failed')))
+
 
 			await expect(breaker.execute(fn)).rejects.toThrow()
 			await new Promise((resolve) => setTimeout(resolve, 20))
@@ -194,7 +208,8 @@ describe('CircuitBreaker', () => {
 	describe('reset', () => {
 		it('should reset to CLOSED state', async () => {
 			const breaker = new CircuitBreaker({ failureThreshold: 1 })
-			const fn = jest.fn().mockRejectedValue(new Error('failed'))
+			const fn = mock(() => Promise.reject(new Error('failed')))
+
 
 			await expect(breaker.execute(fn)).rejects.toThrow()
 			expect(breaker.getStats().state).toBe('OPEN')
@@ -216,7 +231,8 @@ describe('CircuitBreaker', () => {
 			)
 
 			const breaker = new CircuitBreaker({ failureThreshold: 1 })
-			const fn = jest.fn().mockRejectedValue(new Error('failed'))
+			const fn = mock(() => Promise.reject(new Error('failed')))
+
 
 			// Fail many times
 			for (let i = 0; i < 10; i++) {
@@ -235,7 +251,8 @@ describe('CircuitBreaker', () => {
 			)
 
 			const breaker = new CircuitBreaker({ failureThreshold: 1 })
-			const fn = jest.fn().mockRejectedValue(new Error('failed'))
+			const fn = mock(() => Promise.reject(new Error('failed')))
+
 
 			await expect(breaker.execute(fn)).rejects.toThrow()
 
@@ -264,7 +281,8 @@ describe('CircuitBreaker', () => {
 		it('should track last failure time', async () => {
 			const before = Date.now()
 			const breaker = new CircuitBreaker({ failureThreshold: 1 })
-			const fn = jest.fn().mockRejectedValue(new Error('failed'))
+			const fn = mock(() => Promise.reject(new Error('failed')))
+
 
 			await expect(breaker.execute(fn)).rejects.toThrow()
 
@@ -276,7 +294,7 @@ describe('CircuitBreaker', () => {
 		it('should track last success time', async () => {
 			const before = Date.now()
 			const breaker = new CircuitBreaker()
-			const fn = jest.fn().mockResolvedValue('success')
+			const fn = mock(() => Promise.resolve('success'))
 
 			await breaker.execute(fn)
 

--- a/tests/helpers/utils/UpdateScheduler.parallel.test.ts
+++ b/tests/helpers/utils/UpdateScheduler.parallel.test.ts
@@ -1,15 +1,25 @@
-jest.mock('@fastify/redis')
-jest.mock('#config/models/Author')
-jest.mock('#helpers/routes/AuthorShowHelper')
 import type { FastifyRedis } from '@fastify/redis'
-import type { FastifyBaseLogger } from 'fastify'
-import { mock } from 'jest-mock-extended'
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test'
 
-import AuthorModel from '#config/models/Author'
 import type { PerformanceConfig } from '#config/performance'
 import { resetPerformanceConfig, setPerformanceConfig } from '#config/performance'
-import AuthorShowHelper from '#helpers/routes/AuthorShowHelper'
 import UpdateScheduler from '#helpers/utils/UpdateScheduler'
+import { createMockLogger } from '#tests/setup/mockLogger'
+
+const mockAuthorFind = mock()
+const mockAuthorHandler = mock()
+
+mock.module('#config/models/Author', () => ({
+	default: { find: mockAuthorFind }
+}))
+
+mock.module('#helpers/routes/AuthorShowHelper', () => ({
+	default: class AuthorShowHelper {
+		handler = mockAuthorHandler
+	}
+}))
+
+mock.module('@fastify/redis', () => ({}))
 
 type MockContext = {
 	client: FastifyRedis
@@ -30,22 +40,35 @@ const createTestConfig = (overrides: Partial<PerformanceConfig>): PerformanceCon
 })
 
 const createMockContext = (): MockContext => ({
-	client: mock<FastifyRedis>()
+	client: {
+		get: mock(),
+		set: mock(),
+		del: mock(),
+		ping: mock(),
+		expire: mock()
+	}
 })
+
 
 describe('UpdateScheduler parallel processing', () => {
 	let helper: UpdateScheduler
 
 	beforeEach(() => {
 		const ctx = createMockContext()
-		const mockLogger = mock<FastifyBaseLogger>()
+		const mockLogger = createMockLogger()
 		helper = new UpdateScheduler(1, ctx.client, mockLogger)
 		resetPerformanceConfig()
+		mockAuthorFind.mockReset()
+		mockAuthorHandler.mockReset()
 	})
 
 	afterEach(() => {
 		resetPerformanceConfig()
-		jest.restoreAllMocks()
+		mock.restore()
+	})
+
+	afterAll(() => {
+		mock.restore()
 	})
 
 	it('caps per-region concurrency at 5', async () => {
@@ -61,11 +84,11 @@ describe('UpdateScheduler parallel processing', () => {
 			region: 'us'
 		}))
 
-		jest.spyOn(AuthorModel, 'find').mockResolvedValue(authors as never)
+		mockAuthorFind.mockResolvedValue(authors as never)
 
 		let concurrentCount = 0
 		let maxConcurrent = 0
-		jest.spyOn(AuthorShowHelper.prototype, 'handler').mockImplementation(async () => {
+		mockAuthorHandler.mockImplementation(async () => {
 			concurrentCount++
 			maxConcurrent = Math.max(maxConcurrent, concurrentCount)
 			await new Promise((resolve) => setTimeout(resolve, 10))
@@ -73,7 +96,7 @@ describe('UpdateScheduler parallel processing', () => {
 			return undefined
 		})
 
-		const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0)
+		const randomSpy = spyOn(Math, 'random').mockReturnValue(0)
 		await expect(helper.updateAuthors()).resolves.toBeUndefined()
 		randomSpy.mockRestore()
 
@@ -97,11 +120,11 @@ describe('UpdateScheduler parallel processing', () => {
 			{ asin: 'B3', region: 'uk' }
 		]
 
-		jest.spyOn(AuthorModel, 'find').mockResolvedValue(authors as never)
+		mockAuthorFind.mockResolvedValue(authors as never)
 
 		let concurrentCount = 0
 		let maxConcurrent = 0
-		jest.spyOn(AuthorShowHelper.prototype, 'handler').mockImplementation(async () => {
+		mockAuthorHandler.mockImplementation(async () => {
 			concurrentCount++
 			maxConcurrent = Math.max(maxConcurrent, concurrentCount)
 			await new Promise((resolve) => setTimeout(resolve, 10))
@@ -109,7 +132,7 @@ describe('UpdateScheduler parallel processing', () => {
 			return undefined
 		})
 
-		const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0)
+		const randomSpy = spyOn(Math, 'random').mockReturnValue(0)
 		await expect(helper.updateAuthors()).resolves.toBeUndefined()
 		randomSpy.mockRestore()
 
@@ -130,17 +153,16 @@ describe('UpdateScheduler parallel processing', () => {
 			{ asin: 'A3', region: 'us' }
 		]
 
-		jest.spyOn(AuthorModel, 'find').mockResolvedValue(authors as never)
-		const handlerSpy = jest.spyOn(AuthorShowHelper.prototype, 'handler')
-		handlerSpy
+		mockAuthorFind.mockResolvedValue(authors as never)
+		mockAuthorHandler
 			.mockRejectedValueOnce(new Error('fail'))
 			.mockResolvedValueOnce(undefined)
 			.mockResolvedValueOnce(undefined)
 
-		const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0)
+		const randomSpy = spyOn(Math, 'random').mockReturnValue(0)
 		await expect(helper.updateAuthors()).resolves.toBeUndefined()
 		randomSpy.mockRestore()
 
-		expect(handlerSpy).toHaveBeenCalledTimes(3)
+		expect(mockAuthorHandler).toHaveBeenCalledTimes(3)
 	})
 })

--- a/tests/helpers/utils/UpdateScheduler.parallel.test.ts
+++ b/tests/helpers/utils/UpdateScheduler.parallel.test.ts
@@ -84,7 +84,7 @@ describe('UpdateScheduler parallel processing', () => {
 			region: 'us'
 		}))
 
-		mockAuthorFind.mockResolvedValue(authors as never)
+		mockAuthorFind.mockResolvedValue(authors)
 
 		let concurrentCount = 0
 		let maxConcurrent = 0
@@ -120,7 +120,7 @@ describe('UpdateScheduler parallel processing', () => {
 			{ asin: 'B3', region: 'uk' }
 		]
 
-		mockAuthorFind.mockResolvedValue(authors as never)
+		mockAuthorFind.mockResolvedValue(authors)
 
 		let concurrentCount = 0
 		let maxConcurrent = 0
@@ -153,7 +153,7 @@ describe('UpdateScheduler parallel processing', () => {
 			{ asin: 'A3', region: 'us' }
 		]
 
-		mockAuthorFind.mockResolvedValue(authors as never)
+		mockAuthorFind.mockResolvedValue(authors)
 		mockAuthorHandler
 			.mockRejectedValueOnce(new Error('fail'))
 			.mockResolvedValueOnce(undefined)

--- a/tests/helpers/utils/UpdateScheduler.test.ts
+++ b/tests/helpers/utils/UpdateScheduler.test.ts
@@ -1,14 +1,53 @@
-jest.mock('@fastify/redis')
-jest.mock('#config/models/Author')
-jest.mock('#config/models/Book')
-jest.mock('#config/models/Chapter')
-jest.mock('#helpers/routes/AuthorShowHelper')
-jest.mock('#helpers/routes/BookShowHelper')
-jest.mock('#helpers/routes/ChapterShowHelper')
-jest.mock('#helpers/utils/batchProcessor')
-import type { FastifyRedis } from '@fastify/redis'
-import type { FastifyBaseLogger } from 'fastify'
-import { DeepMockProxy, mockDeep } from 'jest-mock-extended'
+import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
+
+import { createMockLogger } from '#tests/setup/mockLogger'
+
+const mockAuthorFind = mock()
+const mockBookFind = mock()
+const mockChapterFind = mock()
+
+mock.module('#config/models/Author', () => ({
+	default: { find: mockAuthorFind }
+}))
+
+mock.module('#config/models/Book', () => ({
+	default: { find: mockBookFind }
+}))
+
+mock.module('#config/models/Chapter', () => ({
+	default: { find: mockChapterFind }
+}))
+
+const mockAuthorHandler = mock()
+const mockBookHandler = mock()
+const mockChapterHandler = mock()
+
+mock.module('#helpers/routes/AuthorShowHelper', () => ({
+	default: class AuthorShowHelper {
+		handler = mockAuthorHandler
+	}
+}))
+
+mock.module('#helpers/routes/BookShowHelper', () => ({
+	default: class BookShowHelper {
+		handler = mockBookHandler
+	}
+}))
+
+mock.module('#helpers/routes/ChapterShowHelper', () => ({
+	default: class ChapterShowHelper {
+		handler = mockChapterHandler
+	}
+}))
+
+const mockProcessBatchByRegion = mock()
+const mockProcessBatch = mock()
+
+mock.module('#helpers/utils/batchProcessor', () => ({
+	processBatchByRegion: mockProcessBatchByRegion,
+	processBatch: mockProcessBatch
+}))
+
 import { AsyncTask, LongIntervalJob } from 'toad-scheduler'
 
 import AuthorModel from '#config/models/Author'
@@ -16,9 +55,6 @@ import BookModel from '#config/models/Book'
 import ChapterModel from '#config/models/Chapter'
 import type { PerformanceConfig } from '#config/performance'
 import { resetPerformanceConfig, setPerformanceConfig } from '#config/performance'
-import AuthorShowHelper from '#helpers/routes/AuthorShowHelper'
-import BookShowHelper from '#helpers/routes/BookShowHelper'
-import ChapterShowHelper from '#helpers/routes/ChapterShowHelper'
 import { processBatchByRegion } from '#helpers/utils/batchProcessor'
 import UpdateScheduler from '#helpers/utils/UpdateScheduler'
 import { authorWithoutProjection } from '#tests/datasets/helpers/authors'
@@ -26,12 +62,14 @@ import { bookWithoutProjection } from '#tests/datasets/helpers/books'
 import { chaptersWithoutProjection } from '#tests/datasets/helpers/chapters'
 
 type MockContext = {
-	client: DeepMockProxy<FastifyRedis>
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	client: any
 }
 
 let ctx: MockContext
 let helper: UpdateScheduler
-let mockLogger: DeepMockProxy<FastifyBaseLogger>
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mockLogger: any
 const projection = {
 	projection: { asin: 1, region: 1 },
 	sort: { updatedAt: -1 },
@@ -40,9 +78,16 @@ const projection = {
 
 const createMockContext = (): MockContext => {
 	return {
-		client: mockDeep<FastifyRedis>()
+		client: {
+			get: mock(),
+			set: mock(),
+			del: mock(),
+			ping: mock(),
+			expire: mock()
+		}
 	}
 }
+
 
 const createBatchSummary = (regions?: Record<string, number>) => ({
 	total: 1,
@@ -61,7 +106,7 @@ const createProcessBatchByRegionMock =
 				const result = await worker(item)
 				results.push(result)
 			} catch {
-				// Error is handled in worker, continue
+				// intentionally empty - testing error handling
 			}
 		}
 		return {
@@ -91,13 +136,22 @@ const makePerformanceConfig = (useParallel: boolean): PerformanceConfig => ({
 
 beforeEach(() => {
 	ctx = createMockContext()
-	mockLogger = mockDeep<FastifyBaseLogger>()
+	mockLogger = createMockLogger()
 	helper = new UpdateScheduler(1, ctx.client, mockLogger)
 	resetPerformanceConfig()
+	mockAuthorFind.mockClear()
+	mockBookFind.mockClear()
+	mockChapterFind.mockClear()
+	mockAuthorHandler.mockClear()
+	mockBookHandler.mockClear()
+	mockChapterHandler.mockClear()
+	mockProcessBatchByRegion.mockClear()
+	mockProcessBatch.mockClear()
 })
 
 afterEach(() => {
 	resetPerformanceConfig()
+	mock.restore()
 })
 
 describe('UpdateScheduler should', () => {
@@ -108,63 +162,63 @@ describe('UpdateScheduler should', () => {
 	})
 
 	test('getAllAuthorAsins', async () => {
-		jest.spyOn(AuthorModel, 'find').mockResolvedValue([authorWithoutProjection])
+		mockAuthorFind.mockResolvedValue([authorWithoutProjection])
 		await expect(helper.getAllAuthorAsins()).resolves.toEqual([authorWithoutProjection])
 		expect(AuthorModel.find).toHaveBeenCalledWith({}, projection)
 	})
 
 	test('getAllBookAsins', async () => {
-		jest.spyOn(BookModel, 'find').mockResolvedValue([bookWithoutProjection])
+		mockBookFind.mockResolvedValue([bookWithoutProjection])
 		await expect(helper.getAllBookAsins()).resolves.toEqual([bookWithoutProjection])
 		expect(BookModel.find).toHaveBeenCalledWith({}, projection)
 	})
 
 	test('getAllChapterAsins', async () => {
-		jest.spyOn(ChapterModel, 'find').mockResolvedValue([chaptersWithoutProjection])
+		mockChapterFind.mockResolvedValue([chaptersWithoutProjection])
 		await expect(helper.getAllChapterAsins()).resolves.toEqual([chaptersWithoutProjection])
 		expect(ChapterModel.find).toHaveBeenCalledWith({}, projection)
 	})
 
 	test('updateAuthors', async () => {
-		jest.spyOn(AuthorModel, 'find').mockResolvedValue([authorWithoutProjection])
-		jest.spyOn(AuthorShowHelper.prototype, 'handler').mockResolvedValue(undefined)
+		mockAuthorFind.mockResolvedValue([authorWithoutProjection])
+		mockAuthorHandler.mockResolvedValue(undefined)
 		setPerformanceConfig(makePerformanceConfig(false))
 		await expect(helper.updateAuthors()).resolves.toEqual(undefined)
 		expect(AuthorModel.find).toHaveBeenCalledWith({}, projection)
-		expect(AuthorShowHelper.prototype.handler).toHaveBeenCalledWith()
+		expect(mockAuthorHandler).toHaveBeenCalledWith()
 	})
 
 	test('updateBooks', async () => {
-		jest.spyOn(BookModel, 'find').mockResolvedValue([bookWithoutProjection])
-		jest.spyOn(BookShowHelper.prototype, 'handler').mockResolvedValue(undefined)
+		mockBookFind.mockResolvedValue([bookWithoutProjection])
+		mockBookHandler.mockResolvedValue(undefined)
 		setPerformanceConfig(makePerformanceConfig(false))
 		await expect(helper.updateBooks()).resolves.toEqual(undefined)
 		expect(BookModel.find).toHaveBeenCalledWith({}, projection)
-		expect(BookShowHelper.prototype.handler).toHaveBeenCalledWith()
+		expect(mockBookHandler).toHaveBeenCalledWith()
 	})
 
 	test('updateChapters', async () => {
-		jest.spyOn(ChapterModel, 'find').mockResolvedValue([chaptersWithoutProjection])
-		jest.spyOn(ChapterShowHelper.prototype, 'handler').mockResolvedValue(undefined)
+		mockChapterFind.mockResolvedValue([chaptersWithoutProjection])
+		mockChapterHandler.mockResolvedValue(undefined)
 		setPerformanceConfig(makePerformanceConfig(false))
 		await expect(helper.updateChapters()).resolves.toEqual(undefined)
 		expect(ChapterModel.find).toHaveBeenCalledWith({}, projection)
-		expect(ChapterShowHelper.prototype.handler).toHaveBeenCalledWith()
+		expect(mockChapterHandler).toHaveBeenCalledWith()
 	})
 
 	test('updateAll', async () => {
-		jest.spyOn(helper, 'updateAuthors').mockResolvedValue(undefined)
-		jest.spyOn(helper, 'updateBooks').mockResolvedValue(undefined)
-		jest.spyOn(helper, 'updateChapters').mockResolvedValue(undefined)
+		const updateAuthorsSpy = spyOn(helper, 'updateAuthors').mockResolvedValue(undefined)
+		const updateBooksSpy = spyOn(helper, 'updateBooks').mockResolvedValue(undefined)
+		const updateChaptersSpy = spyOn(helper, 'updateChapters').mockResolvedValue(undefined)
 		setPerformanceConfig(makePerformanceConfig(false))
 		await expect(helper.updateAll()).resolves.toEqual(undefined)
-		expect(helper.updateAuthors).toHaveBeenCalledWith()
-		expect(helper.updateBooks).toHaveBeenCalledWith()
-		expect(helper.updateChapters).toHaveBeenCalledWith()
+		expect(updateAuthorsSpy).toHaveBeenCalledWith()
+		expect(updateBooksSpy).toHaveBeenCalledWith()
+		expect(updateChaptersSpy).toHaveBeenCalledWith()
 	})
 
 	test('updateAllTask', async () => {
-		jest.spyOn(helper, 'updateAll').mockResolvedValue(undefined)
+		const updateAllSpy = spyOn(helper, 'updateAll').mockResolvedValue(undefined)
 		expect(JSON.stringify(helper.updateAllTask())).toEqual(
 			JSON.stringify(
 				new AsyncTask(
@@ -178,12 +232,13 @@ describe('UpdateScheduler should', () => {
 				)
 			)
 		)
+		updateAllSpy.mockRestore()
 	})
 
 	test('updateAllJob', async () => {
-		jest
-			.spyOn(helper, 'updateAllTask')
-			.mockReturnValue(new AsyncTask('id_1', async () => undefined))
+		const updateAllTaskSpy = spyOn(helper, 'updateAllTask').mockReturnValue(
+			new AsyncTask('id_1', async () => undefined)
+		)
 		expect(JSON.stringify(helper.updateAllJob())).toEqual(
 			JSON.stringify(
 				new LongIntervalJob({ days: 1, runImmediately: true }, helper.updateAllTask(), {
@@ -192,14 +247,14 @@ describe('UpdateScheduler should', () => {
 				})
 			)
 		)
+		updateAllTaskSpy.mockRestore()
 	})
 
-	// Parallel scheduler tests
 	test('updateAuthors with parallel processing when USE_PARALLEL_SCHEDULER is true', async () => {
 		setPerformanceConfig(makePerformanceConfig(true))
 
-		jest.spyOn(AuthorModel, 'find').mockResolvedValue([authorWithoutProjection])
-		;(processBatchByRegion as jest.Mock).mockResolvedValue({
+		mockAuthorFind.mockResolvedValue([authorWithoutProjection])
+		mockProcessBatchByRegion.mockResolvedValue({
 			results: [undefined],
 			summary: createBatchSummary()
 		})
@@ -217,8 +272,8 @@ describe('UpdateScheduler should', () => {
 	test('updateBooks with parallel processing when USE_PARALLEL_SCHEDULER is true', async () => {
 		setPerformanceConfig(makePerformanceConfig(true))
 
-		jest.spyOn(BookModel, 'find').mockResolvedValue([bookWithoutProjection])
-		;(processBatchByRegion as jest.Mock).mockResolvedValue({
+		mockBookFind.mockResolvedValue([bookWithoutProjection])
+		mockProcessBatchByRegion.mockResolvedValue({
 			results: [undefined],
 			summary: createBatchSummary()
 		})
@@ -236,8 +291,8 @@ describe('UpdateScheduler should', () => {
 	test('updateChapters with parallel processing when USE_PARALLEL_SCHEDULER is true', async () => {
 		setPerformanceConfig(makePerformanceConfig(true))
 
-		jest.spyOn(ChapterModel, 'find').mockResolvedValue([chaptersWithoutProjection])
-		;(processBatchByRegion as jest.Mock).mockResolvedValue({
+		mockChapterFind.mockResolvedValue([chaptersWithoutProjection])
+		mockProcessBatchByRegion.mockResolvedValue({
 			results: [undefined],
 			summary: createBatchSummary()
 		})
@@ -255,47 +310,47 @@ describe('UpdateScheduler should', () => {
 	test('updateAuthors with parallel processing handles errors gracefully', async () => {
 		setPerformanceConfig(makePerformanceConfig(true))
 
-		jest.spyOn(AuthorModel, 'find').mockResolvedValue([authorWithoutProjection])
-		jest.spyOn(AuthorShowHelper.prototype, 'handler').mockRejectedValue(new Error('Test error'))
-		;(processBatchByRegion as jest.Mock).mockImplementation(createProcessBatchByRegionMock())
+		mockAuthorFind.mockResolvedValue([authorWithoutProjection])
+		mockAuthorHandler.mockRejectedValue(new Error('Test error'))
+		mockProcessBatchByRegion.mockImplementation(createProcessBatchByRegionMock())
 
 		await helper.updateAuthors()
 
 		expect(processBatchByRegion).toHaveBeenCalled()
-		expect(AuthorShowHelper.prototype.handler).toHaveBeenCalled()
+		expect(mockAuthorHandler).toHaveBeenCalled()
 	})
 
 	test('updateBooks with parallel processing handles errors gracefully', async () => {
 		setPerformanceConfig(makePerformanceConfig(true))
 
-		jest.spyOn(BookModel, 'find').mockResolvedValue([bookWithoutProjection])
-		jest.spyOn(BookShowHelper.prototype, 'handler').mockRejectedValue(new Error('Test error'))
-		;(processBatchByRegion as jest.Mock).mockImplementation(createProcessBatchByRegionMock())
+		mockBookFind.mockResolvedValue([bookWithoutProjection])
+		mockBookHandler.mockRejectedValue(new Error('Test error'))
+		mockProcessBatchByRegion.mockImplementation(createProcessBatchByRegionMock())
 
 		await helper.updateBooks()
 
 		expect(processBatchByRegion).toHaveBeenCalled()
-		expect(BookShowHelper.prototype.handler).toHaveBeenCalled()
+		expect(mockBookHandler).toHaveBeenCalled()
 	})
 
 	test('updateChapters with parallel processing handles errors gracefully', async () => {
 		setPerformanceConfig(makePerformanceConfig(true))
 
-		jest.spyOn(ChapterModel, 'find').mockResolvedValue([chaptersWithoutProjection])
-		jest.spyOn(ChapterShowHelper.prototype, 'handler').mockRejectedValue(new Error('Test error'))
-		;(processBatchByRegion as jest.Mock).mockImplementation(createProcessBatchByRegionMock())
+		mockChapterFind.mockResolvedValue([chaptersWithoutProjection])
+		mockChapterHandler.mockRejectedValue(new Error('Test error'))
+		mockProcessBatchByRegion.mockImplementation(createProcessBatchByRegionMock())
 
 		await helper.updateChapters()
 
 		expect(processBatchByRegion).toHaveBeenCalled()
-		expect(ChapterShowHelper.prototype.handler).toHaveBeenCalled()
+		expect(mockChapterHandler).toHaveBeenCalled()
 	})
 
 	test('updateAuthors uses sequential processing when USE_PARALLEL_SCHEDULER is false', async () => {
 		setPerformanceConfig(makePerformanceConfig(false))
 
-		jest.spyOn(AuthorModel, 'find').mockResolvedValue([authorWithoutProjection])
-		jest.spyOn(AuthorShowHelper.prototype, 'handler').mockResolvedValue(undefined)
+		mockAuthorFind.mockResolvedValue([authorWithoutProjection])
+		mockAuthorHandler.mockResolvedValue(undefined)
 
 		await helper.updateAuthors()
 
@@ -306,8 +361,8 @@ describe('UpdateScheduler should', () => {
 	test('updateBooks uses sequential processing when USE_PARALLEL_SCHEDULER is false', async () => {
 		setPerformanceConfig(makePerformanceConfig(false))
 
-		jest.spyOn(BookModel, 'find').mockResolvedValue([bookWithoutProjection])
-		jest.spyOn(BookShowHelper.prototype, 'handler').mockResolvedValue(undefined)
+		mockBookFind.mockResolvedValue([bookWithoutProjection])
+		mockBookHandler.mockResolvedValue(undefined)
 
 		await helper.updateBooks()
 
@@ -318,8 +373,8 @@ describe('UpdateScheduler should', () => {
 	test('updateChapters uses sequential processing when USE_PARALLEL_SCHEDULER is false', async () => {
 		setPerformanceConfig(makePerformanceConfig(false))
 
-		jest.spyOn(ChapterModel, 'find').mockResolvedValue([chaptersWithoutProjection])
-		jest.spyOn(ChapterShowHelper.prototype, 'handler').mockResolvedValue(undefined)
+		mockChapterFind.mockResolvedValue([chaptersWithoutProjection])
+		mockChapterHandler.mockResolvedValue(undefined)
 
 		await helper.updateChapters()
 
@@ -330,8 +385,8 @@ describe('UpdateScheduler should', () => {
 	test('updateAuthors logs warning when maxConcurrencyObserved exceeds configured concurrency', async () => {
 		setPerformanceConfig(makePerformanceConfig(true))
 
-		jest.spyOn(AuthorModel, 'find').mockResolvedValue([authorWithoutProjection])
-		;(processBatchByRegion as jest.Mock).mockResolvedValue({
+		mockAuthorFind.mockResolvedValue([authorWithoutProjection])
+		mockProcessBatchByRegion.mockResolvedValue({
 			results: [undefined],
 			summary: {
 				total: 1,
@@ -350,4 +405,8 @@ describe('UpdateScheduler should', () => {
 			'Authors batch exceeded configured concurrency (10/5)'
 		)
 	})
+})
+
+afterAll(() => {
+	mock.restore()
 })

--- a/tests/helpers/utils/batchProcessor.test.ts
+++ b/tests/helpers/utils/batchProcessor.test.ts
@@ -1,3 +1,5 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+
 import {
 	PerformanceConfig,
 	resetPerformanceConfig,
@@ -41,7 +43,8 @@ describe('batchProcessor', () => {
 			)
 
 			const items = [1, 2, 3]
-			const processor = jest.fn().mockResolvedValue('result')
+			const processor = mock(() => Promise.resolve('result'))
+
 
 			const { summary } = await processBatch(items, processor)
 
@@ -62,7 +65,8 @@ describe('batchProcessor', () => {
 			)
 
 			const items = [1, 2, 3]
-			const processor = jest.fn().mockResolvedValue('result')
+			const processor = mock(() => Promise.resolve('result'))
+
 
 			const { summary } = await processBatch(items, processor)
 
@@ -79,7 +83,8 @@ describe('batchProcessor', () => {
 			)
 
 			const items = [1, 2, 3]
-			const processor = jest.fn().mockImplementation((item) => Promise.resolve(item * 2))
+			const processor = mock((item) => Promise.resolve(item * 2))
+
 
 			const { results } = await processBatch(items, processor)
 
@@ -95,7 +100,8 @@ describe('batchProcessor', () => {
 			)
 
 			const items = [1, 2, 3]
-			const processor = jest.fn().mockImplementation((item) => {
+			const processor = mock((item) => {
+
 				if (item === 2) {
 					return Promise.reject(new Error('Failed'))
 				}
@@ -116,7 +122,8 @@ describe('batchProcessor', () => {
 			)
 
 			const items = [1, 2, 3]
-			const processor = jest.fn().mockImplementation((item) => {
+			const processor = mock((item) => {
+
 				if (item === 2) {
 					return Promise.reject(new Error('Failed'))
 				}
@@ -140,7 +147,8 @@ describe('batchProcessor', () => {
 			let concurrentCount = 0
 			let maxConcurrent = 0
 
-			const processor = jest.fn().mockImplementation(async () => {
+			const processor = mock(async () => {
+
 				concurrentCount++
 				maxConcurrent = Math.max(maxConcurrent, concurrentCount)
 				await new Promise((resolve) => setTimeout(resolve, 10))
@@ -163,7 +171,8 @@ describe('batchProcessor', () => {
 			)
 
 			const items = [1, 2]
-			const processor = jest.fn().mockResolvedValue('result')
+			const processor = mock(() => Promise.resolve('result'))
+
 
 			await expect(processBatch(items, processor, { concurrency: 3 })).rejects.toThrow(
 				'Concurrency exceeds SCHEDULER_CONCURRENCY guardrail'
@@ -179,7 +188,8 @@ describe('batchProcessor', () => {
 			)
 
 			const items = [1]
-			const processor = jest.fn().mockResolvedValue('result')
+			const processor = mock(() => Promise.resolve('result'))
+
 
 			await expect(processBatch(items, processor)).rejects.toThrow(
 				'SCHEDULER_CONCURRENCY must be at least 1'
@@ -200,7 +210,8 @@ describe('batchProcessor', () => {
 				{ id: 1, region: 'us' },
 				{ id: 2, region: 'uk' }
 			]
-			const processor = jest.fn().mockResolvedValue('result')
+			const processor = mock(() => Promise.resolve('result'))
+
 
 			await processBatchByRegion(items, processor)
 
@@ -223,7 +234,8 @@ describe('batchProcessor', () => {
 				{ id: 5, region: 'uk' }
 			]
 
-			const processor = jest.fn().mockResolvedValue('result')
+			const processor = mock(() => Promise.resolve('result'))
+
 
 			const { summary } = await processBatchByRegion(items, processor)
 
@@ -240,7 +252,8 @@ describe('batchProcessor', () => {
 			)
 
 			const items = [{ id: 1, region: null }, { id: 2, region: undefined }, { id: 3 }]
-			const processor = jest.fn().mockResolvedValue('result')
+			const processor = mock(() => Promise.resolve('result'))
+
 
 			const { summary } = await processBatchByRegion(items, processor)
 
@@ -263,7 +276,8 @@ describe('batchProcessor', () => {
 
 			let concurrentCount = 0
 			let maxConcurrent = 0
-			const processor = jest.fn().mockImplementation(async () => {
+			const processor = mock(async () => {
+
 				concurrentCount++
 				maxConcurrent = Math.max(maxConcurrent, concurrentCount)
 				await new Promise((resolve) => setTimeout(resolve, 10))
@@ -292,7 +306,8 @@ describe('batchProcessor', () => {
 
 			let concurrentCount = 0
 			let maxConcurrent = 0
-			const processor = jest.fn().mockImplementation(async () => {
+			const processor = mock(async () => {
+
 				concurrentCount++
 				maxConcurrent = Math.max(maxConcurrent, concurrentCount)
 				await new Promise((resolve) => setTimeout(resolve, 10))
@@ -320,7 +335,8 @@ describe('batchProcessor', () => {
 				{ id: 3, region: 'us' }
 			]
 
-			const processor = jest.fn().mockImplementation((item) => {
+			const processor = mock((item) => {
+
 				if (item.id === 2) {
 					return Promise.reject(new Error('Failed'))
 				}
@@ -350,7 +366,8 @@ describe('batchProcessor', () => {
 				{ id: 3, region: 'us' }
 			]
 
-			const processor = jest.fn().mockImplementation((item) => {
+			const processor = mock((item) => {
+
 				if (item.id === 2) {
 					return Promise.reject(new Error('Failed'))
 				}
@@ -378,7 +395,8 @@ describe('batchProcessor', () => {
 			let maxConcurrent = 0
 			let concurrentCount = 0
 
-			const processor = jest.fn().mockImplementation(async () => {
+			const processor = mock(async () => {
+
 				concurrentCount++
 				maxConcurrent = Math.max(maxConcurrent, concurrentCount)
 				await new Promise((resolve) => setTimeout(resolve, 10))
@@ -405,7 +423,8 @@ describe('batchProcessor', () => {
 			)
 
 			const items = [{ id: 1, region: 'us' }]
-			const processor = jest.fn().mockResolvedValue('result')
+			const processor = mock(() => Promise.resolve('result'))
+
 
 			await expect(processBatchByRegion(items, processor, { concurrency: 4 })).rejects.toThrow(
 				'Concurrency exceeds SCHEDULER_CONCURRENCY guardrail'
@@ -421,7 +440,8 @@ describe('batchProcessor', () => {
 			)
 
 			const items = [{ id: 1, region: 'us' }]
-			const processor = jest.fn().mockResolvedValue('result')
+			const processor = mock(() => Promise.resolve('result'))
+
 
 			await expect(processBatchByRegion(items, processor, { maxPerRegion: 3 })).rejects.toThrow(
 				'Per-region concurrency exceeds overall concurrency guardrail'
@@ -437,7 +457,7 @@ describe('batchProcessor', () => {
 			)
 
 			const items = [{ id: 1, region: 'us' }]
-			const processor = jest.fn().mockResolvedValue('result')
+			const processor = mock(() => Promise.resolve('result'))
 
 			await expect(processBatchByRegion(items, processor)).rejects.toThrow(
 				'SCHEDULER_CONCURRENCY must be at least 1'

--- a/tests/helpers/utils/cloudflareIps.test.ts
+++ b/tests/helpers/utils/cloudflareIps.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { afterAll, afterEach, beforeEach, describe, expect, mock, setSystemTime, test } from 'bun:test'
 
 const mockGet = mock()
 
@@ -50,6 +50,7 @@ describe('cloudflareIps', () => {
 	afterEach(() => {
 		clearCache()
 		mock.restore()
+		setSystemTime()
 	})
 
 	describe('fetchIpsFromApi', () => {
@@ -145,7 +146,6 @@ describe('cloudflareIps', () => {
 			const result1 = await getIps()
 			expect(result1.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
 
-			const { setSystemTime } = await import('bun:test')
 			setSystemTime(new Date(Date.now() + 25 * 60 * 60 * 1000))
 
 			const result2 = await getIps()
@@ -162,7 +162,6 @@ describe('cloudflareIps', () => {
 			const result1 = await getIps()
 			expect(result1.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
 
-			const { setSystemTime } = await import('bun:test')
 			setSystemTime(new Date(Date.now() + 25 * 60 * 60 * 1000))
 
 			const result2 = await getIps()
@@ -217,7 +216,6 @@ describe('cloudflareIps', () => {
 
 			await getIps()
 
-			const { setSystemTime } = await import('bun:test')
 			setSystemTime(new Date(Date.now() + 25 * 60 * 60 * 1000))
 
 			const result = getCachedIps()
@@ -244,7 +242,6 @@ describe('cloudflareIps', () => {
 
 			await getIps()
 
-			const { setSystemTime } = await import('bun:test')
 			setSystemTime(new Date(Date.now() + 25 * 60 * 60 * 1000))
 
 			expect(isCacheValid()).toBe(false)

--- a/tests/helpers/utils/cloudflareIps.test.ts
+++ b/tests/helpers/utils/cloudflareIps.test.ts
@@ -1,4 +1,10 @@
-jest.mock('#helpers/utils/connectionPool')
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+const mockGet = mock()
+
+mock.module('#helpers/utils/connectionPool', () => {
+	return { default: { get: mockGet } }
+})
 
 import { AxiosResponse } from 'axios'
 
@@ -37,20 +43,19 @@ const mockCloudflareResponseV2 = {
 
 describe('cloudflareIps', () => {
 	beforeEach(() => {
-		jest.clearAllMocks()
+		mockGet.mockClear()
 		clearCache()
-		jest.useRealTimers()
 	})
 
 	afterEach(() => {
 		clearCache()
-		jest.useRealTimers()
+		mock.restore()
 	})
 
 	describe('fetchIpsFromApi', () => {
 		test('should fetch and return Cloudflare IP ranges', async () => {
 			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
-			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+			mockGet.mockResolvedValueOnce(mockResponse)
 
 			const result = await fetchIpsFromApi()
 
@@ -70,13 +75,13 @@ describe('cloudflareIps', () => {
 				},
 				status: 200
 			} as AxiosResponse
-			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(errorResponse)
+			mockGet.mockResolvedValueOnce(errorResponse)
 
 			await expect(fetchIpsFromApi()).rejects.toThrow('Cloudflare API returned errors')
 		})
 
 		test('should throw error when network request fails', async () => {
-			;(pooledAxios.get as jest.Mock).mockRejectedValueOnce(new Error('Network error'))
+			mockGet.mockRejectedValueOnce(new Error('Network error'))
 
 			await expect(fetchIpsFromApi()).rejects.toThrow()
 		})
@@ -85,7 +90,7 @@ describe('cloudflareIps', () => {
 	describe('getIps', () => {
 		test('should fetch IPs when cache is empty', async () => {
 			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
-			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+			mockGet.mockResolvedValueOnce(mockResponse)
 
 			const result = await getIps()
 
@@ -96,95 +101,76 @@ describe('cloudflareIps', () => {
 
 		test('should return cached IPs on subsequent calls', async () => {
 			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
-			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+			mockGet.mockResolvedValueOnce(mockResponse)
 
-			// First call - should fetch
 			const result1 = await getIps()
 			expect(result1.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
 			expect(pooledAxios.get).toHaveBeenCalledTimes(1)
 
-			// Second call - should use cache
 			const result2 = await getIps()
 			expect(result2).toEqual(result1)
-			expect(pooledAxios.get).toHaveBeenCalledTimes(1) // No additional fetch
+			expect(pooledAxios.get).toHaveBeenCalledTimes(1)
 		})
 
 		test('should deduplicate concurrent fetch requests (race condition prevention)', async () => {
-			// Create a delayed response to simulate slow API
 			let resolveRequest: (value: AxiosResponse) => void
 			const responsePromise = new Promise<AxiosResponse>((resolve) => {
 				resolveRequest = resolve
 			})
-			;(pooledAxios.get as jest.Mock).mockReturnValueOnce(responsePromise)
+			mockGet.mockReturnValueOnce(responsePromise)
 
-			// Make multiple concurrent calls while cache is empty
 			const promise1 = getIps()
 			const promise2 = getIps()
 			const promise3 = getIps()
 
-			// Should only make one API call
 			expect(pooledAxios.get).toHaveBeenCalledTimes(1)
 
-			// Resolve the API call
 			resolveRequest!({ data: mockCloudflareResponse, status: 200 } as AxiosResponse)
 
-			// All promises should resolve with the same data
 			const [result1, result2, result3] = await Promise.all([promise1, promise2, promise3])
 			expect(result1).toEqual(result2)
 			expect(result2).toEqual(result3)
 			expect(result1.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
 
-			// Should still only have made one API call
 			expect(pooledAxios.get).toHaveBeenCalledTimes(1)
 		})
 
 		test('should refetch after cache expires', async () => {
-			jest.useFakeTimers()
-
 			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
 			const mockResponseV2 = { data: mockCloudflareResponseV2, status: 200 } as AxiosResponse
-			;(pooledAxios.get as jest.Mock)
+			mockGet
 				.mockResolvedValueOnce(mockResponse)
 				.mockResolvedValueOnce(mockResponseV2)
 
-			// First call - should fetch
 			const result1 = await getIps()
 			expect(result1.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
 
-			// Advance time by 25 hours (cache expires after 24 hours)
-			jest.advanceTimersByTime(25 * 60 * 60 * 1000)
+			const { setSystemTime } = await import('bun:test')
+			setSystemTime(new Date(Date.now() + 25 * 60 * 60 * 1000))
 
-			// Second call - should refetch
 			const result2 = await getIps()
 			expect(result2.ipv4).toEqual(mockCloudflareResponseV2.result.ipv4_cidrs)
 			expect(pooledAxios.get).toHaveBeenCalledTimes(2)
-
-			jest.useRealTimers()
 		})
 
 		test('should return stale cached data when fetch fails', async () => {
 			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
-			;(pooledAxios.get as jest.Mock)
+			mockGet
 				.mockResolvedValueOnce(mockResponse)
 				.mockRejectedValueOnce(new Error('Network error'))
 
-			// First call - should fetch and cache
 			const result1 = await getIps()
 			expect(result1.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
 
-			// Force cache expiration by manipulating time
-			jest.useFakeTimers()
-			jest.advanceTimersByTime(25 * 60 * 60 * 1000)
+			const { setSystemTime } = await import('bun:test')
+			setSystemTime(new Date(Date.now() + 25 * 60 * 60 * 1000))
 
-			// Second call - fetch fails, should return stale cache
 			const result2 = await getIps()
 			expect(result2).toEqual(result1)
-
-			jest.useRealTimers()
 		})
 
 		test('should return empty arrays when fetch fails and no cache exists', async () => {
-			;(pooledAxios.get as jest.Mock).mockRejectedValueOnce(new Error('Network error'))
+			mockGet.mockRejectedValueOnce(new Error('Network error'))
 
 			const result = await getIps()
 
@@ -197,7 +183,7 @@ describe('cloudflareIps', () => {
 	describe('getAllIps', () => {
 		test('should return combined IPv4 and IPv6 ranges', async () => {
 			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
-			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+			mockGet.mockResolvedValueOnce(mockResponse)
 
 			const result = await getAllIps()
 
@@ -216,9 +202,8 @@ describe('cloudflareIps', () => {
 
 		test('should return cached data when available', async () => {
 			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
-			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+			mockGet.mockResolvedValueOnce(mockResponse)
 
-			// Populate cache
 			await getIps()
 
 			const result = getCachedIps()
@@ -227,22 +212,16 @@ describe('cloudflareIps', () => {
 		})
 
 		test('should return expired data when available', async () => {
-			jest.useFakeTimers()
-
 			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
-			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+			mockGet.mockResolvedValueOnce(mockResponse)
 
-			// Populate cache
 			await getIps()
 
-			// Advance time past expiration
-			jest.advanceTimersByTime(25 * 60 * 60 * 1000)
+			const { setSystemTime } = await import('bun:test')
+			setSystemTime(new Date(Date.now() + 25 * 60 * 60 * 1000))
 
-			// Should still return expired data
 			const result = getCachedIps()
 			expect(result?.ipv4).toEqual(mockCloudflareResponse.result.ipv4_cidrs)
-
-			jest.useRealTimers()
 		})
 	})
 
@@ -253,42 +232,40 @@ describe('cloudflareIps', () => {
 
 		test('should return true when cache is valid', async () => {
 			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
-			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+			mockGet.mockResolvedValueOnce(mockResponse)
 
 			await getIps()
 			expect(isCacheValid()).toBe(true)
 		})
 
 		test('should return false when cache is expired', async () => {
-			jest.useFakeTimers()
-
 			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
-			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+			mockGet.mockResolvedValueOnce(mockResponse)
 
 			await getIps()
 
-			// Advance time past expiration
-			jest.advanceTimersByTime(25 * 60 * 60 * 1000)
+			const { setSystemTime } = await import('bun:test')
+			setSystemTime(new Date(Date.now() + 25 * 60 * 60 * 1000))
 
 			expect(isCacheValid()).toBe(false)
-
-			jest.useRealTimers()
 		})
 	})
 
 	describe('clearCache', () => {
 		test('should clear the cache', async () => {
 			const mockResponse = { data: mockCloudflareResponse, status: 200 } as AxiosResponse
-			;(pooledAxios.get as jest.Mock).mockResolvedValueOnce(mockResponse)
+			mockGet.mockResolvedValueOnce(mockResponse)
 
-			// Populate cache
 			await getIps()
 			expect(isCacheValid()).toBe(true)
 
-			// Clear cache
 			clearCache()
 			expect(isCacheValid()).toBe(false)
 			expect(getCachedIps()).toBeNull()
 		})
 	})
+})
+
+afterAll(() => {
+	mock.restore()
 })

--- a/tests/helpers/utils/fetchPlus.test.ts
+++ b/tests/helpers/utils/fetchPlus.test.ts
@@ -1,4 +1,14 @@
-jest.mock('#helpers/utils/connectionPool')
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+const mockGet = mock()
+
+mock.module('#helpers/utils/connectionPool', () => {
+	return { default: { get: mockGet } }
+})
+
+mock.module('#helpers/utils/sleep', () => {
+	return { default: () => Promise.resolve() }
+})
 
 import type { AxiosResponse } from 'axios'
 
@@ -9,24 +19,23 @@ let mockStatus: { status: number; headers?: Record<string, string> }
 
 describe('fetchPlus should', () => {
 	beforeEach(() => {
-		jest.clearAllMocks()
-		jest.useRealTimers()
+		mockGet.mockClear()
 	})
 
 	afterEach(() => {
-		jest.useRealTimers()
+		mock.restore()
 	})
 
 	test('return response', async () => {
 		const mockResponse = { data: 'test', status: 200 } as AxiosResponse
-		;(pooledAxios.get as jest.Mock).mockImplementation(() => Promise.resolve(mockResponse))
+		mockGet.mockImplementation(() => Promise.resolve(mockResponse))
 		const response = await fetchPlus('test')
 		expect(response).toEqual(mockResponse)
 	})
 
 	test('return error with default retries', async () => {
 		mockStatus = { status: 500 }
-		;(pooledAxios.get as jest.Mock).mockImplementation(() =>
+		mockGet.mockImplementation(() =>
 			Promise.reject({ response: mockStatus })
 		)
 
@@ -36,7 +45,7 @@ describe('fetchPlus should', () => {
 
 	test('retry on non-200', async () => {
 		mockStatus = { status: 200 }
-		;(pooledAxios.get as jest.Mock)
+		mockGet
 			.mockRejectedValueOnce({ status: 500 })
 			.mockResolvedValueOnce(mockStatus as AxiosResponse)
 		await expect(fetchPlus('test.com')).resolves.toEqual(mockStatus)
@@ -44,7 +53,7 @@ describe('fetchPlus should', () => {
 
 	test('retry the correct number of times before hard failing', async () => {
 		mockStatus = { status: 500 }
-		;(pooledAxios.get as jest.Mock).mockImplementation(() =>
+		mockGet.mockImplementation(() =>
 			Promise.reject({ response: mockStatus })
 		)
 
@@ -53,7 +62,6 @@ describe('fetchPlus should', () => {
 	})
 
 	test('retry with exponential backoff on 429 without Retry-After header', async () => {
-		jest.useFakeTimers()
 		const mockError = {
 			response: {
 				status: 429,
@@ -62,20 +70,16 @@ describe('fetchPlus should', () => {
 		}
 		const successResponse = { data: 'success', status: 200 } as AxiosResponse
 
-		;(pooledAxios.get as jest.Mock)
+		mockGet
 			.mockRejectedValueOnce(mockError)
 			.mockResolvedValueOnce(successResponse)
 
-		const fetchPromise = fetchPlus('test.com')
-
-		await jest.advanceTimersByTimeAsync(1000)
-		const response = await fetchPromise
+		const response = await fetchPlus('test.com')
 		expect(response).toEqual(successResponse)
 		expect(pooledAxios.get).toHaveBeenCalledTimes(2)
 	})
 
 	test('retry with Retry-After header on 429', async () => {
-		jest.useFakeTimers()
 		const mockError = {
 			response: {
 				status: 429,
@@ -84,21 +88,17 @@ describe('fetchPlus should', () => {
 		}
 		const successResponse = { data: 'success', status: 200 } as AxiosResponse
 
-		;(pooledAxios.get as jest.Mock)
+		mockGet
 			.mockRejectedValueOnce(mockError)
 			.mockResolvedValueOnce(successResponse)
 
-		const fetchPromise = fetchPlus('test.com')
+		const response = await fetchPlus('test.com')
 
-		await jest.advanceTimersByTimeAsync(2000)
-
-		const response = await fetchPromise
 		expect(response).toEqual(successResponse)
 		expect(pooledAxios.get).toHaveBeenCalledTimes(2)
 	})
 
 	test('retry with increasing exponential backoff on multiple 429s', async () => {
-		jest.useFakeTimers()
 		const mockError = {
 			response: {
 				status: 429,
@@ -107,23 +107,18 @@ describe('fetchPlus should', () => {
 		}
 		const successResponse = { data: 'success', status: 200 } as AxiosResponse
 
-		;(pooledAxios.get as jest.Mock)
+		mockGet
 			.mockRejectedValueOnce(mockError)
 			.mockRejectedValueOnce(mockError)
 			.mockResolvedValueOnce(successResponse)
 
-		const fetchPromise = fetchPlus('test.com')
+		const response = await fetchPlus('test.com')
 
-		await jest.advanceTimersByTimeAsync(1000)
-		await jest.advanceTimersByTimeAsync(2000)
-
-		const response = await fetchPromise
 		expect(response).toEqual(successResponse)
 		expect(pooledAxios.get).toHaveBeenCalledTimes(3)
 	})
 
 	test('retry with exponential backoff on 429 with headers missing retry-after key', async () => {
-		jest.useFakeTimers()
 		const mockError = {
 			response: {
 				status: 429,
@@ -132,25 +127,27 @@ describe('fetchPlus should', () => {
 		}
 		const successResponse = { data: 'success', status: 200 } as AxiosResponse
 
-		;(pooledAxios.get as jest.Mock)
+		mockGet
 			.mockRejectedValueOnce(mockError)
 			.mockResolvedValueOnce(successResponse)
 
-		const fetchPromise = fetchPlus('test.com')
+		const response = await fetchPlus('test.com')
 
-		await jest.advanceTimersByTimeAsync(1000)
-		const response = await fetchPromise
 		expect(response).toEqual(successResponse)
 		expect(pooledAxios.get).toHaveBeenCalledTimes(2)
 	})
 
 	test('not add delay for non-429 errors', async () => {
 		mockStatus = { status: 500 }
-		;(pooledAxios.get as jest.Mock).mockImplementation(() =>
+		mockGet.mockImplementation(() =>
 			Promise.reject({ response: mockStatus })
 		)
 
 		await expect(fetchPlus('test.com')).rejects.toEqual(mockStatus)
 		expect(pooledAxios.get).toHaveBeenCalledTimes(4)
 	})
+})
+
+afterAll(() => {
+	mock.restore()
 })

--- a/tests/helpers/utils/fetchPlus.test.ts
+++ b/tests/helpers/utils/fetchPlus.test.ts
@@ -6,8 +6,14 @@ mock.module('#helpers/utils/connectionPool', () => {
 	return { default: { get: mockGet } }
 })
 
+const sleepDelays: number[] = []
 mock.module('#helpers/utils/sleep', () => {
-	return { default: () => Promise.resolve() }
+	return {
+		default: (ms: number) => {
+			sleepDelays.push(ms)
+			return Promise.resolve()
+		}
+	}
 })
 
 import type { AxiosResponse } from 'axios'
@@ -19,6 +25,7 @@ let mockStatus: { status: number; headers?: Record<string, string> }
 
 describe('fetchPlus should', () => {
 	beforeEach(() => {
+		sleepDelays.length = 0
 		mockGet.mockClear()
 	})
 
@@ -77,6 +84,7 @@ describe('fetchPlus should', () => {
 		const response = await fetchPlus('test.com')
 		expect(response).toEqual(successResponse)
 		expect(pooledAxios.get).toHaveBeenCalledTimes(2)
+		expect(sleepDelays).toEqual([1000])
 	})
 
 	test('retry with Retry-After header on 429', async () => {
@@ -96,6 +104,7 @@ describe('fetchPlus should', () => {
 
 		expect(response).toEqual(successResponse)
 		expect(pooledAxios.get).toHaveBeenCalledTimes(2)
+		expect(sleepDelays).toEqual([2000])
 	})
 
 	test('retry with increasing exponential backoff on multiple 429s', async () => {
@@ -116,6 +125,7 @@ describe('fetchPlus should', () => {
 
 		expect(response).toEqual(successResponse)
 		expect(pooledAxios.get).toHaveBeenCalledTimes(3)
+		expect(sleepDelays).toEqual([1000, 2000])
 	})
 
 	test('retry with exponential backoff on 429 with headers missing retry-after key', async () => {
@@ -135,6 +145,7 @@ describe('fetchPlus should', () => {
 
 		expect(response).toEqual(successResponse)
 		expect(pooledAxios.get).toHaveBeenCalledTimes(2)
+		expect(sleepDelays).toEqual([1000])
 	})
 
 	test('not add delay for non-429 errors', async () => {
@@ -145,6 +156,7 @@ describe('fetchPlus should', () => {
 
 		await expect(fetchPlus('test.com')).rejects.toEqual(mockStatus)
 		expect(pooledAxios.get).toHaveBeenCalledTimes(4)
+		expect(sleepDelays).toEqual([])
 	})
 })
 

--- a/tests/helpers/utils/shared.test.ts
+++ b/tests/helpers/utils/shared.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import { afterEach, beforeAll, describe, expect, mock, spyOn, test } from 'bun:test'
 import * as cheerio from 'cheerio'
 import type { FastifyBaseLogger } from 'fastify'
 import type { z } from 'zod'
@@ -25,7 +25,8 @@ beforeAll(() => {
 
 describe('SharedHelper should', () => {
 	afterEach(() => {
-		jest.restoreAllMocks()
+		mock.restore()
+
 	})
 
 	test('build a URL', () => {
@@ -110,10 +111,12 @@ describe('SharedHelper should', () => {
 	})
 
 	test('collectGenres logs warning when ApiGenreSchema.safeParse fails', () => {
-		const mockWarn = jest.fn()
+		const mockWarn = mock()
+
 		const mockLogger = {
 			warn: mockWarn,
-			info: jest.fn()
+			info: mock()
+
 		}
 		const helperWithLogger = new SharedHelper(mockLogger as unknown as FastifyBaseLogger)
 		const asin = 'B012DQ3BCM'
@@ -130,7 +133,8 @@ describe('SharedHelper should', () => {
 			name: string
 			type: string
 		}>
-		jest.spyOn(ApiGenreSchema, 'safeParse').mockReturnValue({
+		spyOn(ApiGenreSchema, 'safeParse').mockReturnValue({
+
 			success: false,
 			error: mockError
 		})
@@ -142,9 +146,10 @@ describe('SharedHelper should', () => {
 	})
 
 	test('collectGenres logs info when genre has no href', () => {
-		const mockInfo = jest.fn()
+		const mockInfo = mock()
+
 		const mockLogger = {
-			warn: jest.fn(),
+			warn: mock(),
 			info: mockInfo
 		}
 		const helperWithLogger = new SharedHelper(mockLogger as unknown as FastifyBaseLogger)

--- a/tests/setup/mockLogger.ts
+++ b/tests/setup/mockLogger.ts
@@ -1,11 +1,14 @@
 import { mock } from 'bun:test'
+import type { FastifyBaseLogger } from 'fastify'
 
-export const createMockLogger = () => ({
+export const createMockLogger = (): FastifyBaseLogger => ({
+	level: 'info',
 	error: mock(),
 	info: mock(),
 	warn: mock(),
 	debug: mock(),
 	fatal: mock(),
 	trace: mock(),
+	silent: mock(),
 	child: () => createMockLogger()
 })

--- a/tests/setup/mockLogger.ts
+++ b/tests/setup/mockLogger.ts
@@ -1,0 +1,11 @@
+import { mock } from 'bun:test'
+
+export const createMockLogger = () => ({
+	error: mock(),
+	info: mock(),
+	warn: mock(),
+	debug: mock(),
+	fatal: mock(),
+	trace: mock(),
+	child: () => createMockLogger()
+})


### PR DESCRIPTION
## Summary

Complete migration of the test suite from Jest to Bun's native `bun:test` runner, removing all Jest-specific dependencies and patterns.

Closes #865

## Changes

### Test framework migration (38 test files)
- Replace `jest.fn()`, `jest.mock()`, `jest.spyOn()` with Bun's `mock()`, `mock.module()`, `spyOn()`
- Replace `jest-mock-extended` `DeepMockProxy` with inline Bun `mock()` functions
- Replace Jest fake timers (`jest.useFakeTimers`) with Bun's `setSystemTime()`
- Add `afterAll(() => mock.restore())` teardowns across all test files
- Add `beforeEach(() => mock.clearAllMocks())` where needed for isolation

### Production code changes
- Extract `sleep()` to `src/helpers/utils/sleep.ts` for test mockability
- Simplify `/metrics` route: merge preHandler auth into handler to fix `ERR_HTTP_HEADERS_SENT` under Bun
- Narrow `MockContext.client` from `Partial<MongoClient>` to `Pick<MongoClient, 'db' | 'connect'>`
- Add `FastifyBaseLogger` return type to `createMockLogger()` with required `level`/`silent` properties

### Test quality improvements
- Replace plain-object Promise rejections with proper `Error` instances (author/book scrape tests)
- Remove redundant `as any` cast in health route test (`app` is already `any`)
- Remove unnecessary `as never` type assertions in UpdateScheduler test
- Remove duplicate comment in chapter test
- Add shared `tests/setup/mockLogger.ts` utility replacing inline logger mocks across 4 files

### Config/CI
- Remove `eslint-plugin-jest` from ESLint config
- Update test script to `bun test --parallel=1` with broader directory coverage
- Remove `jest`, `@types/jest`, `jest-mock-extended`, `ts-jest` dependencies
- Bump Bun CI version from 1.3.11 to 1.3.14 (1.3.11 has broken `mock.module()` for module aliases)

## Test results

```
636 pass, 15 skip, 5 todo, 0 fail
1100 expect() calls across 38 files
```

Full CI (prettier, tsc, eslint, bun test) passes cleanly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated the test suite from Jest to Bun’s native test runner and updated test helpers/fixtures.
  * Updated ESLint configuration to simplify plugins.
  * Upgraded Bun runtime in CI.

* **Refactor**
  * Simplified the metrics endpoint wiring.
  * Extracted a shared sleep utility for retry/delay logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laxamentumtech/audnexus/pull/866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->