### PR TITLE
fix: asins with leading \t characters being filtered out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.13.0](https://github.com/laxamentumtech/audnexus/compare/v1.12.0...v1.13.0) (2026-02-17)
+
+
+### Features
+
+* add Cloudflare IP auto-discovery for rate limiting ([6b633a3](https://github.com/laxamentumtech/audnexus/commit/6b633a37dd2823cdba9fe9753541380b935b6df7))
+
+
+### Bug Fixes
+
+* **cloudflare:** prevent race condition in concurrent IP fetches ([08312af](https://github.com/laxamentumtech/audnexus/commit/08312af15566de03698101c3eec9167b0b5c9431))
+* disable metrics by default, filter error responses, and secure rate limiting ([bb79540](https://github.com/laxamentumtech/audnexus/commit/bb79540f16f865e5ce81f3fcd78f8da6d0c8cd9f))
+* implement rate limiting improvements ([7468147](https://github.com/laxamentumtech/audnexus/commit/7468147b415e3af0406bfc5ca9839e8e87cbfdf0))
+
 ## [1.12.0](https://github.com/laxamentumtech/audnexus/compare/v1.11.0...v1.12.0) (2026-02-16)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.14.0](https://github.com/laxamentumtech/audnexus/compare/v1.13.0...v1.14.0) (2026-05-23)
+
+
+### Features
+
+* **ci:** harden CI workflow and refine error handling ([1dff995](https://github.com/laxamentumtech/audnexus/commit/1dff9950d66135e4a3b3331848392bb81558b440))
+* distinguish delisted products from region-unavailable errors ([#863](https://github.com/laxamentumtech/audnexus/issues/863)) ([3a0a417](https://github.com/laxamentumtech/audnexus/commit/3a0a4176125a9ddb47b42f96147aceb92a3e37ae))
+
+
+### Bug Fixes
+
+* **ci:** update setup-bun SHA to valid v2 tag commit ([31eea04](https://github.com/laxamentumtech/audnexus/commit/31eea041692d22b8f70ab6a72f1271ef3a30582e))
+
 ## [1.13.0](https://github.com/laxamentumtech/audnexus/compare/v1.12.0...v1.13.0) (2026-02-17)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.12.0](https://github.com/laxamentumtech/audnexus/compare/v1.11.0...v1.12.0) (2026-02-16)
+
+
+### Features
+
+* **server:** register metrics hooks and routes ([273846f](https://github.com/laxamentumtech/audnexus/commit/273846fd1437d51a65423eb45605ac1c0d00cf02))
+
+
+### Bug Fixes
+
+* **ci:** align action SHAs with existing workflows ([c48588d](https://github.com/laxamentumtech/audnexus/commit/c48588d41a232c34630e90056495584aa8db0040))
+* **ci:** correct pages action SHAs ([9c5c024](https://github.com/laxamentumtech/audnexus/commit/9c5c0247c98fc6d460e0b9e4e1ba325d79685cbc))
+* **ci:** correct pnpm/action-setup SHA hash ([417a693](https://github.com/laxamentumtech/audnexus/commit/417a693e5bd08896b91af0789b5aa45c07a578ea))
+* **scheduler:** remove artificial rate limiting in parallel mode ([d7cc5ae](https://github.com/laxamentumtech/audnexus/commit/d7cc5aeb7a9bb695ea1cf821df49c8240db87b8c))
+
 ## [1.11.0](https://github.com/laxamentumtech/audnexus/compare/v1.10.0...v1.11.0) (2026-02-16)
 
 ### Dependencies

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "audnexus",
-	"version": "1.12.0",
+	"version": "1.13.0",
 	"description": "An API for aggregating audiobook data",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "audnexus",
-	"version": "1.11.0",
+	"version": "1.12.0",
 	"description": "An API for aggregating audiobook data",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "audnexus",
-	"version": "1.13.0",
+	"version": "1.14.0",
 	"description": "An API for aggregating audiobook data",
 	"repository": {
 		"type": "git",

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -12,7 +12,7 @@ export const asin10Regex = new RegExp(`^${baseAsin10Regex.source}$`)
 export const asin11Regex = /\d{11}/gm
 
 // Reusable types
-export const AsinSchema = z.string().regex(asin10Regex)
+export const AsinSchema = z.string().trim().regex(asin10Regex)
 // Using different regex for 11 digit ASINs because zod validation needs quantifier
 export const GenreAsinSchema = z.string().regex(new RegExp(/^\d{10,12}$/))
 export const NameSchema = z.string().min(2)

--- a/tests/typing/types.test.ts
+++ b/tests/typing/types.test.ts
@@ -13,6 +13,22 @@ describe('schemas should', () => {
 		expect(AsinSchema.safeParse('B0B9YP4F9P').success).toBe(true)
 	})
 
+	test('trim surrounding whitespace from ASINs before validation', () => {
+		// Audible's API returns some author ASINs with a leading tab character,
+		// e.g. "\tB07NCZDY5W" (see PR #869). These must be accepted and normalized.
+		expect(AsinSchema.safeParse('\tB07NCZDY5W').success).toBe(true)
+		expect(AsinSchema.safeParse(' B079LRSMNN ').success).toBe(true)
+		expect(AsinSchema.safeParse('\nB07Q769RZS\n').success).toBe(true)
+
+		// The parsed value must be trimmed, not just validated.
+		expect(AsinSchema.parse('\tB07NCZDY5W')).toBe('B07NCZDY5W')
+		expect(AsinSchema.parse('  1705047572  ')).toBe('1705047572')
+
+		// Internal whitespace is not stripped and must still fail.
+		expect(AsinSchema.safeParse('B079\tRSMNN').success).toBe(false)
+		expect(AsinSchema.safeParse('B079 RSMNN').success).toBe(false)
+	})
+
 	test('validate ASINs with 11 characters', () => {
 		expect(GenreAsinSchema.safeParse('18574784011').success).toBe(true)
 		expect(GenreAsinSchema.safeParse('123456789011').success).toBe(true)


### PR DESCRIPTION
Some books (for example B0DJBZR5FG in region de) return invalid author ASINS (error by Audible), that start with a leading \t character. This causes zod to misinterpret the ASIN and not return the book properly. The fix is to trim ASINS before interpreting them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Product identifier validation now trims leading/trailing whitespace before validating, reducing accidental validation failures and returning the normalized identifier.
* **Tests**
  * Added coverage to ensure whitespace around identifiers is trimmed and accepted, while embedded whitespace still fails validation.
* **Chores**
  * Updated release/version information to 1.14.0 and refreshed changelog entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->