### PR TITLE
feat(search): add book title search endpoint

### DIFF
--- a/src/config/routes/books/search/show.ts
+++ b/src/config/routes/books/search/show.ts
@@ -1,12 +1,16 @@
 import { FastifyInstance } from 'fastify'
 
 import BookSearchApiHelper from '#helpers/books/audible/BookSearchApiHelper'
+import { regions } from '#static/regions'
 
 async function _show(fastify: FastifyInstance) {
 	fastify.get('/books/search', async (request, reply) => {
 		const { q, region = 'us' } = request.query as { q?: string; region?: string }
 		if (!q?.trim()) {
 			return reply.code(400).send({ error: 'Bad Request', message: 'q is required' })
+		}
+		if (!regions[region]) {
+			return reply.code(400).send({ error: 'Bad Request', message: `Unknown region: ${region}` })
 		}
 		const helper = new BookSearchApiHelper(q.trim(), region, request.log)
 		return helper.parseResults()

--- a/src/config/routes/books/search/show.ts
+++ b/src/config/routes/books/search/show.ts
@@ -5,11 +5,11 @@ import { regions } from '#static/regions'
 
 async function _show(fastify: FastifyInstance) {
 	fastify.get('/books/search', async (request, reply) => {
-		const { q, region = 'us' } = request.query as { q?: string; region?: string }
-		if (!q?.trim()) {
+		const { q, region = 'us' } = request.query as { q?: unknown; region?: unknown }
+		if (typeof q !== 'string' || !q.trim()) {
 			return reply.code(400).send({ error: 'Bad Request', message: 'q is required' })
 		}
-		if (!regions[region]) {
+		if (typeof region !== 'string' || !regions[region]) {
 			return reply.code(400).send({ error: 'Bad Request', message: `Unknown region: ${region}` })
 		}
 		const helper = new BookSearchApiHelper(q.trim(), region, request.log)

--- a/src/config/routes/books/search/show.ts
+++ b/src/config/routes/books/search/show.ts
@@ -1,0 +1,16 @@
+import { FastifyInstance } from 'fastify'
+
+import BookSearchApiHelper from '#helpers/books/audible/BookSearchApiHelper'
+
+async function _show(fastify: FastifyInstance) {
+	fastify.get('/books/search', async (request, reply) => {
+		const { q, region = 'us' } = request.query as { q?: string; region?: string }
+		if (!q?.trim()) {
+			return reply.code(400).send({ error: 'Bad Request', message: 'q is required' })
+		}
+		const helper = new BookSearchApiHelper(q.trim(), region, request.log)
+		return helper.parseResults()
+	})
+}
+
+export default _show

--- a/src/helpers/books/audible/BookSearchApiHelper.ts
+++ b/src/helpers/books/audible/BookSearchApiHelper.ts
@@ -1,8 +1,7 @@
 import type { FastifyBaseLogger } from 'fastify'
 
-import ApiHelper from './ApiHelper'
-
 import { ApiBook, AudibleProduct } from '#config/types'
+import ApiHelper from '#helpers/books/audible/ApiHelper'
 import fetch from '#helpers/utils/fetchPlus'
 import SharedHelper from '#helpers/utils/shared'
 import { ErrorMessageHTTPFetch } from '#static/messages'

--- a/src/helpers/books/audible/BookSearchApiHelper.ts
+++ b/src/helpers/books/audible/BookSearchApiHelper.ts
@@ -1,0 +1,69 @@
+import type { FastifyBaseLogger } from 'fastify'
+
+import ApiHelper from './ApiHelper'
+
+import { ApiBook, AudibleProduct } from '#config/types'
+import fetch from '#helpers/utils/fetchPlus'
+import SharedHelper from '#helpers/utils/shared'
+import { ErrorMessageHTTPFetch } from '#static/messages'
+import { regions } from '#static/regions'
+
+class BookSearchApiHelper {
+	query: string
+	region: string
+	requestUrl: string
+	logger?: FastifyBaseLogger
+
+	constructor(query: string, region: string, logger?: FastifyBaseLogger) {
+		this.query = query
+		this.region = region
+		this.logger = logger
+		const helper = new SharedHelper()
+		const baseDomain = 'https://api.audible'
+		const regionTLD = regions[region].tld
+		const baseUrl = '1.0/catalog/products'
+		// Same response groups as single ASIN lookup so getFinalData() can be reused
+		const paramArr = [
+			'category_ladders',
+			'contributors',
+			'media',
+			'product_attrs',
+			'product_desc',
+			'product_details',
+			'product_extended_attrs',
+			'rating',
+			'series',
+			'image_sizes=500,1024'
+		]
+		const paramStr = helper.getParamString(paramArr)
+		const encoded = encodeURIComponent(query)
+		this.requestUrl = `${baseDomain}.${regionTLD}/${baseUrl}?keywords=${encoded}&num_results=10&response_groups=${paramStr}`
+	}
+
+	async fetchBooks(): Promise<{ products: AudibleProduct['product'][] }> {
+		return fetch(this.requestUrl)
+			.then((response) => response.data as { products: AudibleProduct['product'][] })
+			.catch((error) => {
+				throw new Error(ErrorMessageHTTPFetch('search', error.status, 'Audible API'))
+			})
+	}
+
+	async parseResults(): Promise<ApiBook[]> {
+		const response = await this.fetchBooks()
+		if (!response?.products?.length) return []
+
+		const results = await Promise.allSettled(
+			response.products.map((product) => {
+				const helper = new ApiHelper(product.asin, this.region, this.logger)
+				helper.audibleResponse = product
+				return helper.getFinalData()
+			})
+		)
+
+		return results
+			.filter((r): r is PromiseFulfilledResult<ApiBook> => r.status === 'fulfilled')
+			.map((r) => r.value)
+	}
+}
+
+export default BookSearchApiHelper

--- a/src/helpers/books/audible/BookSearchApiHelper.ts
+++ b/src/helpers/books/audible/BookSearchApiHelper.ts
@@ -1,12 +1,12 @@
 import type { FastifyBaseLogger } from 'fastify'
 
+import ApiHelper from './ApiHelper'
+
 import { ApiBook, AudibleProduct } from '#config/types'
 import fetch from '#helpers/utils/fetchPlus'
 import SharedHelper from '#helpers/utils/shared'
 import { ErrorMessageHTTPFetch } from '#static/messages'
 import { regions } from '#static/regions'
-
-import ApiHelper from './ApiHelper'
 
 class BookSearchApiHelper {
 	query: string
@@ -62,7 +62,10 @@ class BookSearchApiHelper {
 
 		for (const [i, r] of results.entries()) {
 			if (r.status === 'rejected') {
-				this.logger?.warn({ asin: response.products[i].asin, err: r.reason }, 'Failed to parse search result')
+				this.logger?.warn(
+					{ asin: response.products[i].asin, err: r.reason },
+					'Failed to parse search result'
+				)
 			}
 		}
 

--- a/src/helpers/books/audible/BookSearchApiHelper.ts
+++ b/src/helpers/books/audible/BookSearchApiHelper.ts
@@ -1,12 +1,12 @@
 import type { FastifyBaseLogger } from 'fastify'
 
-import ApiHelper from './ApiHelper'
-
 import { ApiBook, AudibleProduct } from '#config/types'
 import fetch from '#helpers/utils/fetchPlus'
 import SharedHelper from '#helpers/utils/shared'
 import { ErrorMessageHTTPFetch } from '#static/messages'
 import { regions } from '#static/regions'
+
+import ApiHelper from './ApiHelper'
 
 class BookSearchApiHelper {
 	query: string
@@ -59,6 +59,12 @@ class BookSearchApiHelper {
 				return helper.getFinalData()
 			})
 		)
+
+		for (const [i, r] of results.entries()) {
+			if (r.status === 'rejected') {
+				this.logger?.warn({ asin: response.products[i].asin, err: r.reason }, 'Failed to parse search result')
+			}
+		}
 
 		return results
 			.filter((r): r is PromiseFulfilledResult<ApiBook> => r.status === 'fulfilled')

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,7 @@ import showAuthor from '#config/routes/authors/show'
 import deleteChapter from '#config/routes/books/chapters/delete'
 import showChapter from '#config/routes/books/chapters/show'
 import deleteBook from '#config/routes/books/delete'
+import searchBook from '#config/routes/books/search/show'
 import showBook from '#config/routes/books/show'
 import health from '#config/routes/health'
 import { registerMetricsRoute } from '#config/routes/metrics'
@@ -209,6 +210,7 @@ async function registerPlugins() {
  */
 async function registerRoutes() {
 	await server
+		.register(searchBook)
 		.register(showBook)
 		.register(deleteBook)
 		.register(showChapter)

--- a/tests/config/routes/books/search/show.test.ts
+++ b/tests/config/routes/books/search/show.test.ts
@@ -78,6 +78,12 @@ describe('GET /books/search', () => {
 		expect(reply.code).not.toHaveBeenCalledWith(400)
 	})
 
+	it('returns 400 for unknown region', async () => {
+		const reply = makeReply()
+		await getHandler(app)({ query: { q: 'test', region: 'zz' }, log: mockLog }, reply)
+		expect(reply.code).toHaveBeenCalledWith(400)
+	})
+
 	it('defaults region to us when not provided', async () => {
 		mockParseResults.mockResolvedValue([])
 		await getHandler(app)({ query: { q: 'test' }, log: mockLog }, makeReply())

--- a/tests/config/routes/books/search/show.test.ts
+++ b/tests/config/routes/books/search/show.test.ts
@@ -3,9 +3,13 @@ import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test'
 import _show from '#config/routes/books/search/show'
 
 const mockParseResults = mock()
+const mockConstructor = mock()
 
 mock.module('#helpers/books/audible/BookSearchApiHelper', () => ({
 	default: class MockBookSearchApiHelper {
+		constructor(...args: unknown[]) {
+			mockConstructor(...args)
+		}
 		parseResults = mockParseResults
 	}
 }))
@@ -40,6 +44,7 @@ describe('GET /books/search', () => {
 
 	beforeEach(async () => {
 		mockParseResults.mockReset()
+		mockConstructor.mockReset()
 		app = makeApp()
 		await _show(app as never)
 	})
@@ -74,8 +79,15 @@ describe('GET /books/search', () => {
 		mockParseResults.mockResolvedValue([])
 		const reply = makeReply()
 		await getHandler(app)({ query: { q: '  carl  ' }, log: mockLog }, reply)
-		expect(mockParseResults).toHaveBeenCalled()
+		expect(mockConstructor).toHaveBeenCalledWith('carl', 'us', mockLog)
 		expect(reply.code).not.toHaveBeenCalledWith(400)
+	})
+
+	it('returns 400 when q is repeated (array)', async () => {
+		const reply = makeReply()
+		await getHandler(app)({ query: { q: ['carl', 'donut'] }, log: mockLog }, reply)
+		expect(reply.code).toHaveBeenCalledWith(400)
+		expect(mockConstructor).not.toHaveBeenCalled()
 	})
 
 	it('returns 400 for unknown region', async () => {
@@ -87,7 +99,7 @@ describe('GET /books/search', () => {
 	it('defaults region to us when not provided', async () => {
 		mockParseResults.mockResolvedValue([])
 		await getHandler(app)({ query: { q: 'test' }, log: mockLog }, makeReply())
-		expect(mockParseResults).toHaveBeenCalled()
+		expect(mockConstructor).toHaveBeenCalledWith('test', 'us', mockLog)
 	})
 })
 

--- a/tests/config/routes/books/search/show.test.ts
+++ b/tests/config/routes/books/search/show.test.ts
@@ -1,0 +1,90 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import _show from '#config/routes/books/search/show'
+
+const mockParseResults = mock()
+
+mock.module('#helpers/books/audible/BookSearchApiHelper', () => ({
+	default: class MockBookSearchApiHelper {
+		parseResults = mockParseResults
+	}
+}))
+
+const mockLog = {
+	error: mock(),
+	info: mock(),
+	debug: mock(),
+	warn: mock()
+}
+
+function makeApp() {
+	// ponytail: minimal fastify stub — only what the route registers
+	const app = { get: mock() }
+	return app
+}
+
+function getHandler(app: ReturnType<typeof makeApp>) {
+	return app.get.mock.calls[0][1]
+}
+
+function makeReply() {
+	const reply = {
+		code: mock(() => reply),
+		send: mock(() => reply)
+	}
+	return reply
+}
+
+describe('GET /books/search', () => {
+	let app: ReturnType<typeof makeApp>
+
+	beforeEach(async () => {
+		mockParseResults.mockReset()
+		app = makeApp()
+		await _show(app as never)
+	})
+
+	it('returns 400 when q is missing', async () => {
+		const reply = makeReply()
+		await getHandler(app)({ query: {}, log: mockLog }, reply)
+		expect(reply.code).toHaveBeenCalledWith(400)
+	})
+
+	it('returns 400 when q is empty string', async () => {
+		const reply = makeReply()
+		await getHandler(app)({ query: { q: '' }, log: mockLog }, reply)
+		expect(reply.code).toHaveBeenCalledWith(400)
+	})
+
+	it('returns 400 when q is whitespace only', async () => {
+		const reply = makeReply()
+		await getHandler(app)({ query: { q: '   ' }, log: mockLog }, reply)
+		expect(reply.code).toHaveBeenCalledWith(400)
+	})
+
+	it('returns results from helper for valid query', async () => {
+		const books = [{ asin: 'B08V8B2CGV', title: 'Dungeon Crawler Carl' }]
+		mockParseResults.mockResolvedValue(books)
+		const reply = makeReply()
+		const result = await getHandler(app)({ query: { q: 'dungeon crawler carl' }, log: mockLog }, reply)
+		expect(result).toEqual(books)
+	})
+
+	it('trims whitespace from query before passing to helper', async () => {
+		mockParseResults.mockResolvedValue([])
+		const reply = makeReply()
+		await getHandler(app)({ query: { q: '  carl  ' }, log: mockLog }, reply)
+		expect(mockParseResults).toHaveBeenCalled()
+		expect(reply.code).not.toHaveBeenCalledWith(400)
+	})
+
+	it('defaults region to us when not provided', async () => {
+		mockParseResults.mockResolvedValue([])
+		await getHandler(app)({ query: { q: 'test' }, log: mockLog }, makeReply())
+		expect(mockParseResults).toHaveBeenCalled()
+	})
+})
+
+afterAll(() => {
+	mock.restore()
+})

--- a/tests/config/routes/books/search/show.test.ts
+++ b/tests/config/routes/books/search/show.test.ts
@@ -90,6 +90,13 @@ describe('GET /books/search', () => {
 		expect(mockConstructor).not.toHaveBeenCalled()
 	})
 
+	it('returns 400 when region is repeated (array)', async () => {
+		const reply = makeReply()
+		await getHandler(app)({ query: { q: 'carl', region: ['us', 'uk'] }, log: mockLog }, reply)
+		expect(reply.code).toHaveBeenCalledWith(400)
+		expect(mockConstructor).not.toHaveBeenCalled()
+	})
+
 	it('returns 400 for unknown region', async () => {
 		const reply = makeReply()
 		await getHandler(app)({ query: { q: 'test', region: 'zz' }, log: mockLog }, reply)

--- a/tests/helpers/books/audible/BookSearchApiHelper.test.ts
+++ b/tests/helpers/books/audible/BookSearchApiHelper.test.ts
@@ -94,12 +94,16 @@ describe('BookSearchApiHelper', () => {
 			expect(results).toHaveLength(1)
 		})
 
-		it('logs a warning for each rejected product', async () => {
+		it('logs a warning with asin and error for each rejected product', async () => {
+			const err = new Error('parse failed')
 			mockFetch.mockResolvedValue({ data: { products: [minimalProduct] } })
-			mockGetFinalData.mockRejectedValue(new Error('parse failed'))
+			mockGetFinalData.mockRejectedValue(err)
 			const helper = new BookSearchApiHelper('dungeon crawler carl', 'us', mockLogger)
 			await helper.parseResults()
-			expect(mockLogger.warn).toHaveBeenCalled()
+			expect(mockLogger.warn).toHaveBeenCalledWith(
+				{ asin: minimalProduct.asin, err },
+				'Failed to parse search result'
+			)
 		})
 
 		it('throws with structured message on fetch error', async () => {

--- a/tests/helpers/books/audible/BookSearchApiHelper.test.ts
+++ b/tests/helpers/books/audible/BookSearchApiHelper.test.ts
@@ -94,6 +94,14 @@ describe('BookSearchApiHelper', () => {
 			expect(results).toHaveLength(1)
 		})
 
+		it('logs a warning for each rejected product', async () => {
+			mockFetch.mockResolvedValue({ data: { products: [minimalProduct] } })
+			mockGetFinalData.mockRejectedValue(new Error('parse failed'))
+			const helper = new BookSearchApiHelper('dungeon crawler carl', 'us', mockLogger)
+			await helper.parseResults()
+			expect(mockLogger.warn).toHaveBeenCalled()
+		})
+
 		it('throws with structured message on fetch error', async () => {
 			mockFetch.mockRejectedValue({ status: 403 })
 			const helper = new BookSearchApiHelper('dungeon crawler carl', 'us', mockLogger)

--- a/tests/helpers/books/audible/BookSearchApiHelper.test.ts
+++ b/tests/helpers/books/audible/BookSearchApiHelper.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test'
 
 import BookSearchApiHelper from '#helpers/books/audible/BookSearchApiHelper'
+import { createMockLogger } from '#tests/setup/mockLogger'
 
 const mockFetch = mock()
 
@@ -15,12 +16,7 @@ mock.module('#helpers/books/audible/ApiHelper', () => ({
 	}
 }))
 
-const mockLogger = {
-	error: mock(),
-	info: mock(),
-	debug: mock(),
-	warn: mock()
-}
+const mockLogger = createMockLogger()
 
 const minimalProduct = {
 	asin: 'B08V8B2CGV',

--- a/tests/helpers/books/audible/BookSearchApiHelper.test.ts
+++ b/tests/helpers/books/audible/BookSearchApiHelper.test.ts
@@ -1,0 +1,107 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import BookSearchApiHelper from '#helpers/books/audible/BookSearchApiHelper'
+
+const mockFetch = mock()
+
+mock.module('#helpers/utils/fetchPlus', () => ({ default: mockFetch }))
+
+const mockGetFinalData = mock()
+
+mock.module('#helpers/books/audible/ApiHelper', () => ({
+	default: class MockApiHelper {
+		audibleResponse: unknown
+		getFinalData = mockGetFinalData
+	}
+}))
+
+const mockLogger = {
+	error: mock(),
+	info: mock(),
+	debug: mock(),
+	warn: mock()
+}
+
+const minimalProduct = {
+	asin: 'B08V8B2CGV',
+	title: 'Dungeon Crawler Carl',
+	authors: [{ name: 'Matt Dinniman', asin: 'B002BLP1QY' }]
+}
+
+const minimalBook = {
+	asin: 'B08V8B2CGV',
+	title: 'Dungeon Crawler Carl',
+	authors: [{ name: 'Matt Dinniman', asin: 'B002BLP1QY' }]
+}
+
+describe('BookSearchApiHelper', () => {
+	beforeEach(() => {
+		mockFetch.mockReset()
+		mockGetFinalData.mockReset()
+	})
+
+	describe('constructor', () => {
+		it('builds correct URL for us region', () => {
+			const helper = new BookSearchApiHelper('dungeon crawler carl', 'us', mockLogger)
+			expect(helper.requestUrl).toContain('https://api.audible.com/1.0/catalog/products')
+			expect(helper.requestUrl).toContain('keywords=dungeon%20crawler%20carl')
+			expect(helper.requestUrl).toContain('num_results=10')
+		})
+
+		it('uses correct TLD for non-us region', () => {
+			const helper = new BookSearchApiHelper('test', 'uk', mockLogger)
+			expect(helper.requestUrl).toContain('api.audible.co.uk')
+		})
+
+		it('URL-encodes the query', () => {
+			const helper = new BookSearchApiHelper('harry & the potter', 'us', mockLogger)
+			expect(helper.requestUrl).toContain('harry%20%26%20the%20potter')
+			expect(helper.requestUrl).not.toContain('harry & the potter')
+		})
+	})
+
+	describe('parseResults', () => {
+		it('returns empty array when no products', async () => {
+			mockFetch.mockResolvedValue({ data: { products: [] } })
+			const helper = new BookSearchApiHelper('nothing', 'us', mockLogger)
+			expect(await helper.parseResults()).toEqual([])
+		})
+
+		it('returns empty array when products is undefined', async () => {
+			mockFetch.mockResolvedValue({ data: {} })
+			const helper = new BookSearchApiHelper('nothing', 'us', mockLogger)
+			expect(await helper.parseResults()).toEqual([])
+		})
+
+		it('returns parsed books for valid products', async () => {
+			mockFetch.mockResolvedValue({ data: { products: [minimalProduct] } })
+			mockGetFinalData.mockResolvedValue(minimalBook)
+			const helper = new BookSearchApiHelper('dungeon crawler carl', 'us', mockLogger)
+			const results = await helper.parseResults()
+			expect(results).toHaveLength(1)
+			expect(results[0]).toEqual(minimalBook)
+		})
+
+		it('skips products where getFinalData rejects', async () => {
+			const goodProduct = { ...minimalProduct, asin: 'GOOD1234' }
+			const badProduct = { ...minimalProduct, asin: 'BAD12345' }
+			mockFetch.mockResolvedValue({ data: { products: [goodProduct, badProduct] } })
+			mockGetFinalData
+				.mockResolvedValueOnce(minimalBook)
+				.mockRejectedValueOnce(new Error('parse failed'))
+			const helper = new BookSearchApiHelper('dungeon crawler carl', 'us', mockLogger)
+			const results = await helper.parseResults()
+			expect(results).toHaveLength(1)
+		})
+
+		it('throws with structured message on fetch error', async () => {
+			mockFetch.mockRejectedValue({ status: 403 })
+			const helper = new BookSearchApiHelper('dungeon crawler carl', 'us', mockLogger)
+			await expect(helper.parseResults()).rejects.toThrow()
+		})
+	})
+})
+
+afterAll(() => {
+	mock.restore()
+})


### PR DESCRIPTION
Replaces #873 (same commits, rebased onto `develop` per maintainer guidance — no more release artifacts in the diff).

Adds a title search endpoint that proxies Audible's catalog API and returns results in the existing `ApiBook[]` shape.

Endpoint: `GET /books/search?q=<query>&region=<region>`

- `q` (required) - keyword query, URL-encoded; returns 400 when missing/blank
- `region` (optional, default `us`) - validated against existing region codes, 400 on unknown values
- Results are fetched in parallel via `Promise.allSettled`; failed individual products are logged (ASIN + error) and skipped
- No DB/Redis involvement - pass-through only
- Returns up to 10 results (Audible default)

All CodeRabbit findings from #873 are already addressed in these commits. Testing: route input validation + helper unit tests using `bun:test` native mocks (664 tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a book search endpoint: `GET /books/search`.
  * Search terms are trimmed; region selection is supported and defaults to `us`.
  * Returns matching books from the external catalog and includes partial results when some items can’t be processed.
* **Bug Fixes**
  * Added request validation for blank/invalid `q` and unknown/invalid `region`, returning `400` for bad inputs.
  * Improves handling when upstream fetching fails or individual results can’t be parsed.
* **Tests**
  * Added route and helper test coverage for validation, trimming, region rules, parsing, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->