### PR TITLE
fix(config): trim surrounding whitespace from ASINs before validation

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -12,7 +12,7 @@ export const asin10Regex = new RegExp(`^${baseAsin10Regex.source}$`)
 export const asin11Regex = /\d{11}/gm
 
 // Reusable types
-export const AsinSchema = z.string().regex(asin10Regex)
+export const AsinSchema = z.string().trim().regex(asin10Regex)
 // Using different regex for 11 digit ASINs because zod validation needs quantifier
 export const GenreAsinSchema = z.string().regex(new RegExp(/^\d{10,12}$/))
 export const NameSchema = z.string().min(2)

--- a/tests/typing/types.test.ts
+++ b/tests/typing/types.test.ts
@@ -13,6 +13,22 @@ describe('schemas should', () => {
 		expect(AsinSchema.safeParse('B0B9YP4F9P').success).toBe(true)
 	})
 
+	test('trim surrounding whitespace from ASINs before validation', () => {
+		// Audible's API returns some author ASINs with a leading tab character,
+		// e.g. "\tB07NCZDY5W" (see PR #869). These must be accepted and normalized.
+		expect(AsinSchema.safeParse('\tB07NCZDY5W').success).toBe(true)
+		expect(AsinSchema.safeParse(' B079LRSMNN ').success).toBe(true)
+		expect(AsinSchema.safeParse('\nB07Q769RZS\n').success).toBe(true)
+
+		// The parsed value must be trimmed, not just validated.
+		expect(AsinSchema.parse('\tB07NCZDY5W')).toBe('B07NCZDY5W')
+		expect(AsinSchema.parse('  1705047572  ')).toBe('1705047572')
+
+		// Internal whitespace is not stripped and must still fail.
+		expect(AsinSchema.safeParse('B079\tRSMNN').success).toBe(false)
+		expect(AsinSchema.safeParse('B079 RSMNN').success).toBe(false)
+	})
+
 	test('validate ASINs with 11 characters', () => {
 		expect(GenreAsinSchema.safeParse('18574784011').success).toBe(true)
 		expect(GenreAsinSchema.safeParse('123456789011').success).toBe(true)


### PR DESCRIPTION
## What & why

Audible's API sometimes returns author ASINs with a leading tab character (e.g. `\tB07NCZDY5W`). `AsinSchema`'s regex rejected these values, so otherwise-valid books were silently filtered out. `AsinSchema` now `.trim()`s surrounding whitespace before regex validation.

## Changes

- `src/config/types.ts` — add `.trim()` to `AsinSchema` before the `asin10Regex` check.
- `tests/typing/types.test.ts` — regression test asserting surrounding whitespace (spaces, `\t`, `\n`) is trimmed and accepted, that the parsed value is normalized, and that internal whitespace is still rejected.

## Notes

- Supersedes #869, which was accidentally opened from `main` and therefore pulled in unrelated release history (workflow files, `AGENTS.md`, `docker-compose`, `package.json` version bump, `CHANGELOG`). This branch is cut from `develop` and contains a single Conventional Commit with the 2-file change only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - ASIN inputs with leading or trailing spaces, tabs, or newlines are now accepted and automatically trimmed.
  - Inputs containing whitespace within the ASIN continue to be rejected.

- **Tests**
  - Added coverage for trimming valid ASIN inputs and rejecting internal whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->