### PR TITLE
fix(ci): align release-please tag scheme with existing v* tags

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+	"include-component-in-tag": false,
 	"packages": {
 		".": {
 			"release-type": "node",


### PR DESCRIPTION
## Problem

Release-please was generating `audnexus-v*` tags (component-prefixed), but all 20 existing releases use `v*` tags (no prefix). This mismatch caused release-please to fail finding the last release anchor:

```
⚠ Found release tag with component , but not configured in manifest
⚠ Expected 1 releases, only found 0
```

Without an anchor, release-please swept **all** commit history on every run, producing:
- Changelogs that include commits already shipped in 1.10.0–1.14.0 (#887, #890)
- Version bumps to 1.16.0 with **no new code** since 1.15.0 (#890)

## Fix

Add `"include-component-in-tag": false` to `release-please-config.json`. This makes release-please generate `v*` tags, matching the existing `v1.0.0` → `v1.14.0` scheme.

## Verification

The action log for run [30150631818](https://github.com/laxamentumtech/audnexus/actions/runs/30150631818) shows `include-component-in-tag: false` was already the **action input** default, but the config file overrides action inputs — and the config was missing this key, so it defaulted to `true`. Adding it explicitly to the config ensures release-please uses the correct tag scheme.

Per [release-please docs](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#subsequent-versions):

> To fix this, component can be removed from tagName being searched using the `include-component-in-tag` property. Setting this to `false` will change the tagName to `v<release-version>`