### PR TITLE
fix(books): allow future release dates for pre-orders #881

### DIFF
--- a/src/helpers/books/audible/ApiHelper.ts
+++ b/src/helpers/books/audible/ApiHelper.ts
@@ -31,7 +31,6 @@ import {
 	ErrorMessageParse,
 	ErrorMessageProductDelisted,
 	ErrorMessageRegion,
-	ErrorMessageReleaseDate,
 	ErrorMessageRequiredKey
 } from '#static/messages'
 import { regions } from '#static/regions'
@@ -189,7 +188,8 @@ class ApiHelper {
 	 * 1. The release date of the product
 	 * 2. The issue date of the product
 	 *
-	 * Error on a date in the future.
+	 * Future dates are valid and indicate pre-order/upcoming titles; they are
+	 * returned as-is so callers can treat them as pre-order metadata.
 	 */
 	getReleaseDate() {
 		if (!this.audibleResponse) throw new Error(ErrorMessageNoData(this.asin, 'ApiHelper'))
@@ -197,8 +197,6 @@ class ApiHelper {
 			? new Date(this.audibleResponse.release_date)
 			: new Date(this.audibleResponse.issue_date)
 
-		// Check that release date isn't in the future
-		if (releaseDate > new Date()) throw new Error(ErrorMessageReleaseDate(this.asin))
 		return releaseDate
 	}
 

--- a/src/helpers/routes/GenericShowHelper.ts
+++ b/src/helpers/routes/GenericShowHelper.ts
@@ -148,6 +148,14 @@ export default class GenericShowHelper {
 	}
 
 	/**
+	 * A book is a pre-order when its freshly-fetched releaseDate is strictly in
+	 * the future. Pre-order metadata is provisional and must not be persisted.
+	 */
+	private isPreOrder(data: ApiAuthorProfile | ApiBook | ApiChapter | undefined): boolean {
+		return this.type === 'book' && !!data && (data as ApiBook).releaseDate > new Date()
+	}
+
+	/**
 	 * Get the new data and pass it to the paprHelper to create or update the data
 	 * Then, set redis cache and return the data
 	 * @returns {Promise<ApiAuthorProfile | ApiBook | ApiChapter | undefined>}
@@ -158,6 +166,15 @@ export default class GenericShowHelper {
 		const newData = await this.getNewData()
 		// Special handling for chapter undefined
 		if (this.type == 'chapter' && !newData) return undefined
+
+		// Pre-order books carry provisional metadata that can change before release;
+		// return them transiently without persisting to Papr or Redis.
+		if (this.isPreOrder(newData)) {
+			this.logger?.info(
+				`Pre-order book ${this.asin} (releaseDate ${(newData as ApiBook).releaseDate.toISOString()}): returning transient data, skipping persistence.`
+			)
+			return newData
+		}
 
 		this.paprHelper.setData(newData as never)
 

--- a/src/static/messages.ts
+++ b/src/static/messages.ts
@@ -33,9 +33,6 @@ export const ErrorMessageContentTypeMismatch = (
 // Validation failed
 export const ErrorMessageValidationFailed = (asin: string, reason: string) =>
 	`Validation failed for ASIN: ${asin}. ${reason}`
-// Release date is in the future
-export const ErrorMessageReleaseDate = (asin: string) =>
-	`Release date is in the future for ASIN: ${asin}`
 // Required key generic message
 export const ErrorMessageRequiredKey = (asin: string, key: string, source: string) =>
 	`Required key '${key}' does not ${source} in Audible API response for ASIN ${asin}`

--- a/tests/helpers/books/audible/ApiHelper.test.ts
+++ b/tests/helpers/books/audible/ApiHelper.test.ts
@@ -443,10 +443,12 @@ describe('ApiHelper should throw error when', () => {
 		expect(() => helper.getFinalData()).toThrow('No input data')
 	})
 
-	test('release_date is in the future', async () => {
+	test('release_date is in the future returns the future date (pre-order)', async () => {
 		helper.audibleResponse = mockResponse.product
 		helper.audibleResponse!.release_date = '2080-01-01'
-		expect(() => helper.getReleaseDate()).toThrow('Release date is in the future')
+		const result = helper.getReleaseDate()
+		expect(result).toBeInstanceOf(Date)
+		expect(result.toISOString()).toBe(new Date('2080-01-01').toISOString())
 	})
 
 	test('category is invalid', () => {

--- a/tests/helpers/routes/GenericShowHelper.test.ts
+++ b/tests/helpers/routes/GenericShowHelper.test.ts
@@ -350,13 +350,15 @@ describe('GenericShowHelper pre-order transient handling', () => {
 
 		spyOn(helper, 'getNewData').mockResolvedValue(pastBook)
 		const setDataSpy = spyOn(helper.paprHelper, 'setData')
-		spyOn(helper.paprHelper, 'createOrUpdate').mockResolvedValue({ data: pastBook })
+		const createOrUpdateSpy = spyOn(helper.paprHelper, 'createOrUpdate')
+		createOrUpdateSpy.mockResolvedValue({ data: pastBook })
 		spyOn(helper, 'getDataWithProjection').mockResolvedValue(pastBook)
 		const setOneSpy = spyOn(helper.redisHelper, 'setOne')
 
 		await helper.createOrUpdateData()
 
 		expect(setDataSpy).toHaveBeenCalledTimes(1)
+		expect(createOrUpdateSpy).toHaveBeenCalledTimes(1)
 		expect(setOneSpy).toHaveBeenCalledTimes(1)
 	})
 })

--- a/tests/helpers/routes/GenericShowHelper.test.ts
+++ b/tests/helpers/routes/GenericShowHelper.test.ts
@@ -21,6 +21,7 @@ mock.module('#helpers/database/papr/audible/PaprAudibleBookHelper', () => {
 	}
 })
 
+import type { ApiBook } from '#config/types'
 import { BadRequestError, NotFoundError } from '#helpers/errors/ApiErrors'
 import GenericShowHelper from '#helpers/routes/GenericShowHelper'
 import { bookWithoutProjection } from '#tests/datasets/helpers/books'
@@ -300,6 +301,63 @@ describe('GenericShowHelper updateActions non-Error rejection handling', () => {
 			expect(error.message).toBe('undefined')
 			expect(error.cause).toBe(undefined)
 		}
+	})
+})
+
+describe('GenericShowHelper pre-order transient handling', () => {
+	let helper: GenericShowHelper
+	const asin = 'B0DLQ2TZCD'
+	let mockLogger: ReturnType<typeof createMockLogger>
+
+	beforeEach(() => {
+		mockLogger = createMockLogger()
+		helper = new GenericShowHelper(
+			asin,
+			{ region: 'us', seedAuthors: undefined, update: '1' },
+			null,
+			'book',
+			mockLogger
+		)
+	})
+
+	test('returns pre-order data transiently without persisting to Papr or Redis', async () => {
+		const futureDate = new Date()
+		futureDate.setFullYear(futureDate.getFullYear() + 1)
+		const preOrderBook = {
+			...(bookWithoutProjection as unknown as ApiBook),
+			releaseDate: futureDate
+		} as ApiBook
+
+		spyOn(helper, 'getNewData').mockResolvedValue(preOrderBook)
+		const setDataSpy = spyOn(helper.paprHelper, 'setData')
+		const createOrUpdateSpy = spyOn(helper.paprHelper, 'createOrUpdate')
+		const setOneSpy = spyOn(helper.redisHelper, 'setOne')
+
+		const result = await helper.createOrUpdateData()
+
+		expect(result).toBe(preOrderBook)
+		expect(setDataSpy).not.toHaveBeenCalled()
+		expect(createOrUpdateSpy).not.toHaveBeenCalled()
+		expect(setOneSpy).not.toHaveBeenCalled()
+		expect(mockLogger.info).toHaveBeenCalledTimes(1)
+	})
+
+	test('persists released books normally (releaseDate in the past)', async () => {
+		const pastBook = {
+			...(bookWithoutProjection as unknown as ApiBook),
+			releaseDate: new Date('2020-01-01')
+		} as ApiBook
+
+		spyOn(helper, 'getNewData').mockResolvedValue(pastBook)
+		const setDataSpy = spyOn(helper.paprHelper, 'setData')
+		spyOn(helper.paprHelper, 'createOrUpdate').mockResolvedValue({ data: pastBook })
+		spyOn(helper, 'getDataWithProjection').mockResolvedValue(pastBook)
+		const setOneSpy = spyOn(helper.redisHelper, 'setOne')
+
+		await helper.createOrUpdateData()
+
+		expect(setDataSpy).toHaveBeenCalledTimes(1)
+		expect(setOneSpy).toHaveBeenCalledTimes(1)
 	})
 })
 


### PR DESCRIPTION
## Summary

Allow pre-order audiobooks to return fresh metadata without erroring or caching.

## Motivation

`GET /books/:asin` returned HTTP 500 for any pre-order title because `ApiHelper.getReleaseDate()` unconditionally threw when `releaseDate` was in the future. Pre-order titles are a standard part of the Audible catalog — their future release dates are valid data, not errors.

## Changes

- **`ApiHelper.getReleaseDate()`**: Removed the future-date throw guard; future dates are now returned as-is.
- **`GenericShowHelper.createOrUpdateData()`**: Added `isPreOrder()` predicate and a transient return branch — pre-order books skip Papr/Redis persistence entirely, so provisional metadata is never cached.
- **`messages.ts`**: Deleted the now-unused `ErrorMessageReleaseDate` constant.
- **Tests**: Updated the `ApiHelper` future-date test to assert a return value (not a throw) and added a `GenericShowHelper` test suite covering transient pre-order handling and normal released-book persistence.

## Notes

Pre-order metadata is provisional — description, image, authors, and even the release date can change before the actual launch. Caching it would serve stale data. The trade-off is one Audible fetch per pre-order request, which is acceptable given low pre-order traffic. Legacy persisted pre-orders are out of scope for this fix.

## Resolves

Fixes #881


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Future-dated book releases are now treated as pre-orders instead of causing an error.
  * Pre-order results are returned to the caller without being stored or cached.
  * Released books continue to be stored and cached as before.
* **Tests**
  * Added/updated automated tests to verify pre-order transient handling and standard released-book processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->