### PR TITLE
fix(api): handle unknown Audible content_delivery_type values #885

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -216,10 +216,26 @@ const podcastShape = z.object({
 
 // This is the shape of the data we get from Audible's API for series content
 const seriesShape = z.object({
-	content_delivery_type: z.enum(['MultiPartBook', 'SinglePartBook']),
+	content_delivery_type: z.enum([
+		'MultiPartBook',
+		'SinglePartBook',
+		'AudioPart',
+		'SinglePartIssue',
+		'PodcastEpisode',
+		'BookSeries',
+		'Periodical',
+		'Bundle'
+	]),
 	publication_name: z.string().optional(),
 	series: z.array(AudibleSeriesSchema).optional()
 })
+
+// Single source of truth for the recognized content_delivery_type values.
+// Used by the schema, the parser, and the live-test availability check
+// so they cannot drift apart. PodcastParent is intentionally excluded:
+// it is handled as a content type mismatch in ApiHelper.parseResponse.
+export const recognizedContentTypes: readonly string[] =
+	seriesShape.shape.content_delivery_type.options
 
 // This is the shape for fallback when content_delivery_type is missing or unknown
 export const fallbackShape = baseShape.extend({

--- a/src/helpers/books/audible/ApiHelper.ts
+++ b/src/helpers/books/audible/ApiHelper.ts
@@ -18,7 +18,8 @@ import {
 	AudibleSeriesSchema,
 	baseShape,
 	FallbackAudibleProduct,
-	fallbackShape
+	fallbackShape,
+	recognizedContentTypes
 } from '#config/types'
 import { ContentTypeMismatchError, NotFoundError } from '#helpers/errors/ApiErrors'
 import cleanupDescription from '#helpers/utils/cleanupDescription'
@@ -429,7 +430,7 @@ class ApiHelper {
 		}
 
 		// Check if content_delivery_type exists and is a known book type
-		const knownTypes = ['MultiPartBook', 'SinglePartBook']
+		const knownTypes = recognizedContentTypes
 		if (!contentType || !knownTypes.includes(contentType)) {
 			// Try parsing with baseShape directly (fallback for missing/unknown type)
 			const baseResult = baseShape.safeParse(product)

--- a/tests/helpers/books/audible/ApiHelper.test.ts
+++ b/tests/helpers/books/audible/ApiHelper.test.ts
@@ -364,11 +364,15 @@ describe('ApiHelper edge cases should', () => {
 		)
 	})
 
-	// The six new recognized types added beyond MultiPartBook/SinglePartBook.
-	// Each must parse through AudibleProductSchema without the Unknown-content-type warning.
-	const newContentTypes = recognizedContentTypes.filter(
-		(type) => type !== 'MultiPartBook' && type !== 'SinglePartBook'
-	)
+	// The six recognized types beyond the original MultiPartBook/SinglePartBook.
+	const newContentTypes = ['AudioPart', 'SinglePartIssue', 'PodcastEpisode', 'BookSeries', 'Periodical', 'Bundle'] as const
+
+	test('recognizedContentTypes includes all six newer content types', () => {
+		for (const type of newContentTypes) {
+			expect(recognizedContentTypes).toContain(type)
+		}
+	})
+
 	for (const type of newContentTypes) {
 		test(`parses recognized content_delivery_type '${type}' without warning`, async () => {
 			const response = deepCopy(mockResponse)

--- a/tests/helpers/books/audible/ApiHelper.test.ts
+++ b/tests/helpers/books/audible/ApiHelper.test.ts
@@ -7,7 +7,8 @@ import {
 	AudibleProduct,
 	AudibleProductSchema,
 	AudibleSeries,
-	fallbackShape
+	fallbackShape,
+	recognizedContentTypes
 } from '#config/types'
 import ApiHelper from '#helpers/books/audible/ApiHelper'
 import { ContentTypeMismatchError, NotFoundError } from '#helpers/errors/ApiErrors'
@@ -362,6 +363,23 @@ describe('ApiHelper edge cases should', () => {
 			expect.stringContaining('Unknown content_delivery_type')
 		)
 	})
+
+	// The six new recognized types added beyond MultiPartBook/SinglePartBook.
+	// Each must parse through AudibleProductSchema without the Unknown-content-type warning.
+	const newContentTypes = recognizedContentTypes.filter(
+		(type) => type !== 'MultiPartBook' && type !== 'SinglePartBook'
+	)
+	for (const type of newContentTypes) {
+		test(`parses recognized content_delivery_type '${type}' without warning`, async () => {
+			const response = deepCopy(mockResponse)
+			response.product.content_delivery_type = type
+			const mockLogger = createMockLogger()
+			helper = new ApiHelper(asin, region, mockLogger as unknown as FastifyBaseLogger)
+			const data = await helper.parseResponse(response)
+			expect(data.asin).toBe(asin)
+			expect(mockLogger.warn).not.toHaveBeenCalled()
+		})
+	}
 
 	test('throws region unavailable when baseShape also fails', async () => {
 		const emptyProductResponse = { product: {} } as AudibleProduct

--- a/tests/live/audible/books/api.live.test.ts
+++ b/tests/live/audible/books/api.live.test.ts
@@ -1,4 +1,4 @@
-import type { ApiBook, AudibleProduct } from '#config/types'
+import { type ApiBook, type AudibleProduct, recognizedContentTypes } from '#config/types'
 import ApiHelper from '#helpers/books/audible/ApiHelper'
 import { BadRequestError, ContentTypeMismatchError, NotFoundError } from '#helpers/errors/ApiErrors'
 
@@ -24,7 +24,7 @@ function isInUnavailableAllowlist(asin: string, region: string): boolean {
 function checkAvailability(response: AudibleProduct): boolean {
 	const product = response.product
 	const contentType = product?.content_delivery_type
-	const knownTypes = ['PodcastParent', 'MultiPartBook', 'SinglePartBook'] // PodcastParent included for detection purposes - content type mismatch should be thrown
+	const knownTypes = [...recognizedContentTypes, 'PodcastParent'] // PodcastParent included for detection - content type mismatch should be thrown
 
 	// Content is only considered available when content_delivery_type is present and known
 	// This prevents false positives from incomplete product stubs


### PR DESCRIPTION
## Summary
Recognize six new Audible `content_delivery_type` enum values in the product schema parser.

## Motivation
Production server logs revealed Audible now returns `AudioPart`, `SinglePartIssue`, `PodcastEpisode`, `BookSeries`, `Periodical`, and `Bundle` as `content_delivery_type` values. Each previously triggered an `[AUDIBLE API] Unknown content_delivery_type` warning and fell back to an `Unknown` product shape, losing the actual type information.

## Changes
- Extended the `content_delivery_type` Zod enum in `seriesShape` to include all six new types, which reuse the existing book-shaped schema (optional `publication_name` and `series` fields).
- Exported `recognizedContentTypes` derived from the schema enum as a single source of truth, replacing hardcoded whitelists in `ApiHelper.parseResponse()` and the live-test availability checker.
- Added parameterized unit tests verifying each new type parses without triggering the unknown-type warning.

## Notes
Genuinely unknown types still fall back to the `'Unknown'` path with the existing warning. `PodcastParent` remains handled separately as a content-type mismatch. No dedicated shapes were added — the six new types share `seriesShape + baseShape`, which covers the verified `BookSeries` and `Bundle` payloads observed via live API probing.

## Resolves
Closes #885


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Expanded Audible content-type recognition to support additional book, audio, issue, podcast, series, and bundle formats.
  * Improved processing of supported Audible products, reducing incorrect classification as unknown content.
  * Enhanced availability checks for a broader range of Audible content types.

* **Tests**
  * Added coverage to verify all recognized content types are handled successfully without unnecessary warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->