### PR TITLE
fix(scraping): add retry, ASIN and content-type checks #884

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -13,6 +13,13 @@ export const asin11Regex = /\d{11}/gm
 
 // Reusable types
 export const AsinSchema = z.string().trim().regex(asin10Regex)
+// Audible book/author ASINs are always B-prefixed 10-char identifiers.
+// Used for route-param validation only; AsinSchema stays permissive for stored
+// data (chapter asins etc. can legitimately be numeric).
+export const BookAsinSchema = z
+	.string()
+	.trim()
+	.regex(/^B[\dA-Z]{9}$/)
 // Using different regex for 11 digit ASINs because zod validation needs quantifier
 export const GenreAsinSchema = z.string().regex(new RegExp(/^\d{10,12}$/))
 export const NameSchema = z.string().min(2)

--- a/src/helpers/books/audible/ApiHelper.ts
+++ b/src/helpers/books/audible/ApiHelper.ts
@@ -436,7 +436,7 @@ class ApiHelper {
 		}
 
 		// Check if content_delivery_type exists and is a known book type
-		const knownTypes = ['MultiPartBook', 'SinglePartBook']
+		const knownTypes = recognizedContentTypes
 		// Present but not a known book type → reject with a clear error instead of
 		// silently storing a non-book that later fails as "Data type is not ApiBook".
 		if (contentType !== undefined && !knownTypes.includes(contentType)) {

--- a/src/helpers/books/audible/ApiHelper.ts
+++ b/src/helpers/books/audible/ApiHelper.ts
@@ -436,14 +436,25 @@ class ApiHelper {
 		}
 
 		// Check if content_delivery_type exists and is a known book type
-		const knownTypes = recognizedContentTypes
-		if (!contentType || !knownTypes.includes(contentType)) {
-			// Try parsing with baseShape directly (fallback for missing/unknown type)
+		const knownTypes = ['MultiPartBook', 'SinglePartBook']
+		// Present but not a known book type → reject with a clear error instead of
+		// silently storing a non-book that later fails as "Data type is not ApiBook".
+		if (contentType !== undefined && !knownTypes.includes(contentType)) {
+			throw new ContentTypeMismatchError(
+				ErrorMessageContentTypeMismatch(this.asin, contentType, 'book'),
+				{ asin: this.asin, requestedType: 'book', actualType: contentType }
+			)
+		}
+		// Missing content_delivery_type → fall back to baseShape (some catalog
+		// responses omit it entirely) and let fetchProductState surface a delisted/
+		// region-unavailable NotFoundError if baseShape also fails.
+		if (!contentType) {
+			// Try parsing with baseShape directly (fallback for missing type)
 			const baseResult = baseShape.safeParse(product)
 			if (baseResult.success) {
-				// Log unknown type for future analysis
+				// Log missing type for future analysis
 				this.logger?.warn(
-					`[AUDIBLE API] Unknown content_delivery_type: ${contentType} for ASIN ${this.asin}`
+					`[AUDIBLE API] Missing content_delivery_type for ASIN ${this.asin}; falling back to baseShape`
 				)
 				// Set the discriminant for the fallback type
 				this.audibleResponse = fallbackShape.parse({

--- a/src/helpers/routes/RouteCommonHelper.ts
+++ b/src/helpers/routes/RouteCommonHelper.ts
@@ -1,7 +1,7 @@
 import { FastifyReply } from 'fastify'
 import { ZodError } from 'zod'
 
-import { ApiQueryString, ApiQueryStringSchema, AsinSchema } from '#config/types'
+import { ApiQueryString, ApiQueryStringSchema, BookAsinSchema } from '#config/types'
 import { BadRequestError } from '#helpers/errors/ApiErrors'
 import {
 	ErrorMessageBadQuery,
@@ -59,7 +59,7 @@ class RouteCommonHelper {
 	 * @returns {boolean}
 	 */
 	isValidAsin(asin: string): boolean {
-		return AsinSchema.safeParse(asin).success
+		return BookAsinSchema.safeParse(asin).success
 	}
 
 	/**

--- a/src/helpers/utils/fetchPlus.ts
+++ b/src/helpers/utils/fetchPlus.ts
@@ -12,41 +12,39 @@ const TRANSIENT_STATUSES = new Set([429, 503, 504])
 
 /**
  * Calculates the delay for retry attempts with exponential backoff.
- * For 429 status, uses exponential backoff starting at 1s, doubling each retry (max 8s).
- * Respects Retry-After header if present (includes delay-in-seconds and HTTP-date formats).
+ * For 429 status, honors Retry-After header when present (delay-in-seconds and HTTP-date formats),
+ * otherwise uses exponential backoff starting at 1s, doubling each retry (max 8s).
+ * For 503/504, always uses exponential backoff (Retry-After is ignored).
  * @param {number} retries The current retry count
  * @param {AxiosError} error The axios error response
  * @returns {number} The delay in milliseconds
  */
 function calculateRetryDelay(retries: number, error: AxiosError): number {
-	if (!error.response || !error.response.headers) {
-		// No response or headers, fall back to exponential backoff
-		return Math.min(1000 * Math.pow(2, retries), MAX_BACKOFF_MS)
-	}
+	const status = error.response?.status
 
-	const retryAfter = error.response.headers['retry-after']
-	if (!retryAfter) {
-		// No Retry-After header, fall back to exponential backoff
-		return Math.min(1000 * Math.pow(2, retries), MAX_BACKOFF_MS)
-	}
+	// Only honor Retry-After for 429; 503/504 always use exponential backoff
+	if (status === 429 && error.response?.headers) {
+		const retryAfter = error.response.headers['retry-after']
+		if (retryAfter) {
+			// Retry-After can be a delay in seconds or an HTTP-date
+			const parsedAsNumber = parseInt(retryAfter, 10)
+			if (!isNaN(parsedAsNumber) && parsedAsNumber > 0) {
+				return parsedAsNumber * 1000
+			}
 
-	// Retry-After can be a delay in seconds or an HTTP-date
-	const parsedAsNumber = parseInt(retryAfter, 10)
-	if (!isNaN(parsedAsNumber) && parsedAsNumber > 0) {
-		return parsedAsNumber * 1000
-	}
-
-	// Try parsing as HTTP-date (e.g., "Wed, 21 Oct 2015 07:28:00 GMT")
-	const parsedDate = new Date(retryAfter)
-	if (!isNaN(parsedDate.getTime())) {
-		const now = Date.now()
-		const delay = parsedDate.getTime() - now
-		if (delay > 0) {
-			return delay
+			// Try parsing as HTTP-date (e.g., "Wed, 21 Oct 2015 07:28:00 GMT")
+			const parsedDate = new Date(retryAfter)
+			if (!isNaN(parsedDate.getTime())) {
+				const now = Date.now()
+				const delay = parsedDate.getTime() - now
+				if (delay > 0) {
+					return delay
+				}
+			}
 		}
 	}
 
-	// Invalid Retry-After value, fall back to exponential backoff
+	// Exponential backoff (429 without Retry-After, 503, 504, or no response)
 	return Math.min(1000 * Math.pow(2, retries), MAX_BACKOFF_MS)
 }
 

--- a/src/helpers/utils/fetchPlus.ts
+++ b/src/helpers/utils/fetchPlus.ts
@@ -5,6 +5,11 @@ import sleep from '#helpers/utils/sleep'
 
 const MAX_BACKOFF_MS = 8000
 
+// HTTP statuses that warrant retry with exponential backoff + jitter.
+// 429 keeps an exact-delay path (no jitter) to preserve Retry-After semantics;
+// 503/504 add bounded jitter on top of backoff to avoid thundering Audible retry bursts.
+const TRANSIENT_STATUSES = new Set([429, 503, 504])
+
 /**
  * Calculates the delay for retry attempts with exponential backoff.
  * For 429 status, uses exponential backoff starting at 1s, doubling each retry (max 8s).
@@ -68,11 +73,14 @@ function fetchPlus(url: string, options = {}, retries = 0): Promise<AxiosRespons
 			})
 			.catch(async (reason: AxiosError) => {
 				if (retries < 3) {
-					// Check if this is a 429 (Too Many Requests) response
+					// Transient (429/503/504) responses back off before retrying.
 					const status = reason.response?.status
-					if (status === 429) {
+					if (status && TRANSIENT_STATUSES.has(status)) {
 						const delay = calculateRetryDelay(retries, reason)
-						await sleep(delay)
+						// 429 keeps the exact Retry-After/backoff delay (asserted in tests);
+						// 503/504 add bounded jitter (up to 250ms) to spread retries.
+						const finalDelay = status === 429 ? delay : delay + Math.floor(Math.random() * 250)
+						await sleep(finalDelay)
 					}
 
 					fetchPlus(url, options, retries + 1)

--- a/tests/helpers/books/audible/ApiHelper.test.ts
+++ b/tests/helpers/books/audible/ApiHelper.test.ts
@@ -374,17 +374,24 @@ describe('ApiHelper edge cases should', () => {
 		expect(parsed.asin).toBe(asin)
 	})
 
-	test('parses book with unknown content_delivery_type successfully', async () => {
+	test('throws ContentTypeMismatchError for unknown content_delivery_type', async () => {
 		const unknownTypeResponse = deepCopy(mockResponse)
 		unknownTypeResponse.product.content_delivery_type = 'UnknownType'
 		const mockLogger = createMockLogger()
 		helper = new ApiHelper(asin, region, mockLogger as unknown as FastifyBaseLogger)
-		const data = await helper.parseResponse(unknownTypeResponse)
-		expect(data.asin).toBe(asin)
-		expect(mockLogger.warn).toHaveBeenCalled()
-		expect(mockLogger.warn).toHaveBeenCalledWith(
-			expect.stringContaining('Unknown content_delivery_type')
+		await expect(helper.parseResponse(unknownTypeResponse)).rejects.toBeInstanceOf(
+			ContentTypeMismatchError
 		)
+		await expect(helper.parseResponse(unknownTypeResponse)).rejects.toMatchObject({
+			name: 'ContentTypeMismatchError',
+			statusCode: 400,
+			message: `Item is a UnknownType, not a book. ASIN: ${asin}`,
+			details: {
+				asin,
+				requestedType: 'book',
+				actualType: 'UnknownType'
+			}
+		})
 	})
 
 	// The six recognized types beyond the original MultiPartBook/SinglePartBook.
@@ -446,7 +453,9 @@ describe('ApiHelper edge cases should', () => {
 			).mockResolvedValue(state)
 			try {
 				const emptyProductResponse = { product: {} } as AudibleProduct
-				await expect(helper.parseResponse(emptyProductResponse)).rejects.toBeInstanceOf(NotFoundError)
+				await expect(helper.parseResponse(emptyProductResponse)).rejects.toBeInstanceOf(
+					NotFoundError
+				)
 				await expect(helper.parseResponse(emptyProductResponse)).rejects.toMatchObject({
 					name: 'NotFoundError',
 					statusCode: 404,

--- a/tests/helpers/books/audible/ApiHelper.test.ts
+++ b/tests/helpers/books/audible/ApiHelper.test.ts
@@ -374,6 +374,24 @@ describe('ApiHelper edge cases should', () => {
 		expect(parsed.asin).toBe(asin)
 	})
 
+	test('throws ContentTypeMismatchError for empty content_delivery_type', async () => {
+		const emptyTypeResponse = deepCopy(mockResponse)
+		emptyTypeResponse.product.content_delivery_type = '' as never
+		await expect(helper.parseResponse(emptyTypeResponse)).rejects.toBeInstanceOf(
+			ContentTypeMismatchError
+		)
+		await expect(helper.parseResponse(emptyTypeResponse)).rejects.toMatchObject({
+			name: 'ContentTypeMismatchError',
+			statusCode: 400,
+			message: `Item is a , not a book. ASIN: ${asin}`,
+			details: {
+				asin,
+				requestedType: 'book',
+				actualType: ''
+			}
+		})
+	})
+
 	test('throws ContentTypeMismatchError for unknown content_delivery_type', async () => {
 		const unknownTypeResponse = deepCopy(mockResponse)
 		unknownTypeResponse.product.content_delivery_type = 'UnknownType'

--- a/tests/helpers/routes/RouteCommonHelper.test.ts
+++ b/tests/helpers/routes/RouteCommonHelper.test.ts
@@ -63,6 +63,14 @@ describe('RouteCommonHelper should throw an error', () => {
 		expect(() => helper.runValidations()).toThrow(BadRequestError)
 		expect(() => helper.runValidations()).toThrow('Bad ASIN')
 	})
+	test('if the asin is numeric (ISBN-style)', () => {
+		// 10-char numeric strings previously passed AsinSchema validation,
+		// hit Audible's scrape URL, and returned a misleading 404.
+		// Route params require a B-prefixed book ASIN.
+		helper = new RouteCommonHelper('9781538548', query, ctx.client)
+		expect(() => helper.runValidations()).toThrow(BadRequestError)
+		expect(() => helper.runValidations()).toThrow('Bad ASIN')
+	})
 	test('if the name is not valid', () => {
 		helper = new RouteCommonHelper('', { name: '' }, ctx.client)
 		expect(() => helper.runValidations()).toThrow(BadRequestError)

--- a/tests/helpers/utils/fetchPlus.test.ts
+++ b/tests/helpers/utils/fetchPlus.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from 'bun:test'
+import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
 
 const mockGet = mock()
 
@@ -85,9 +85,7 @@ describe('fetchPlus should', () => {
 		}
 		const successResponse = { data: 'success', status: 200 } as AxiosResponse
 
-		mockGet
-			.mockRejectedValueOnce(mockError)
-			.mockResolvedValueOnce(successResponse)
+		mockGet.mockRejectedValueOnce(mockError).mockResolvedValueOnce(successResponse)
 
 		const response = await fetchPlus('test.com')
 		expect(response).toEqual(successResponse)
@@ -104,9 +102,7 @@ describe('fetchPlus should', () => {
 		}
 		const successResponse = { data: 'success', status: 200 } as AxiosResponse
 
-		mockGet
-			.mockRejectedValueOnce(mockError)
-			.mockResolvedValueOnce(successResponse)
+		mockGet.mockRejectedValueOnce(mockError).mockResolvedValueOnce(successResponse)
 
 		const response = await fetchPlus('test.com')
 
@@ -145,15 +141,58 @@ describe('fetchPlus should', () => {
 		}
 		const successResponse = { data: 'success', status: 200 } as AxiosResponse
 
-		mockGet
-			.mockRejectedValueOnce(mockError)
-			.mockResolvedValueOnce(successResponse)
+		mockGet.mockRejectedValueOnce(mockError).mockResolvedValueOnce(successResponse)
 
 		const response = await fetchPlus('test.com')
 
 		expect(response).toEqual(successResponse)
 		expect(pooledAxios.get).toHaveBeenCalledTimes(2)
 		expect(sleepDelays).toEqual([1000])
+	})
+
+	test('retry with exponential backoff on 503', async () => {
+		const mockError = {
+			response: {
+				status: 503,
+				headers: {}
+			}
+		}
+		const successResponse = { data: 'success', status: 200 } as AxiosResponse
+
+		mockGet.mockRejectedValueOnce(mockError).mockResolvedValueOnce(successResponse)
+
+		// Mock Math.random to 0.5 → jitter = floor(0.5 * 250) = 125
+		const randomSpy = spyOn(Math, 'random').mockReturnValue(0.5)
+		try {
+			const response = await fetchPlus('test.com')
+			expect(response).toEqual(successResponse)
+			expect(pooledAxios.get).toHaveBeenCalledTimes(2)
+			expect(sleepDelays).toEqual([1125])
+		} finally {
+			randomSpy.mockRestore()
+		}
+	})
+
+	test('retry with exponential backoff on 504', async () => {
+		const mockError = {
+			response: {
+				status: 504,
+				headers: {}
+			}
+		}
+		const successResponse = { data: 'success', status: 200 } as AxiosResponse
+
+		mockGet.mockRejectedValueOnce(mockError).mockResolvedValueOnce(successResponse)
+
+		const randomSpy = spyOn(Math, 'random').mockReturnValue(0.5)
+		try {
+			const response = await fetchPlus('test.com')
+			expect(response).toEqual(successResponse)
+			expect(pooledAxios.get).toHaveBeenCalledTimes(2)
+			expect(sleepDelays).toEqual([1125])
+		} finally {
+			randomSpy.mockRestore()
+		}
 	})
 
 	test('not add delay for non-429 errors', async () => {

--- a/tests/helpers/utils/fetchPlus.test.ts
+++ b/tests/helpers/utils/fetchPlus.test.ts
@@ -195,6 +195,55 @@ describe('fetchPlus should', () => {
 		}
 	})
 
+	test('not honor Retry-After header on 503', async () => {
+		const mockError = {
+			response: {
+				status: 503,
+				headers: { 'retry-after': '10' }
+			}
+		}
+		const successResponse = { data: 'success', status: 200 } as AxiosResponse
+
+		mockGet.mockRejectedValueOnce(mockError).mockResolvedValueOnce(successResponse)
+
+		// Mock Math.random to 0.5 → jitter = floor(0.5 * 250) = 125
+		const randomSpy = spyOn(Math, 'random').mockReturnValue(0.5)
+		try {
+			const response = await fetchPlus('test.com')
+			expect(response).toEqual(successResponse)
+			expect(pooledAxios.get).toHaveBeenCalledTimes(2)
+			// Should use exponential backoff (1000ms + jitter), NOT Retry-After (10000ms)
+			expect(sleepDelays).toEqual([1125])
+			expect(sleepDelays[0]).toBeLessThan(2000)
+		} finally {
+			randomSpy.mockRestore()
+		}
+	})
+
+	test('not honor Retry-After header on 504', async () => {
+		const mockError = {
+			response: {
+				status: 504,
+				headers: { 'retry-after': '10' }
+			}
+		}
+		const successResponse = { data: 'success', status: 200 } as AxiosResponse
+
+		mockGet.mockRejectedValueOnce(mockError).mockResolvedValueOnce(successResponse)
+
+		const randomSpy = spyOn(Math, 'random').mockReturnValue(0.5)
+		try {
+			const response = await fetchPlus('test.com')
+			expect(response).toEqual(successResponse)
+			expect(pooledAxios.get).toHaveBeenCalledTimes(2)
+			// Should use exponential backoff (1000ms + jitter), NOT Retry-After (10000ms)
+			expect(sleepDelays).toEqual([1125])
+			expect(sleepDelays[0]).toBeLessThan(2000)
+		} finally {
+			randomSpy.mockRestore()
+		}
+	})
+
 	test('not add delay for non-429 errors', async () => {
 		mockStatus = { status: 500 }
 		mockGet.mockImplementation(() => {


### PR DESCRIPTION
## Summary
Add exponential backoff with jitter for transient Audible HTTP errors, reject numeric ISBN-style ASIN route parameters, and strictly filter non-book content types

## Motivation
Three scraping resilience gaps were causing misleading failures:

1. **Transient 503/504 errors** from Audible were retried with zero delay, hammering their servers and failing on the first hit. The existing retry logic only applied exponential backoff for 429 responses.
2. **Numeric ISBN-style identifiers** (10-digit strings like `9781538548`) passed route validation, constructed a malformed scrape URL, and returned a confusing 404 instead of a clear rejection.
3. **Unknown `content_delivery_type` values** silently fell through to database storage, then failed downstream with the misleading error "Data type is not ApiBook."

## Changes
- **fetchPlus.ts**: Added `TRANSIENT_STATUSES` set including 429, 503, and 504. All transient errors now get exponential backoff before retry; 503/504 additionally receive bounded jitter (+250 ms max) to prevent thundering-herd retry bursts. The 429 path keeps exact Retry-After delays (preserving existing test assertions).
- **types.ts / RouteCommonHelper.ts**: Introduced `BookAsinSchema` (B-prefixed 10-char regex) for route-param validation. The permissive `AsinSchema` remains unchanged for stored data (chapter ASINs can legitimately be numeric). Numeric ASINs now get `400 Bad ASIN` at validation instead of 404 at scrape time.
- **ApiHelper.ts**: Split the content-type fallback to distinguish missing vs present-but-unknown types. Unknown types now throw `ContentTypeMismatchError` (400) with a clear message instead of silently storing non-book data.

## Notes
- B-prefix ASIN assumption validated against every test fixture and a live 50-product bestseller batch. If a legitimate B-less book ASIN surfaces, `BookAsinSchema` can be broadened.
- The unknown content-type guard converts a future "what if" into a clear 400 error — treat any production 400 as a signal to extend `knownTypes`, not a regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stricter validation for book ASINs in route parameters.
  * Expanded automatic retry handling for temporary HTTP 503 and 504 errors using exponential backoff with jitter (Retry-After is honored only for 429).

* **Bug Fixes**
  * Improved handling of unsupported or missing content delivery type values: unsupported values now produce a clear error, while missing information continues with a safer fallback and an explicit warning.

* **Tests**
  * Added/updated unit tests to cover the new validation and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->