### PR TITLE
fix: reject empty content_delivery_type and add 503/504 retry backoff

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -216,10 +216,26 @@ const podcastShape = z.object({
 
 // This is the shape of the data we get from Audible's API for series content
 const seriesShape = z.object({
-	content_delivery_type: z.enum(['MultiPartBook', 'SinglePartBook']),
+	content_delivery_type: z.enum([
+		'MultiPartBook',
+		'SinglePartBook',
+		'AudioPart',
+		'SinglePartIssue',
+		'PodcastEpisode',
+		'BookSeries',
+		'Periodical',
+		'Bundle'
+	]),
 	publication_name: z.string().optional(),
 	series: z.array(AudibleSeriesSchema).optional()
 })
+
+// Single source of truth for the recognized content_delivery_type values.
+// Used by the schema, the parser, and the live-test availability check
+// so they cannot drift apart. PodcastParent is intentionally excluded:
+// it is handled as a content type mismatch in ApiHelper.parseResponse.
+export const recognizedContentTypes: readonly string[] =
+	seriesShape.shape.content_delivery_type.options
 
 // This is the shape for fallback when content_delivery_type is missing or unknown
 export const fallbackShape = baseShape.extend({

--- a/src/helpers/books/audible/ApiHelper.ts
+++ b/src/helpers/books/audible/ApiHelper.ts
@@ -429,6 +429,14 @@ class ApiHelper {
 			)
 		}
 
+		// Reject empty content_delivery_type (not the same as missing/undefined)
+		if ((contentType as string) === '') {
+			throw new ContentTypeMismatchError(
+				ErrorMessageContentTypeMismatch(this.asin, 'unknown type', 'book'),
+				{ asin: this.asin, requestedType: 'book', actualType: '' }
+			)
+		}
+
 		// Check if content_delivery_type exists and is a known book type
 		const knownTypes = recognizedContentTypes
 		if (!contentType || !knownTypes.includes(contentType)) {

--- a/src/helpers/books/audible/ApiHelper.ts
+++ b/src/helpers/books/audible/ApiHelper.ts
@@ -18,7 +18,8 @@ import {
 	AudibleSeriesSchema,
 	baseShape,
 	FallbackAudibleProduct,
-	fallbackShape
+	fallbackShape,
+	recognizedContentTypes
 } from '#config/types'
 import { ContentTypeMismatchError, NotFoundError } from '#helpers/errors/ApiErrors'
 import cleanupDescription from '#helpers/utils/cleanupDescription'
@@ -429,7 +430,7 @@ class ApiHelper {
 		}
 
 		// Check if content_delivery_type exists and is a known book type
-		const knownTypes = ['MultiPartBook', 'SinglePartBook']
+		const knownTypes = recognizedContentTypes
 		if (!contentType || !knownTypes.includes(contentType)) {
 			// Try parsing with baseShape directly (fallback for missing/unknown type)
 			const baseResult = baseShape.safeParse(product)

--- a/src/helpers/utils/fetchPlus.ts
+++ b/src/helpers/utils/fetchPlus.ts
@@ -5,26 +5,11 @@ import sleep from '#helpers/utils/sleep'
 
 const MAX_BACKOFF_MS = 8000
 
-/**
- * Calculates the delay for retry attempts with exponential backoff.
- * For 429 status, uses exponential backoff starting at 1s, doubling each retry (max 8s).
- * Respects Retry-After header if present (includes delay-in-seconds and HTTP-date formats).
- * @param {number} retries The current retry count
- * @param {AxiosError} error The axios error response
- * @returns {number} The delay in milliseconds
- */
-function calculateRetryDelay(retries: number, error: AxiosError): number {
-	if (!error.response || !error.response.headers) {
-		// No response or headers, fall back to exponential backoff
-		return Math.min(1000 * Math.pow(2, retries), MAX_BACKOFF_MS)
-	}
+function jitter(base: number): number {
+	return base + Math.floor(Math.random() * (base / 2 + 1)) - Math.floor(base / 4)
+}
 
-	const retryAfter = error.response.headers['retry-after']
-	if (!retryAfter) {
-		// No Retry-After header, fall back to exponential backoff
-		return Math.min(1000 * Math.pow(2, retries), MAX_BACKOFF_MS)
-	}
-
+function parseRetryAfter(retryAfter: string): number | null {
 	// Retry-After can be a delay in seconds or an HTTP-date
 	const parsedAsNumber = parseInt(retryAfter, 10)
 	if (!isNaN(parsedAsNumber) && parsedAsNumber > 0) {
@@ -41,15 +26,39 @@ function calculateRetryDelay(retries: number, error: AxiosError): number {
 		}
 	}
 
-	// Invalid Retry-After value, fall back to exponential backoff
-	return Math.min(1000 * Math.pow(2, retries), MAX_BACKOFF_MS)
+	return null
+}
+
+/**
+ * Calculates the delay for retry attempts with exponential backoff.
+ * For 429 status, honors Retry-After header when present (delay-in-seconds and HTTP-date formats).
+ * For 429 without Retry-After, 503, and 504, uses exponential backoff with bounded jitter
+ * starting at 1s, doubling each retry (max 8s).
+ * @param {number} retries The current retry count
+ * @param {AxiosError} error The axios error response
+ * @returns {number} The delay in milliseconds
+ */
+function calculateRetryDelay(retries: number, error: AxiosError): number {
+	const status = error.response?.status
+	const retryAfter = error.response?.headers?.['retry-after']
+
+	// Only honor Retry-After for 429
+	if (status === 429 && retryAfter) {
+		const parsed = parseRetryAfter(retryAfter)
+		if (parsed !== null) {
+			return parsed
+		}
+	}
+
+	// For 429 without Retry-After (or invalid), or any other retriable status: use exponential backoff with jitter
+	return jitter(Math.min(1000 * Math.pow(2, retries), MAX_BACKOFF_MS))
 }
 
 /**
  * Fetches a url with axios and retries 3 additional times on non-200 status
  * Uses connection pooling for improved performance.
- * Implements exponential backoff for 429 (Too Many Requests) responses,
- * respecting Retry-After header when present.
+ * Implements exponential backoff with bounded jitter for 429, 503, and 504 responses.
+ * For 429, respects Retry-After header when present.
  * @param {string} url The url to fetch
  * @param {object} options The options to pass to axios (default: {})
  * @param {number} retries The number of retries to start from (default: 0)
@@ -68,9 +77,8 @@ function fetchPlus(url: string, options = {}, retries = 0): Promise<AxiosRespons
 			})
 			.catch(async (reason: AxiosError) => {
 				if (retries < 3) {
-					// Check if this is a 429 (Too Many Requests) response
 					const status = reason.response?.status
-					if (status === 429) {
+					if (status === 429 || status === 503 || status === 504) {
 						const delay = calculateRetryDelay(retries, reason)
 						await sleep(delay)
 					}

--- a/tests/helpers/books/audible/ApiHelper.test.ts
+++ b/tests/helpers/books/audible/ApiHelper.test.ts
@@ -364,11 +364,15 @@ describe('ApiHelper edge cases should', () => {
 		)
 	})
 
-	// The six new recognized types added beyond MultiPartBook/SinglePartBook.
-	// Each must parse through AudibleProductSchema without the Unknown-content-type warning.
-	const newContentTypes = recognizedContentTypes.filter(
-		(type) => type !== 'MultiPartBook' && type !== 'SinglePartBook'
-	)
+	// The six recognized types beyond the original MultiPartBook/SinglePartBook.
+	const newContentTypes = ['AudioPart', 'SinglePartIssue', 'PodcastEpisode', 'BookSeries', 'Periodical', 'Bundle'] as const
+
+	test('recognizedContentTypes includes all six newer content types', () => {
+		for (const type of newContentTypes) {
+			expect(recognizedContentTypes).toContain(type)
+		}
+	})
+
 	for (const type of newContentTypes) {
 		test(`parses recognized content_delivery_type '${type}' without warning`, async () => {
 			const response = deepCopy(mockResponse)

--- a/tests/helpers/books/audible/ApiHelper.test.ts
+++ b/tests/helpers/books/audible/ApiHelper.test.ts
@@ -212,6 +212,22 @@ describe('ApiHelper should', () => {
 		})
 	})
 
+	test('throws ContentTypeMismatchError for empty content_delivery_type', async () => {
+		const emptyTypeResponse = deepCopy(mockResponse)
+		emptyTypeResponse.product.content_delivery_type = '' as never
+		await expect(helper.parseResponse(emptyTypeResponse)).rejects.toBeInstanceOf(ContentTypeMismatchError)
+		await expect(helper.parseResponse(emptyTypeResponse)).rejects.toMatchObject({
+			name: 'ContentTypeMismatchError',
+			statusCode: 400,
+			message: `Item is a unknown type, not a book. ASIN: ${asin}`,
+			details: {
+				asin: asin,
+				requestedType: 'book',
+				actualType: ''
+			}
+		})
+	})
+
 	describe('handle region: ', () => {
 		test.each(Object.keys(regions))('%s', async (region) => {
 			helper = new ApiHelper('B079LRSMNN', region)

--- a/tests/helpers/books/audible/ApiHelper.test.ts
+++ b/tests/helpers/books/audible/ApiHelper.test.ts
@@ -7,7 +7,8 @@ import {
 	AudibleProduct,
 	AudibleProductSchema,
 	AudibleSeries,
-	fallbackShape
+	fallbackShape,
+	recognizedContentTypes
 } from '#config/types'
 import ApiHelper from '#helpers/books/audible/ApiHelper'
 import { ContentTypeMismatchError, NotFoundError } from '#helpers/errors/ApiErrors'
@@ -362,6 +363,23 @@ describe('ApiHelper edge cases should', () => {
 			expect.stringContaining('Unknown content_delivery_type')
 		)
 	})
+
+	// The six new recognized types added beyond MultiPartBook/SinglePartBook.
+	// Each must parse through AudibleProductSchema without the Unknown-content-type warning.
+	const newContentTypes = recognizedContentTypes.filter(
+		(type) => type !== 'MultiPartBook' && type !== 'SinglePartBook'
+	)
+	for (const type of newContentTypes) {
+		test(`parses recognized content_delivery_type '${type}' without warning`, async () => {
+			const response = deepCopy(mockResponse)
+			response.product.content_delivery_type = type
+			const mockLogger = createMockLogger()
+			helper = new ApiHelper(asin, region, mockLogger as unknown as FastifyBaseLogger)
+			const data = await helper.parseResponse(response)
+			expect(data.asin).toBe(asin)
+			expect(mockLogger.warn).not.toHaveBeenCalled()
+		})
+	}
 
 	test('throws region unavailable when baseShape also fails', async () => {
 		const emptyProductResponse = { product: {} } as AudibleProduct

--- a/tests/helpers/utils/fetchPlus.test.ts
+++ b/tests/helpers/utils/fetchPlus.test.ts
@@ -92,7 +92,10 @@ describe('fetchPlus should', () => {
 		const response = await fetchPlus('test.com')
 		expect(response).toEqual(successResponse)
 		expect(pooledAxios.get).toHaveBeenCalledTimes(2)
-		expect(sleepDelays).toEqual([1000])
+		// Jittered backoff at retry 0: base 1000ms, jitter range ~750-1500ms
+		expect(sleepDelays.length).toBe(1)
+		expect(sleepDelays[0]).toBeGreaterThanOrEqual(500)
+		expect(sleepDelays[0]).toBeLessThanOrEqual(1500)
 	})
 
 	test('retry with Retry-After header on 429', async () => {
@@ -133,7 +136,12 @@ describe('fetchPlus should', () => {
 
 		expect(response).toEqual(successResponse)
 		expect(pooledAxios.get).toHaveBeenCalledTimes(3)
-		expect(sleepDelays).toEqual([1000, 2000])
+		expect(sleepDelays.length).toBe(2)
+		// Retry 0: base 1000ms with jitter, retry 1: base 2000ms with jitter
+		expect(sleepDelays[0]).toBeGreaterThanOrEqual(500)
+		expect(sleepDelays[0]).toBeLessThanOrEqual(1500)
+		expect(sleepDelays[1]).toBeGreaterThanOrEqual(1000)
+		expect(sleepDelays[1]).toBeLessThanOrEqual(3000)
 	})
 
 	test('retry with exponential backoff on 429 with headers missing retry-after key', async () => {
@@ -153,10 +161,13 @@ describe('fetchPlus should', () => {
 
 		expect(response).toEqual(successResponse)
 		expect(pooledAxios.get).toHaveBeenCalledTimes(2)
-		expect(sleepDelays).toEqual([1000])
+		// Jittered backoff at retry 0: base 1000ms, jitter range ~750-1500ms
+		expect(sleepDelays.length).toBe(1)
+		expect(sleepDelays[0]).toBeGreaterThanOrEqual(500)
+		expect(sleepDelays[0]).toBeLessThanOrEqual(1500)
 	})
 
-	test('not add delay for non-429 errors', async () => {
+	test('not add delay for non-retriable errors', async () => {
 		mockStatus = { status: 500 }
 		mockGet.mockImplementation(() => {
 			const error: Error & { response: typeof mockStatus } = Object.assign(
@@ -169,6 +180,94 @@ describe('fetchPlus should', () => {
 		await expect(fetchPlus('test.com')).rejects.toEqual(mockStatus)
 		expect(pooledAxios.get).toHaveBeenCalledTimes(4)
 		expect(sleepDelays).toEqual([])
+	})
+
+	test('retry with exponential backoff on 503', async () => {
+		const mockError = {
+			response: {
+				status: 503,
+				headers: {}
+			}
+		}
+		const successResponse = { data: 'success', status: 200 } as AxiosResponse
+
+		mockGet
+			.mockRejectedValueOnce(mockError)
+			.mockResolvedValueOnce(successResponse)
+
+		const response = await fetchPlus('test.com')
+		expect(response).toEqual(successResponse)
+		expect(pooledAxios.get).toHaveBeenCalledTimes(2)
+		expect(sleepDelays.length).toBe(1)
+		// Jittered backoff at retry 0: base 1000ms, jitter range ~750-1500ms
+		expect(sleepDelays[0]).toBeGreaterThanOrEqual(500)
+		expect(sleepDelays[0]).toBeLessThanOrEqual(1500)
+	})
+
+	test('retry with exponential backoff on 504', async () => {
+		const mockError = {
+			response: {
+				status: 504,
+				headers: {}
+			}
+		}
+		const successResponse = { data: 'success', status: 200 } as AxiosResponse
+
+		mockGet
+			.mockRejectedValueOnce(mockError)
+			.mockResolvedValueOnce(successResponse)
+
+		const response = await fetchPlus('test.com')
+		expect(response).toEqual(successResponse)
+		expect(pooledAxios.get).toHaveBeenCalledTimes(2)
+		expect(sleepDelays.length).toBe(1)
+		// Jittered backoff at retry 0: base 1000ms, jitter range ~750-1500ms
+		expect(sleepDelays[0]).toBeGreaterThanOrEqual(500)
+		expect(sleepDelays[0]).toBeLessThanOrEqual(1500)
+	})
+
+	test('not honor Retry-After header on 503', async () => {
+		const mockError = {
+			response: {
+				status: 503,
+				headers: { 'retry-after': '10' }
+			}
+		}
+		const successResponse = { data: 'success', status: 200 } as AxiosResponse
+
+		mockGet
+			.mockRejectedValueOnce(mockError)
+			.mockResolvedValueOnce(successResponse)
+
+		const response = await fetchPlus('test.com')
+		expect(response).toEqual(successResponse)
+		expect(pooledAxios.get).toHaveBeenCalledTimes(2)
+		// Must use exponential backoff with jitter, NOT the Retry-After value (10000ms)
+		expect(sleepDelays[0]).not.toBe(10000)
+		expect(sleepDelays[0]).toBeGreaterThanOrEqual(500)
+		expect(sleepDelays[0]).toBeLessThanOrEqual(1500)
+	})
+
+	test('not honor Retry-After header on 504', async () => {
+		const mockError = {
+			response: {
+				status: 504,
+				headers: { 'retry-after': '10' }
+			}
+		}
+		const successResponse = { data: 'success', status: 200 } as AxiosResponse
+
+		mockGet
+			.mockRejectedValueOnce(mockError)
+			.mockResolvedValueOnce(successResponse)
+
+		const response = await fetchPlus('test.com')
+		expect(response).toEqual(successResponse)
+		expect(pooledAxios.get).toHaveBeenCalledTimes(2)
+		// Must use exponential backoff with jitter, NOT the Retry-After value (10000ms)
+		expect(sleepDelays[0]).not.toBe(10000)
+		expect(sleepDelays[0]).toBeGreaterThanOrEqual(500)
+		expect(sleepDelays[0]).toBeLessThanOrEqual(1500)
 	})
 })
 

--- a/tests/live/audible/books/api.live.test.ts
+++ b/tests/live/audible/books/api.live.test.ts
@@ -1,4 +1,4 @@
-import type { ApiBook, AudibleProduct } from '#config/types'
+import { type ApiBook, type AudibleProduct, recognizedContentTypes } from '#config/types'
 import ApiHelper from '#helpers/books/audible/ApiHelper'
 import { BadRequestError, ContentTypeMismatchError, NotFoundError } from '#helpers/errors/ApiErrors'
 
@@ -24,7 +24,7 @@ function isInUnavailableAllowlist(asin: string, region: string): boolean {
 function checkAvailability(response: AudibleProduct): boolean {
 	const product = response.product
 	const contentType = product?.content_delivery_type
-	const knownTypes = ['PodcastParent', 'MultiPartBook', 'SinglePartBook'] // PodcastParent included for detection purposes - content type mismatch should be thrown
+	const knownTypes = [...recognizedContentTypes, 'PodcastParent'] // PodcastParent included for detection - content type mismatch should be thrown
 
 	// Content is only considered available when content_delivery_type is present and known
 	// This prevents false positives from incomplete product stubs


### PR DESCRIPTION
## Summary
Reject empty `content_delivery_type` as a content type mismatch and add retry backoff for 503/504 responses.

## Motivation
Two edge cases in the Audible API and fetch retry logic were not handled correctly:

1. **Empty `content_delivery_type`**: An empty string (`""`) was treated identically to `undefined` due to JavaScript falsiness (`!contentType`), causing the parser to fall back to `baseShape` instead of rejecting the response. This could silently produce incorrect data from malformed API responses. Missing (`undefined`) values are legitimately rare and benefit from the fallback; empty strings indicate a concrete but invalid value and should be rejected.

2. **No retry backoff for 503/504**: Only HTTP 429 triggered exponential backoff between retries. 503 (Service Unavailable) and 504 (Gateway Timeout) retried immediately, potentially amplifying load on a struggling upstream server. Additionally, `Retry-After` header parsing was not gated by status code — if called for non-429, it would still honor the header.

## Changes
- **ApiHelper**: Added explicit `contentType === ''` guard before the `!contentType` fallback check. Empty strings now throw `ContentTypeMismatchError` (400). `undefined` continues to fall back to `baseShape` and then `fetchProductState()` for delisted/region-specific errors.
- **fetchPlus**: Restructured retry logic with three helpers — `jitter()` for bounded randomization, `parseRetryAfter()` for header parsing, and a status-aware `calculateRetryDelay()`. `Retry-After` is honored only for 429. 503/504 now use capped exponential backoff (1s–8s) with bounded jitter. 500 and other non-retriable statuses remain unaffected.
- **Tests**: Added regression test for empty `content_delivery_type`; added four new tests for 503/504 retry behavior (backoff and Retry-After rejection); updated existing 429 tests to assert jittered delay ranges.

## Notes
- The jitter function adds ±~25% variance around the base exponential backoff value, preventing thundering herd on retry without introducing excessive latency.
- The `as string` type assertion on `contentType === ''` is necessary because Zod's discriminated union narrows the type to exclude empty strings; the assertion reflects the reality that raw API responses can contain values not in our schema before validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional Audible series delivery types, including podcast episodes and bundles.
  * Improved handling of missing or unrecognized content types.

* **Bug Fixes**
  * Retry handling now supports HTTP 503 and 504 responses with exponential backoff and randomized delays.
  * Retry-After headers are applied appropriately for rate-limit responses.
  * Empty content delivery types are now reported clearly as mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->