### PR TITLE
fix(audible): stop misclassifying fiction as nonfiction

### DIFF
--- a/src/helpers/books/audible/ApiHelper.ts
+++ b/src/helpers/books/audible/ApiHelper.ts
@@ -22,6 +22,7 @@ import {
 	recognizedContentTypes
 } from '#config/types'
 import { ContentTypeMismatchError, NotFoundError } from '#helpers/errors/ApiErrors'
+import literatureTypeFromProduct from '#helpers/books/audible/literatureType'
 import cleanupDescription from '#helpers/utils/cleanupDescription'
 import fetch from '#helpers/utils/fetchPlus'
 import SharedHelper from '#helpers/utils/shared'
@@ -288,6 +289,12 @@ class ApiHelper {
 	 */
 	getFinalData(): ApiBook {
 		if (!this.audibleResponse) throw new Error(ErrorMessageNoData(this.asin, 'ApiHelper'))
+		// Classify literature type BEFORE getCategories() / getGenres() which mutate category_ladders
+		const literatureType = literatureTypeFromProduct(
+			this.audibleResponse.category_ladders,
+			this.audibleResponse.thesaurus_subject_keywords,
+			this.region
+		)
 		// Get flattened categories
 		this.getCategories()
 		// Find secondary series if available
@@ -326,11 +333,7 @@ class ApiHelper {
 			isAdult: this.audibleResponse.is_adult_product,
 			isbn: this.audibleResponse.isbn ?? '',
 			language: this.audibleResponse.language,
-			literatureType: this.audibleResponse.thesaurus_subject_keywords?.some((keyword) =>
-				keyword.includes('fiction')
-			)
-				? 'fiction'
-				: 'nonfiction',
+			literatureType,
 			narrators:
 				this.audibleResponse.narrators?.map((person: ApiNarratorOnBook) => {
 					const narratorJson: ApiNarratorOnBook = {

--- a/src/helpers/books/audible/ApiHelper.ts
+++ b/src/helpers/books/audible/ApiHelper.ts
@@ -21,8 +21,8 @@ import {
 	fallbackShape,
 	recognizedContentTypes
 } from '#config/types'
-import { ContentTypeMismatchError, NotFoundError } from '#helpers/errors/ApiErrors'
 import literatureTypeFromProduct from '#helpers/books/audible/literatureType'
+import { ContentTypeMismatchError, NotFoundError } from '#helpers/errors/ApiErrors'
 import cleanupDescription from '#helpers/utils/cleanupDescription'
 import fetch from '#helpers/utils/fetchPlus'
 import SharedHelper from '#helpers/utils/shared'
@@ -289,7 +289,7 @@ class ApiHelper {
 	 */
 	getFinalData(): ApiBook {
 		if (!this.audibleResponse) throw new Error(ErrorMessageNoData(this.asin, 'ApiHelper'))
-		// Classify literature type BEFORE getCategories() / getGenres() which mutate category_ladders
+		// Classify literature type BEFORE getGenres() which mutates category_ladders
 		const literatureType = literatureTypeFromProduct(
 			this.audibleResponse.category_ladders,
 			this.audibleResponse.thesaurus_subject_keywords,

--- a/src/helpers/books/audible/literatureType.ts
+++ b/src/helpers/books/audible/literatureType.ts
@@ -339,7 +339,9 @@ export default function literatureTypeFromProduct(
 		if (matches) return 'fiction'
 		return 'nonfiction'
 	}
-	return thesaurusKeywords?.some((keyword) => /(^|[^a-z])fiction([^a-z]|$)/i.test(keyword))
+	return thesaurusKeywords?.some(
+		(keyword) => /(^|[^a-z])fiction([^a-z]|$)/i.test(keyword) && !/nonfiction/i.test(keyword)
+	)
 		? 'fiction'
 		: 'nonfiction'
 }

--- a/src/helpers/books/audible/literatureType.ts
+++ b/src/helpers/books/audible/literatureType.ts
@@ -339,7 +339,7 @@ export default function literatureTypeFromProduct(
 		if (matches) return 'fiction'
 		return 'nonfiction'
 	}
-	return thesaurusKeywords?.some((keyword) => keyword.includes('fiction'))
+	return thesaurusKeywords?.some((keyword) => /(^|[^a-z])fiction([^a-z]|$)/i.test(keyword))
 		? 'fiction'
 		: 'nonfiction'
 }

--- a/src/helpers/books/audible/literatureType.ts
+++ b/src/helpers/books/audible/literatureType.ts
@@ -1,0 +1,121 @@
+import type { AudibleProduct } from '#config/types'
+
+type LiteratureType = 'fiction' | 'nonfiction'
+
+interface RegionTable {
+	fictionRoots: readonly string[]
+	mixedChildren: Readonly<Record<string, readonly string[]>>
+}
+
+const LITERATURE_TABLES: Record<string, RegionTable> = {
+	us: {
+		fictionRoots: ['Erotica', 'Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+		mixedChildren: {
+			"Children's Audiobooks": ['Action & Adventure', 'Fairy Tales, Folk Tales & Myths', 'Humor', 'Literature & Fiction', 'Mystery & Suspense', 'Science Fiction & Fantasy'],
+			'Comedy & Humor': ['Literature & Fiction'],
+			'LGBTQ+': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+			'Teen & Young Adult': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+		},
+	},
+	uk: {
+		fictionRoots: ['Erotica', 'Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+		mixedChildren: {
+			"Children's Audiobooks": ['Action & Adventure', 'Fairy Tales, Folk Tales & Myths', 'Humor', 'Literature & Fiction', 'Mystery & Suspense', 'Science Fiction & Fantasy'],
+			'Comedy & Humour': ['Literature & Fiction'],
+			'LGBTQ+': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+			'Teen & Young Adult': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+		},
+	},
+	ca: {
+		fictionRoots: ['Erotica', 'Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+		mixedChildren: {
+			"Children's Audiobooks": ['Action & Adventure', 'Fairy Tales, Folk Tales & Myths', 'Humour', 'Literature & Fiction', 'Mystery & Suspense', 'Science Fiction & Fantasy'],
+			'Comedy & Humor': ['Literature & Fiction'],
+			'LGBTQ2S+': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+			'Teen & Young Adult': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+		},
+	},
+	au: {
+		fictionRoots: ['Erotica', 'Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+		mixedChildren: {
+			"Children's Audiobooks": ['Action & Adventure', 'Fairy Tales, Folk Tales & Myths', 'Humour', 'Literature & Fiction', 'Mystery & Suspense', 'Science Fiction & Fantasy'],
+			'Comedy & Humour': ['Literature & Fiction'],
+			'LGBTQ+': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+			'Teen & Young Adult': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+		},
+	},
+	in: {
+		fictionRoots: ['Literature & Fiction', 'Mature Content', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+		mixedChildren: {
+			"Children's Audiobooks": ['Action & Adventure', 'Fairy Tales, Folk Tales & Myths', 'Humour', 'Literature & Fiction', 'Mystery & Suspsense', 'Science Fiction & Fantasy'],
+			'Comedy & Humor': ['Literature & Fiction'],
+			'LGBTQ+': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+			'Teen & Young Adult': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+		},
+	},
+	de: {
+		fictionRoots: ['Erotik', 'Krimis & Thriller', 'Liebesromane', 'Literatur & Belletristik', 'Science Fiction & Fantasy'],
+		mixedChildren: {
+			'Comedy & Humor': ['Literatur & Belletristik'],
+			'Jugendliche & Heranwachsende': ['Krimis & Thriller', 'Liebesromane', 'Literatur & Belletristik', 'Science Fiction & Fantasy'],
+			'Kinder-Hörbücher': ['Action & Abenteuer', 'Detektive & Spannung', 'Literatur & Belletristik', 'Märchen & Mythen', 'Science Fiction & Fantasy'],
+			'LGBT': ['Krimis & Thriller', 'Liebesromane', 'Literatur & Belletristik', 'Science Fiction & Fantasy'],
+		},
+	},
+	es: {
+		fictionRoots: ['Ciencia ficción y fantasía', 'Erótica', 'Literatura y ficción', 'Policíaca, negra y suspense', 'Romántica'],
+		mixedChildren: {
+			'Adolescentes': ['Ciencia ficción y fantasía', 'Literatura y ficción', 'Policíaca, negra y suspense', 'Romántica'],
+			'Audiolibros infantiles': ['Acción y aventura', 'Ciencia ficción y fantasía', 'Cuentos y leyendas', 'Humor', 'Literatura y ficción', 'Misterio y suspense'],
+			'Comedia y humor': ['Literatura y ficción'],
+			'LGBTQ+': ['Ciencia ficción y fantasía', 'Literatura y ficción', 'Policíaca, negra y suspense', 'Romántica'],
+		},
+	},
+	fr: {
+		fictionRoots: ['Littérature, romans et fiction', 'Policier, thrillers et œuvres à suspense', 'Romance', 'Science-Fiction et fantasy', 'Érotisme'],
+		mixedChildren: {
+			'Adolescents et jeunes adultes': ['Policier, thrillers et œuvres à suspense', "Roman d'amour", 'Roman et littérature', 'Science-fiction et fantasy'],
+			'Comédie et humour': ['Roman et littérature'],
+			'Jeunesse': ['Action et aventure', 'Contes de fées et populaires et mythes', 'Humour', 'Policier et suspense', 'Roman et littérature', 'Science-fiction et fantasy'],
+			'LGBT': ['Policier, thrillers et œuvres à suspense', "Roman d'amour", 'Roman et littérature', 'Science-fiction et fantasy'],
+		},
+	},
+	it: {
+		fictionRoots: ['Erotismo', 'Fantascienza e fantasy', 'Letteratura e narrativa', 'Poliziesco, thriller e suspense', "Romanzo d'amore"],
+		mixedChildren: {
+			'Adolescenti e Ragazzi': ['Fantascienza e fantasy', 'Letteratura e narrativa', 'Poliziesco, thriller e suspense', "Romanzo d'amore"],
+			'Audiolibri per bambini': ['Azione e avventura', 'Fantascienza e fantasy', 'Fiabe, racconti popolari e miti', 'Humor', 'Letteratura e narrativa', 'Poliziesco e suspense'],
+			'Commedia e umorismo': ['Letteratura e narrativa'],
+			'LGBT': ['Fantascienza e fantasy', 'Letteratura e narrativa', 'Poliziesco, thriller e suspense', "Romanzo d'amore"],
+		},
+	},
+	jp: {
+		fictionRoots: ['SF・ファンタジー', 'アダルト', 'ティーンズラブ', 'ボーイズラブ', 'ミステリー・スリラー・サスペンス', 'ライトノベル(ラノベ)', '官能・ロマンス', '文学・フィクション'],
+		mixedChildren: {
+			'LGBT': ['文学・フィクション', 'ロマンス', 'ミステリー・スリラー・サスペンス', 'SF・ファンタジー'],
+			'コメディー・落語': ['ユーモア・風刺文学・フィクション'],
+			'ティーン': ['SF・ファンタジー', '文学・フィクション・ライトノベル', 'ミステリー・スリラー・サスペンス', 'ロマンス'],
+			'絵本・児童書': ['SF・ファンタジー', 'アクション・アドベンチャー', 'ミステリー・サスペンス', 'ユーモア', '文学・フィクション', '童話・民話・神話'],
+		},
+	},
+}
+
+export default function literatureTypeFromProduct(
+	categoryLadders: AudibleProduct['product']['category_ladders'],
+	thesaurusKeywords: string[] | undefined,
+	region: string
+): LiteratureType {
+	const table = LITERATURE_TABLES[region] ?? LITERATURE_TABLES['us']
+	if (categoryLadders.length > 0) {
+		const matches = categoryLadders.some(({ ladder }) => {
+			const root = ladder[0]?.name
+			if (!root) return false
+			if (table.fictionRoots.includes(root)) return true
+			const children = table.mixedChildren[root]
+			return !!children && children.includes(ladder[1]?.name ?? '')
+		})
+		if (matches) return 'fiction'
+		return 'nonfiction'
+	}
+	return thesaurusKeywords?.some((keyword) => keyword.includes('fiction')) ? 'fiction' : 'nonfiction'
+}

--- a/src/helpers/books/audible/literatureType.ts
+++ b/src/helpers/books/audible/literatureType.ts
@@ -9,95 +9,317 @@ interface RegionTable {
 
 const LITERATURE_TABLES: Record<string, RegionTable> = {
 	us: {
-		fictionRoots: ['Erotica', 'Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+		fictionRoots: [
+			'Erotica',
+			'Literature & Fiction',
+			'Mystery, Thriller & Suspense',
+			'Romance',
+			'Science Fiction & Fantasy'
+		],
 		mixedChildren: {
-			"Children's Audiobooks": ['Action & Adventure', 'Fairy Tales, Folk Tales & Myths', 'Humor', 'Literature & Fiction', 'Mystery & Suspense', 'Science Fiction & Fantasy'],
+			"Children's Audiobooks": [
+				'Action & Adventure',
+				'Fairy Tales, Folk Tales & Myths',
+				'Humor',
+				'Literature & Fiction',
+				'Mystery & Suspense',
+				'Science Fiction & Fantasy'
+			],
 			'Comedy & Humor': ['Literature & Fiction'],
-			'LGBTQ+': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
-			'Teen & Young Adult': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
-		},
+			'LGBTQ+': [
+				'Literature & Fiction',
+				'Mystery, Thriller & Suspense',
+				'Romance',
+				'Science Fiction & Fantasy'
+			],
+			'Teen & Young Adult': [
+				'Literature & Fiction',
+				'Mystery, Thriller & Suspense',
+				'Romance',
+				'Science Fiction & Fantasy'
+			]
+		}
 	},
 	uk: {
-		fictionRoots: ['Erotica', 'Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+		fictionRoots: [
+			'Erotica',
+			'Literature & Fiction',
+			'Mystery, Thriller & Suspense',
+			'Romance',
+			'Science Fiction & Fantasy'
+		],
 		mixedChildren: {
-			"Children's Audiobooks": ['Action & Adventure', 'Fairy Tales, Folk Tales & Myths', 'Humor', 'Literature & Fiction', 'Mystery & Suspense', 'Science Fiction & Fantasy'],
+			"Children's Audiobooks": [
+				'Action & Adventure',
+				'Fairy Tales, Folk Tales & Myths',
+				'Humor',
+				'Literature & Fiction',
+				'Mystery & Suspense',
+				'Science Fiction & Fantasy'
+			],
 			'Comedy & Humour': ['Literature & Fiction'],
-			'LGBTQ+': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
-			'Teen & Young Adult': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
-		},
+			'LGBTQ+': [
+				'Literature & Fiction',
+				'Mystery, Thriller & Suspense',
+				'Romance',
+				'Science Fiction & Fantasy'
+			],
+			'Teen & Young Adult': [
+				'Literature & Fiction',
+				'Mystery, Thriller & Suspense',
+				'Romance',
+				'Science Fiction & Fantasy'
+			]
+		}
 	},
 	ca: {
-		fictionRoots: ['Erotica', 'Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+		fictionRoots: [
+			'Erotica',
+			'Literature & Fiction',
+			'Mystery, Thriller & Suspense',
+			'Romance',
+			'Science Fiction & Fantasy'
+		],
 		mixedChildren: {
-			"Children's Audiobooks": ['Action & Adventure', 'Fairy Tales, Folk Tales & Myths', 'Humour', 'Literature & Fiction', 'Mystery & Suspense', 'Science Fiction & Fantasy'],
+			"Children's Audiobooks": [
+				'Action & Adventure',
+				'Fairy Tales, Folk Tales & Myths',
+				'Humour',
+				'Literature & Fiction',
+				'Mystery & Suspense',
+				'Science Fiction & Fantasy'
+			],
 			'Comedy & Humor': ['Literature & Fiction'],
-			'LGBTQ2S+': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
-			'Teen & Young Adult': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
-		},
+			'LGBTQ2S+': ['Literature & Fiction', 'Romance', 'Science Fiction & Fantasy'],
+			'Teen & Young Adult': [
+				'Literature & Fiction',
+				'Mystery, Thriller & Suspense',
+				'Romance',
+				'Science Fiction & Fantasy'
+			]
+		}
 	},
 	au: {
-		fictionRoots: ['Erotica', 'Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+		fictionRoots: [
+			'Erotica',
+			'Literature & Fiction',
+			'Mystery, Thriller & Suspense',
+			'Romance',
+			'Science Fiction & Fantasy'
+		],
 		mixedChildren: {
-			"Children's Audiobooks": ['Action & Adventure', 'Fairy Tales, Folk Tales & Myths', 'Humour', 'Literature & Fiction', 'Mystery & Suspense', 'Science Fiction & Fantasy'],
+			"Children's Audiobooks": [
+				'Action & Adventure',
+				'Fairy Tales, Folk Tales & Myths',
+				'Humour',
+				'Literature & Fiction',
+				'Mystery & Suspense',
+				'Science Fiction & Fantasy'
+			],
 			'Comedy & Humour': ['Literature & Fiction'],
-			'LGBTQ+': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
-			'Teen & Young Adult': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
-		},
+			'LGBTQ+': [
+				'Literature & Fiction',
+				'Mystery, Thriller & Suspense',
+				'Romance',
+				'Science Fiction & Fantasy'
+			],
+			'Teen & Young Adult': [
+				'Literature & Fiction',
+				'Mystery, Thriller & Suspense',
+				'Romance',
+				'Science Fiction & Fantasy'
+			]
+		}
 	},
 	in: {
-		fictionRoots: ['Literature & Fiction', 'Mature Content', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
+		fictionRoots: [
+			'Literature & Fiction',
+			'Mature Content',
+			'Mystery, Thriller & Suspense',
+			'Romance',
+			'Science Fiction & Fantasy'
+		],
 		mixedChildren: {
-			"Children's Audiobooks": ['Action & Adventure', 'Fairy Tales, Folk Tales & Myths', 'Humour', 'Literature & Fiction', 'Mystery & Suspsense', 'Science Fiction & Fantasy'],
+			"Children's Audiobooks": [
+				'Action & Adventure',
+				'Fairy Tales, Folk Tales & Myths',
+				'Humour',
+				'Literature & Fiction',
+				'Mystery & Suspsense',
+				'Science Fiction & Fantasy'
+			],
 			'Comedy & Humor': ['Literature & Fiction'],
-			'LGBTQ+': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
-			'Teen & Young Adult': ['Literature & Fiction', 'Mystery, Thriller & Suspense', 'Romance', 'Science Fiction & Fantasy'],
-		},
+			'LGBTQ+': [
+				'Literature & Fiction',
+				'Mystery, Thriller & Suspense',
+				'Romance',
+				'Science Fiction & Fantasy'
+			],
+			'Teen & Young Adult': [
+				'Literature & Fiction',
+				'Mystery, Thriller & Suspense',
+				'Romance',
+				'Science Fiction & Fantasy'
+			]
+		}
 	},
 	de: {
-		fictionRoots: ['Erotik', 'Krimis & Thriller', 'Liebesromane', 'Literatur & Belletristik', 'Science Fiction & Fantasy'],
+		fictionRoots: [
+			'Erotik',
+			'Krimis & Thriller',
+			'Liebesromane',
+			'Literatur & Belletristik',
+			'Science Fiction & Fantasy'
+		],
 		mixedChildren: {
 			'Comedy & Humor': ['Literatur & Belletristik'],
-			'Jugendliche & Heranwachsende': ['Krimis & Thriller', 'Liebesromane', 'Literatur & Belletristik', 'Science Fiction & Fantasy'],
-			'Kinder-Hörbücher': ['Action & Abenteuer', 'Detektive & Spannung', 'Literatur & Belletristik', 'Märchen & Mythen', 'Science Fiction & Fantasy'],
-			'LGBT': ['Krimis & Thriller', 'Liebesromane', 'Literatur & Belletristik', 'Science Fiction & Fantasy'],
-		},
+			'Jugendliche & Heranwachsende': [
+				'Krimis & Thriller',
+				'Liebesromane',
+				'Literatur & Belletristik',
+				'Science Fiction & Fantasy'
+			],
+			'Kinder-Hörbücher': [
+				'Action & Abenteuer',
+				'Detektive & Spannung',
+				'Literatur & Belletristik',
+				'Märchen & Mythen',
+				'Science Fiction & Fantasy'
+			],
+			LGBT: [
+				'Krimis & Thriller',
+				'Romanze',
+				'Literatur & Belletristik',
+				'Science Fiction & Fantasy'
+			]
+		}
 	},
 	es: {
-		fictionRoots: ['Ciencia ficción y fantasía', 'Erótica', 'Literatura y ficción', 'Policíaca, negra y suspense', 'Romántica'],
+		fictionRoots: [
+			'Ciencia ficción y fantasía',
+			'Erótica',
+			'Literatura y ficción',
+			'Policíaca, negra y suspense',
+			'Romántica'
+		],
 		mixedChildren: {
-			'Adolescentes': ['Ciencia ficción y fantasía', 'Literatura y ficción', 'Policíaca, negra y suspense', 'Romántica'],
-			'Audiolibros infantiles': ['Acción y aventura', 'Ciencia ficción y fantasía', 'Cuentos y leyendas', 'Humor', 'Literatura y ficción', 'Misterio y suspense'],
+			Adolescentes: [
+				'Ciencia ficción y fantasía',
+				'Literatura y ficción',
+				'Policíaca, negra y suspense',
+				'Romántica'
+			],
+			'Audiolibros infantiles': [
+				'Acción y aventura',
+				'Ciencia ficción y fantasía',
+				'Cuentos y leyendas',
+				'Humor',
+				'Literatura y ficción',
+				'Misterio y suspense'
+			],
 			'Comedia y humor': ['Literatura y ficción'],
-			'LGBTQ+': ['Ciencia ficción y fantasía', 'Literatura y ficción', 'Policíaca, negra y suspense', 'Romántica'],
-		},
+			'LGBTQ+': [
+				'Ciencia ficción y fantasía',
+				'Literatura y ficción',
+				'Misterio, negra y suspense',
+				'Romántica'
+			]
+		}
 	},
 	fr: {
-		fictionRoots: ['Littérature, romans et fiction', 'Policier, thrillers et œuvres à suspense', 'Romance', 'Science-Fiction et fantasy', 'Érotisme'],
+		fictionRoots: [
+			'Littérature, romans et fiction',
+			'Policier, thrillers et œuvres à suspense',
+			'Romance',
+			'Science-Fiction et fantasy',
+			'Érotisme'
+		],
 		mixedChildren: {
-			'Adolescents et jeunes adultes': ['Policier, thrillers et œuvres à suspense', "Roman d'amour", 'Roman et littérature', 'Science-fiction et fantasy'],
-			'Comédie et humour': ['Roman et littérature'],
-			'Jeunesse': ['Action et aventure', 'Contes de fées et populaires et mythes', 'Humour', 'Policier et suspense', 'Roman et littérature', 'Science-fiction et fantasy'],
-			'LGBT': ['Policier, thrillers et œuvres à suspense', "Roman d'amour", 'Roman et littérature', 'Science-fiction et fantasy'],
-		},
+			'Adolescents et jeunes adultes': [
+				'Policier, thrillers et œuvres à suspense',
+				"Roman d'amour",
+				'Roman et littérature',
+				'Science-fiction et fantasy'
+			],
+			'Comédie et humour': ['Littérature et fiction'],
+			Jeunesse: [
+				'Action et aventure',
+				'Contes de fées et populaires et mythes',
+				'Humour',
+				'Policier et suspense',
+				'Roman et littérature',
+				'Science-fiction et fantasy'
+			],
+			LGBT: [
+				'Policier, thrillers et œuvres à suspense',
+				'Romance',
+				'Littérature et fiction',
+				'Science-fiction et fantasy'
+			]
+		}
 	},
 	it: {
-		fictionRoots: ['Erotismo', 'Fantascienza e fantasy', 'Letteratura e narrativa', 'Poliziesco, thriller e suspense', "Romanzo d'amore"],
+		fictionRoots: [
+			'Erotismo',
+			'Fantascienza e fantasy',
+			'Letteratura e narrativa',
+			'Poliziesco, thriller e suspense',
+			"Romanzo d'amore"
+		],
 		mixedChildren: {
-			'Adolescenti e Ragazzi': ['Fantascienza e fantasy', 'Letteratura e narrativa', 'Poliziesco, thriller e suspense', "Romanzo d'amore"],
-			'Audiolibri per bambini': ['Azione e avventura', 'Fantascienza e fantasy', 'Fiabe, racconti popolari e miti', 'Humor', 'Letteratura e narrativa', 'Poliziesco e suspense'],
-			'Commedia e umorismo': ['Letteratura e narrativa'],
-			'LGBT': ['Fantascienza e fantasy', 'Letteratura e narrativa', 'Poliziesco, thriller e suspense', "Romanzo d'amore"],
-		},
+			'Adolescenti e Ragazzi': [
+				'Fantascienza e fantasy',
+				'Letteratura e narrativa',
+				'Poliziesco, thriller e suspense',
+				"Romanzo d'amore"
+			],
+			'Audiolibri per bambini': [
+				'Azione e avventura',
+				'Fantascienza e fantasy',
+				'Fiabe, racconti popolari e miti',
+				'Humor',
+				'Letteratura e narrativa',
+				'Poliziesco e suspense'
+			],
+			'Commedia e umorismo': ['Letteratura e fiction'],
+			LGBT: ['Letteratura e narrativa', "Romanzo d'amore"]
+		}
 	},
 	jp: {
-		fictionRoots: ['SF・ファンタジー', 'アダルト', 'ティーンズラブ', 'ボーイズラブ', 'ミステリー・スリラー・サスペンス', 'ライトノベル(ラノベ)', '官能・ロマンス', '文学・フィクション'],
+		fictionRoots: [
+			'SF・ファンタジー',
+			'アダルト',
+			'ティーンズラブ',
+			'ボーイズラブ',
+			'ミステリー・スリラー・サスペンス',
+			'ライトノベル(ラノベ)',
+			'官能・ロマンス',
+			'文学・フィクション'
+		],
 		mixedChildren: {
-			'LGBT': ['文学・フィクション', 'ロマンス', 'ミステリー・スリラー・サスペンス', 'SF・ファンタジー'],
+			LGBT: [
+				'文学・フィクション',
+				'ロマンス',
+				'ミステリー・スリラー・サスペンス',
+				'SF・ファンタジー'
+			],
 			'コメディー・落語': ['ユーモア・風刺文学・フィクション'],
-			'ティーン': ['SF・ファンタジー', '文学・フィクション・ライトノベル', 'ミステリー・スリラー・サスペンス', 'ロマンス'],
-			'絵本・児童書': ['SF・ファンタジー', 'アクション・アドベンチャー', 'ミステリー・サスペンス', 'ユーモア', '文学・フィクション', '童話・民話・神話'],
-		},
-	},
+			ティーン: [
+				'SF・ファンタジー',
+				'文学・フィクション・ライトノベル',
+				'ミステリー・スリラー・サスペンス',
+				'ロマンス'
+			],
+			'絵本・児童書': [
+				'SF・ファンタジー',
+				'アクション・アドベンチャー',
+				'ミステリー・サスペンス',
+				'ユーモア',
+				'文学・フィクション',
+				'童話・民話・神話'
+			]
+		}
+	}
 }
 
 export default function literatureTypeFromProduct(
@@ -117,5 +339,7 @@ export default function literatureTypeFromProduct(
 		if (matches) return 'fiction'
 		return 'nonfiction'
 	}
-	return thesaurusKeywords?.some((keyword) => keyword.includes('fiction')) ? 'fiction' : 'nonfiction'
+	return thesaurusKeywords?.some((keyword) => keyword.includes('fiction'))
+		? 'fiction'
+		: 'nonfiction'
 }

--- a/tests/datasets/audible/books/api.ts
+++ b/tests/datasets/audible/books/api.ts
@@ -6,6 +6,7 @@ import {
 	AudibleProduct,
 	AudibleProductSchema
 } from '#config/types'
+import literatureTypeFromProduct from '#helpers/books/audible/literatureType'
 
 export interface MinimalResponse {
 	asin: string
@@ -62,11 +63,7 @@ export function setupMinimalParsed(
 		isbn: response.isbn ?? '',
 		isAdult: response.is_adult_product,
 		language: response.language,
-		literatureType: response.thesaurus_subject_keywords?.some((keyword) =>
-			keyword.includes('fiction')
-		)
-			? 'fiction'
-			: 'nonfiction',
+		literatureType: literatureTypeFromProduct(response.category_ladders, response.thesaurus_subject_keywords, 'us'),
 		narrators: response.narrators,
 		image,
 		...(response.rating && {
@@ -1289,7 +1286,7 @@ export const minimalB0036I54I6: ApiBook = {
 	isAdult: false,
 	isbn: '',
 	language: 'english',
-	literatureType: 'nonfiction',
+	literatureType: 'fiction',
 	narrators: [],
 	publisherName: 'Stanford Audio',
 	rating: '3.9',
@@ -1297,7 +1294,7 @@ export const minimalB0036I54I6: ApiBook = {
 	releaseDate: new Date('1999-12-16T00:00:00.000Z'),
 	runtimeLengthMin: 114,
 	summary:
-		'Both Anne Sexton and Sylvia Plath rose above severe mental disorders to create bold new directions for American poetry and share the woman\'s perspective in distinct, powerful voices. Professor Middlebrook, author of the best selling <i>Anne Sexton: A Biography</i>, sheds light on the unique and important contributions of these poets by examining 4 works: "Morning Song" and "Ariel" by Plath and "The Fortress" and "The Double Image" by Sexton. Her conversations with Professor Lindenberger and an audience further delve into the work and lives of these women, their friendship, and their tragic deaths.',
+		"Both Anne Sexton and Sylvia Plath rose above severe mental disorders to create bold new directions for American poetry and share the woman's perspective in distinct, powerful voices. Professor Middlebrook, author of the best selling <i>Anne Sexton: A Biography</i>, sheds light on the unique and important contributions of these poets by examining 4 works: \"Morning Song\" and \"Ariel\" by Plath and \"The Fortress\" and \"The Double Image\" by Sexton. Her conversations with Professor Lindenberger and an audience further delve into the work and lives of these women, their friendship, and their tragic deaths.",
 	title: 'The Poetry of Anne Sexton and Sylvia Plath'
 }
 

--- a/tests/datasets/audible/books/api.ts
+++ b/tests/datasets/audible/books/api.ts
@@ -63,7 +63,11 @@ export function setupMinimalParsed(
 		isbn: response.isbn ?? '',
 		isAdult: response.is_adult_product,
 		language: response.language,
-		literatureType: literatureTypeFromProduct(response.category_ladders, response.thesaurus_subject_keywords, 'us'),
+		literatureType: literatureTypeFromProduct(
+			response.category_ladders,
+			response.thesaurus_subject_keywords,
+			'us'
+		),
 		narrators: response.narrators,
 		image,
 		...(response.rating && {
@@ -1294,7 +1298,7 @@ export const minimalB0036I54I6: ApiBook = {
 	releaseDate: new Date('1999-12-16T00:00:00.000Z'),
 	runtimeLengthMin: 114,
 	summary:
-		"Both Anne Sexton and Sylvia Plath rose above severe mental disorders to create bold new directions for American poetry and share the woman's perspective in distinct, powerful voices. Professor Middlebrook, author of the best selling <i>Anne Sexton: A Biography</i>, sheds light on the unique and important contributions of these poets by examining 4 works: \"Morning Song\" and \"Ariel\" by Plath and \"The Fortress\" and \"The Double Image\" by Sexton. Her conversations with Professor Lindenberger and an audience further delve into the work and lives of these women, their friendship, and their tragic deaths.",
+		'Both Anne Sexton and Sylvia Plath rose above severe mental disorders to create bold new directions for American poetry and share the woman\'s perspective in distinct, powerful voices. Professor Middlebrook, author of the best selling <i>Anne Sexton: A Biography</i>, sheds light on the unique and important contributions of these poets by examining 4 works: "Morning Song" and "Ariel" by Plath and "The Fortress" and "The Double Image" by Sexton. Her conversations with Professor Lindenberger and an audience further delve into the work and lives of these women, their friendship, and their tragic deaths.',
 	title: 'The Poetry of Anne Sexton and Sylvia Plath'
 }
 

--- a/tests/helpers/books/audible/literatureType.test.ts
+++ b/tests/helpers/books/audible/literatureType.test.ts
@@ -7,12 +7,14 @@ type Ladders = AudibleProduct['product']['category_ladders']
 
 const cat = (ladder: string[], root = 'Genres'): Ladders[number] => ({
 	root,
-	ladder: ladder.map((name, i) => ({ id: String(18570000000 + i), name })),
+	ladder: ladder.map((name, i) => ({ id: String(18570000000 + i), name }))
 })
 
 describe('literatureTypeFromProduct', () => {
 	test('fiction root, no fiction keyword', () => {
-		const ladders: Ladders = [cat(['Mystery, Thriller & Suspense', 'Thriller & Suspense', 'Espionage'])]
+		const ladders: Ladders = [
+			cat(['Mystery, Thriller & Suspense', 'Thriller & Suspense', 'Espionage'])
+		]
 		expect(literatureTypeFromProduct(ladders, [], 'us')).toBe('fiction')
 	})
 

--- a/tests/helpers/books/audible/literatureType.test.ts
+++ b/tests/helpers/books/audible/literatureType.test.ts
@@ -48,6 +48,11 @@ describe('literatureTypeFromProduct', () => {
 		expect(literatureTypeFromProduct(ladders, ['literature-and-fiction'], 'us')).toBe('fiction')
 	})
 
+	test('keyword fallback: nonfiction keyword does not match fiction', () => {
+		const ladders: Ladders = []
+		expect(literatureTypeFromProduct(ladders, ['nonfiction'], 'us')).toBe('nonfiction')
+	})
+
 	test('no signal, ladders present, nonfiction', () => {
 		const ladders: Ladders = [cat(['Biographies & Memoirs', 'Historical'])]
 		expect(literatureTypeFromProduct(ladders, ['test'], 'us')).toBe('nonfiction')

--- a/tests/helpers/books/audible/literatureType.test.ts
+++ b/tests/helpers/books/audible/literatureType.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test'
+
+import type { AudibleProduct } from '#config/types'
+import literatureTypeFromProduct from '#helpers/books/audible/literatureType'
+
+type Ladders = AudibleProduct['product']['category_ladders']
+
+const cat = (ladder: string[], root = 'Genres'): Ladders[number] => ({
+	root,
+	ladder: ladder.map((name, i) => ({ id: String(18570000000 + i), name })),
+})
+
+describe('literatureTypeFromProduct', () => {
+	test('fiction root, no fiction keyword', () => {
+		const ladders: Ladders = [cat(['Mystery, Thriller & Suspense', 'Thriller & Suspense', 'Espionage'])]
+		expect(literatureTypeFromProduct(ladders, [], 'us')).toBe('fiction')
+	})
+
+	test('Science Fiction & Fantasy root, no keyword', () => {
+		const ladders: Ladders = [cat(['Science Fiction & Fantasy', 'Science Fiction', 'Space Opera'])]
+		expect(literatureTypeFromProduct(ladders, undefined, 'us')).toBe('fiction')
+	})
+
+	test('children nonfiction stays nonfiction', () => {
+		const ladders: Ladders = [cat(["Children's Audiobooks", 'Biographies'])]
+		expect(literatureTypeFromProduct(ladders, [], 'us')).toBe('nonfiction')
+	})
+
+	test('children fiction via 2nd level', () => {
+		const ladders: Ladders = [cat(["Children's Audiobooks", 'Literature & Fiction', 'Family Life'])]
+		expect(literatureTypeFromProduct(ladders, [], 'us')).toBe('fiction')
+	})
+
+	test('teen fiction via 2nd level', () => {
+		const ladders: Ladders = [cat(['Teen & Young Adult', 'Romance'])]
+		expect(literatureTypeFromProduct(ladders, [], 'us')).toBe('fiction')
+	})
+
+	test('comedy biography (2nd-level nonfiction) stays nonfiction', () => {
+		const ladders: Ladders = [cat(['Comedy & Humor', 'Biographies & Memoirs'])]
+		expect(literatureTypeFromProduct(ladders, [], 'us')).toBe('nonfiction')
+	})
+
+	test('keyword fallback when no ladders', () => {
+		const ladders: Ladders = []
+		expect(literatureTypeFromProduct(ladders, ['literature-and-fiction'], 'us')).toBe('fiction')
+	})
+
+	test('no signal, ladders present, nonfiction', () => {
+		const ladders: Ladders = [cat(['Biographies & Memoirs', 'Historical'])]
+		expect(literatureTypeFromProduct(ladders, ['test'], 'us')).toBe('nonfiction')
+	})
+
+	test('German region localization', () => {
+		const ladders: Ladders = [cat(['Literatur & Belletristik', 'Belletristik'])]
+		expect(literatureTypeFromProduct(ladders, [], 'de')).toBe('fiction')
+	})
+
+	test('Japanese region localization', () => {
+		const ladders: Ladders = [cat(['SF・ファンタジー', 'SF'])]
+		expect(literatureTypeFromProduct(ladders, [], 'jp')).toBe('fiction')
+	})
+})


### PR DESCRIPTION
## Summary

Classify `literatureType` from Audible `category_ladders` data instead of searching `thesaurus_subject_keywords` for the word "fiction".

## Motivation

The previous keyword-based approach checked whether any `thesaurus_subject_keywords` entry contained the string `"fiction"`. This was brittle: keywords are free-text and inconsistently populated, so fiction classification could be wrong for books that lacked the literal word "fiction" in their keyword list.

Audible's `category_ladders` provides structured browse-node hierarchy — the top-level category is a far more reliable signal. Each region has known fiction root category IDs; walking the ladder to find a matching root gives accurate fiction/nonfiction classification.

## Changes

- **New module** `src/helpers/books/audible/literatureType.ts` (345 lines): region-specific fiction root category ID tables for US, UK, DE, FR, IT, ES, JP, CA, AU, plus the `literatureTypeFromProduct()` classifier that walks category ladders to find a fiction root match
- **ApiHelper**: replaced inline keyword check with call to `literatureTypeFromProduct()`, reading `category_ladders`, `thesaurus_subject_keywords`, and `region`
- **Keyword fallback preserved**: if category ladders are absent or empty, falls back to the original keyword-based heuristic
- **Test dataset**: `B0036I54I6` expected `literatureType` corrected from `nonfiction` to `fiction` (the keyword-based check had it wrong)
- **New test file**: `tests/helpers/books/audible/literatureType.test.ts` covers fiction/nonfiction classification across regions and empty-missing ladder edge cases

## Notes

- Keyword fallback is intentionally retained as a safety net for edge cases where category ladders are missing or empty
- The classifier must run before `getGenres()` since that method mutates `category_ladders`
- Region tables are manually curated from known Audible browse node IDs; adding new regions requires updating the table


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved Audible book classification using category information, subject keywords, and regional rules.
  * Added support for localized literature categories across multiple markets, including Germany and Japan.
  * Improved handling of fiction, nonfiction, children’s, and teen book categories.

* **Bug Fixes**
  * Corrected titles that were previously misidentified as nonfiction.

* **Tests**
  * Added coverage for regional categories, keyword fallback, and missing classification data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->