### PR TITLE
fix(api): accept numeric Audible book ASINs in route validation

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -12,14 +12,11 @@ export const asin10Regex = new RegExp(`^${baseAsin10Regex.source}$`)
 export const asin11Regex = /\d{11}/gm
 
 // Reusable types
+// Audible book ASINs are either B-prefixed 10-char identifiers (e.g. B079LRSMNN)
+// or 10-char numeric identifiers (e.g. 1978650817). Both are valid book lookup
+// params; upstream Audible itself resolves existence, so unknown values should
+// surface as not-found there rather than being rejected here.
 export const AsinSchema = z.string().trim().regex(asin10Regex)
-// Audible book/author ASINs are always B-prefixed 10-char identifiers.
-// Used for route-param validation only; AsinSchema stays permissive for stored
-// data (chapter asins etc. can legitimately be numeric).
-export const BookAsinSchema = z
-	.string()
-	.trim()
-	.regex(/^B[\dA-Z]{9}$/)
 // Using different regex for 11 digit ASINs because zod validation needs quantifier
 export const GenreAsinSchema = z.string().regex(new RegExp(/^\d{10,12}$/))
 export const NameSchema = z.string().min(2)

--- a/src/helpers/routes/RouteCommonHelper.ts
+++ b/src/helpers/routes/RouteCommonHelper.ts
@@ -1,7 +1,7 @@
 import { FastifyReply } from 'fastify'
 import { ZodError } from 'zod'
 
-import { ApiQueryString, ApiQueryStringSchema, BookAsinSchema } from '#config/types'
+import { ApiQueryString, ApiQueryStringSchema, AsinSchema } from '#config/types'
 import { BadRequestError } from '#helpers/errors/ApiErrors'
 import {
 	ErrorMessageBadQuery,
@@ -59,7 +59,7 @@ class RouteCommonHelper {
 	 * @returns {boolean}
 	 */
 	isValidAsin(asin: string): boolean {
-		return BookAsinSchema.safeParse(asin).success
+		return AsinSchema.safeParse(asin).success
 	}
 
 	/**

--- a/tests/helpers/routes/RouteCommonHelper.test.ts
+++ b/tests/helpers/routes/RouteCommonHelper.test.ts
@@ -63,13 +63,15 @@ describe('RouteCommonHelper should throw an error', () => {
 		expect(() => helper.runValidations()).toThrow(BadRequestError)
 		expect(() => helper.runValidations()).toThrow('Bad ASIN')
 	})
-	test('if the asin is numeric (ISBN-style)', () => {
-		// 10-char numeric strings previously passed AsinSchema validation,
-		// hit Audible's scrape URL, and returned a misleading 404.
-		// Route params require a B-prefixed book ASIN.
+	test('if the asin is numeric (10-char ISBN-style)', () => {
+		// Numeric ASINs are legitimate Audible book identifiers (e.g. 1978650817,
+		// Randomize by Andy Weir) and must pass route validation; upstream Audible
+		// resolves existence, so unknown numeric values 404 there instead of a 400 here.
+		// (GitHub issue #914: numeric ASINs were wrongly rejected as "Bad ASIN".)
+		helper = new RouteCommonHelper('1978650817', query, ctx.client)
+		expect(() => helper.runValidations()).not.toThrow()
 		helper = new RouteCommonHelper('9781538548', query, ctx.client)
-		expect(() => helper.runValidations()).toThrow(BadRequestError)
-		expect(() => helper.runValidations()).toThrow('Bad ASIN')
+		expect(() => helper.runValidations()).not.toThrow()
 	})
 	test('if the name is not valid', () => {
 		helper = new RouteCommonHelper('', { name: '' }, ctx.client)


### PR DESCRIPTION
## Repro
`GET /books/1978650817/chapters?region=us` returns `{"error":{"code":"BAD_REQUEST","message":"Bad ASIN"}}`, yet `1978650817` is a valid Audible book ASIN: `https://api.audible.com/1.0/catalog/products/1978650817?...` returns the full product (Randomize by Andy Weir, ISBN 9781978650817) and the audible.com product page resolves. Local repro exercising the exact validation path:
```
REPRODUCED: 1978650817 rejected -> Bad ASIN   (pre-fix)
NOT REPRODUCED: 1978650817 passed validation   (post-fix)
```

## Cause
`src/helpers/routes/RouteCommonHelper.isValidAsin` validated route params against `BookAsinSchema` (`src/config/types.ts`), introduced in #908 (merged 2026-08-08): `/^B[\dA-Z]{9}$/`, which only accepts B-prefixed ASINs and rejects 10-char numeric ASINs. The schema's comment claims "Audible book/author ASINs are always B-prefixed 10-char identifiers", which is incorrect — Audible's catalog API resolves numeric ASINs like `1978650817`. Prior to #908, routes used the permissive `AsinSchema` (`asin10Regex`: `^(B[\dA-Z]{9}|\d{9}(X|\d))$`), which accepted numeric ASINs; #908's tightening broke them.

## Fix
- `src/config/types.ts`: remove `BookAsinSchema` and its false-premise comment; document that B-prefixed and numeric 10-char ASINs are both valid book lookup params.
- `src/helpers/routes/RouteCommonHelper.ts`: revert `isValidAsin` to `AsinSchema`, restoring acceptance of numeric ASINs. Unknown numeric values are correctly surfaced as not-found by upstream Audible rather than rejected with a misleading 400.
- `tests/helpers/routes/RouteCommonHelper.test.ts`: flip the numeric-ASIN test to assert `1978650817` and `9781538548` now pass route validation (regression lock for #914); the 11-digit malformed-ASIN rejection test still holds.

The rest of #908 (retry/backoff, content-type checks) is untouched.

## Verification
- `bun run scripts/repro-914.ts`: `NOT REPRODUCED: 1978650817 passed validation`, exit 0 (pre-fix it exited 1 with `Bad ASIN`).
- `bun test --timeout 30000 tests/helpers/routes/RouteCommonHelper.test.ts`: 11 pass, 0 fail.
- `bun run test`: 697 pass, 0 fail.
- `bun run lint`: prettier check + `tsc --noEmit` + eslint pass. `bun run build`: clean.

The repo defines no `fix`/`check` scripts, so the pre-publish gate is not run.

Fixes #914

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Audible book identifiers with either a “B” prefix or 10 numeric characters are now accepted during route validation.
  - Valid numeric 10-character identifiers no longer trigger a bad-request error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->