### PR TITLE
chore: merge develop into main

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 
 </div>
 
+> **Looking for audiobook metadata?** Check out [AudiobookDB](https://audiobookdb.org) — our community-maintained audiobook metadata database and the successor to this API: proper book/release separation, moderated community contributions, and fast search. New projects should start there; audnexus remains online and maintained.
+
 ---
 
 <p align="center"> An audiobook data aggregation API, combining multiple sources of data into one, consistent source.

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -12,14 +12,11 @@ export const asin10Regex = new RegExp(`^${baseAsin10Regex.source}$`)
 export const asin11Regex = /\d{11}/gm
 
 // Reusable types
+// Audible book ASINs are either B-prefixed 10-char identifiers (e.g. B079LRSMNN)
+// or 10-char numeric identifiers (e.g. 1978650817). Both are valid book lookup
+// params; upstream Audible itself resolves existence, so unknown values should
+// surface as not-found there rather than being rejected here.
 export const AsinSchema = z.string().trim().regex(asin10Regex)
-// Audible book/author ASINs are always B-prefixed 10-char identifiers.
-// Used for route-param validation only; AsinSchema stays permissive for stored
-// data (chapter asins etc. can legitimately be numeric).
-export const BookAsinSchema = z
-	.string()
-	.trim()
-	.regex(/^B[\dA-Z]{9}$/)
 // Using different regex for 11 digit ASINs because zod validation needs quantifier
 export const GenreAsinSchema = z.string().regex(new RegExp(/^\d{10,12}$/))
 export const NameSchema = z.string().min(2)

--- a/src/helpers/routes/RouteCommonHelper.ts
+++ b/src/helpers/routes/RouteCommonHelper.ts
@@ -1,7 +1,7 @@
 import { FastifyReply } from 'fastify'
 import { ZodError } from 'zod'
 
-import { ApiQueryString, ApiQueryStringSchema, BookAsinSchema } from '#config/types'
+import { ApiQueryString, ApiQueryStringSchema, AsinSchema } from '#config/types'
 import { BadRequestError } from '#helpers/errors/ApiErrors'
 import {
 	ErrorMessageBadQuery,
@@ -59,7 +59,7 @@ class RouteCommonHelper {
 	 * @returns {boolean}
 	 */
 	isValidAsin(asin: string): boolean {
-		return BookAsinSchema.safeParse(asin).success
+		return AsinSchema.safeParse(asin).success
 	}
 
 	/**

--- a/tests/helpers/routes/RouteCommonHelper.test.ts
+++ b/tests/helpers/routes/RouteCommonHelper.test.ts
@@ -63,13 +63,15 @@ describe('RouteCommonHelper should throw an error', () => {
 		expect(() => helper.runValidations()).toThrow(BadRequestError)
 		expect(() => helper.runValidations()).toThrow('Bad ASIN')
 	})
-	test('if the asin is numeric (ISBN-style)', () => {
-		// 10-char numeric strings previously passed AsinSchema validation,
-		// hit Audible's scrape URL, and returned a misleading 404.
-		// Route params require a B-prefixed book ASIN.
+	test('if the asin is numeric (10-char ISBN-style)', () => {
+		// Numeric ASINs are legitimate Audible book identifiers (e.g. 1978650817,
+		// Randomize by Andy Weir) and must pass route validation; upstream Audible
+		// resolves existence, so unknown numeric values 404 there instead of a 400 here.
+		// (GitHub issue #914: numeric ASINs were wrongly rejected as "Bad ASIN".)
+		helper = new RouteCommonHelper('1978650817', query, ctx.client)
+		expect(() => helper.runValidations()).not.toThrow()
 		helper = new RouteCommonHelper('9781538548', query, ctx.client)
-		expect(() => helper.runValidations()).toThrow(BadRequestError)
-		expect(() => helper.runValidations()).toThrow('Bad ASIN')
+		expect(() => helper.runValidations()).not.toThrow()
 	})
 	test('if the name is not valid', () => {
 		helper = new RouteCommonHelper('', { name: '' }, ctx.client)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Audible book identifiers containing 10 numeric characters are now accepted as valid ASINs.
  * Route validation continues to reject malformed or incorrectly sized identifiers with the appropriate error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->