### PR TITLE
feat(api): expose rating counts and star histogram on /books/{asin} #919

### DIFF
--- a/docs/spec/audnexus.yaml
+++ b/docs/spec/audnexus.yaml
@@ -444,6 +444,75 @@ paths:
         in: path
         required: true
         description: Audible.com ID
+  '/books/backfill-ratings':
+    post:
+      summary: Backfill ratings
+      description: |
+        Re-fetches every stored book that is missing the `ratings` field and
+        persists the rating counts and star distributions. Admin-only; disabled
+        unless the `UPDATE_STATS` environment flag is enabled.
+      operationId: backfillRatings
+      tags:
+        - Books
+      parameters:
+        - name: x-admin-token
+          in: header
+          description: Admin token used to authorize the backfill
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Backfill completed
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  total:
+                    type: integer
+                    description: Number of books processed
+                  updated:
+                    type: integer
+                    description: Number of books successfully updated
+                  failed:
+                    type: integer
+                    description: Number of books that failed to update
+                example:
+                  message: Ratings backfill complete
+                  total: 1500
+                  updated: 1498
+                  failed: 2
+        '401':
+          description: Missing or invalid admin token
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+              example:
+                error: Unauthorized
+                message: Invalid admin token
+        '404':
+          description: Backfill endpoint disabled
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                  message:
+                    type: string
+              example:
+                error: Not Found
+                message: Route not available
   '/books/{ASIN}/chapters':
     get:
       summary: Find chapters by ASIN

--- a/docs/spec/audnexus.yaml
+++ b/docs/spec/audnexus.yaml
@@ -294,6 +294,28 @@ paths:
                       - name: Ray Porter
                     publisherName: Audible Studios
                     rating: '4.9'
+                    ratings:
+                      value: '4.9'
+                      numRatings: 158505
+                      numReviews: 18832
+                      distribution:
+                        five: 141378
+                        four: 14019
+                        three: 2262
+                        two: 558
+                        one: 288
+                      performanceDistribution:
+                        five: 136044
+                        four: 7138
+                        three: 1126
+                        two: 237
+                        one: 185
+                      storyDistribution:
+                        five: 125817
+                        four: 14956
+                        three: 2467
+                        two: 619
+                        one: 318
                     region: us
                     releaseDate: '2021-05-04T00:00:00.000Z'
                     runtimeLengthMin: 970
@@ -1125,6 +1147,27 @@ components:
           type: string
         rating:
           type: string
+        ratings:
+          type: object
+          description: Rating counts and star distribution from Audible
+          properties:
+            value:
+              type: string
+            numRatings:
+              type: number
+            numReviews:
+              type: number
+            distribution:
+              $ref: '#/components/schemas/RatingDistribution'
+            performanceDistribution:
+              $ref: '#/components/schemas/RatingDistribution'
+            storyDistribution:
+              $ref: '#/components/schemas/RatingDistribution'
+          required:
+            - value
+            - numRatings
+            - numReviews
+            - distribution
         region:
           type: string
           enum:
@@ -1235,6 +1278,26 @@ components:
           type: string
       required:
         - name
+    RatingDistribution:
+      type: object
+      description: Star distribution counts
+      properties:
+        five:
+          type: number
+        four:
+          type: number
+        three:
+          type: number
+        two:
+          type: number
+        one:
+          type: number
+      required:
+        - five
+        - four
+        - three
+        - two
+        - one
     Series:
       required:
         - name

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "audnexus",
-	"version": "1.15.1",
+	"version": "1.15.2",
 	"description": "An API for aggregating audiobook data",
 	"repository": {
 		"type": "git",

--- a/src/config/models/Book.ts
+++ b/src/config/models/Book.ts
@@ -36,6 +36,35 @@ const bookSchema = schema(
 		),
 		publisherName: types.string({ required: true }),
 		rating: types.string({ required: true }),
+		ratings: types.object({
+			value: types.string({ required: true }),
+			numRatings: types.number({ required: true }),
+			numReviews: types.number({ required: true }),
+			distribution: types.object(
+				{
+					five: types.number({ required: true }),
+					four: types.number({ required: true }),
+					three: types.number({ required: true }),
+					two: types.number({ required: true }),
+					one: types.number({ required: true })
+				},
+				{ required: true }
+			),
+			performanceDistribution: types.object({
+				five: types.number({ required: true }),
+				four: types.number({ required: true }),
+				three: types.number({ required: true }),
+				two: types.number({ required: true }),
+				one: types.number({ required: true })
+			}),
+			storyDistribution: types.object({
+				five: types.number({ required: true }),
+				four: types.number({ required: true }),
+				three: types.number({ required: true }),
+				two: types.number({ required: true }),
+				one: types.number({ required: true })
+			})
+		}),
 		region: types.string({
 			enum: Object.keys(regions),
 			pattern: regionRegex,

--- a/src/config/routes/books/backfill.ts
+++ b/src/config/routes/books/backfill.ts
@@ -1,0 +1,27 @@
+import crypto from 'crypto'
+import { FastifyInstance } from 'fastify'
+
+import BookBackfillHelper from '#helpers/routes/BookBackfillHelper'
+
+async function _backfill(fastify: FastifyInstance) {
+	fastify.post('/books/backfill-ratings', async (request, reply) => {
+		if (process.env.UPDATE_STATS !== '1') {
+			return reply.code(404).send({ error: 'Not Found', message: 'Route not available' })
+		}
+		const adminToken = process.env.ADMIN_TOKEN
+		const requestToken = request.headers['x-admin-token']?.toString()
+		if (!adminToken || !requestToken) {
+			return reply.code(401).send({ error: 'Unauthorized', message: 'Missing admin token' })
+		}
+		const bufRequest = Buffer.from(requestToken)
+		const bufAuth = Buffer.from(adminToken)
+		if (bufRequest.length !== bufAuth.length || !crypto.timingSafeEqual(bufRequest, bufAuth)) {
+			return reply.code(401).send({ error: 'Unauthorized', message: 'Invalid admin token' })
+		}
+		const helper = new BookBackfillHelper(request.log)
+		const summary = await helper.process()
+		return { message: 'Ratings backfill complete', ...summary }
+	})
+}
+
+export default _backfill

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -177,8 +177,10 @@ const AudibleRatingItemSchema = z.object({
 const AudibleRatingSchema = z.object({
 	num_reviews: z.number().or(z.literal(0)),
 	overall_distribution: AudibleRatingItemSchema,
-	performance_distribution: AudibleRatingItemSchema,
-	story_distribution: AudibleRatingItemSchema
+	// Audible omits these groups for some products; keep them optional so the
+	// parse does not reject products that lack a performance/story distribution
+	performance_distribution: AudibleRatingItemSchema.optional(),
+	story_distribution: AudibleRatingItemSchema.optional()
 })
 
 export const AudibleSeriesSchema = z.object({

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -84,6 +84,27 @@ export const ApiNarratorOnBookSchema = z.object({
 })
 export type ApiNarratorOnBook = z.infer<typeof ApiNarratorOnBookSchema>
 
+// Book ratings
+// Star distribution counts derived from Audible's rating response group
+export const ApiRatingDistributionSchema = z.object({
+	five: z.number(),
+	four: z.number(),
+	three: z.number(),
+	two: z.number(),
+	one: z.number()
+})
+export type ApiRatingDistribution = z.infer<typeof ApiRatingDistributionSchema>
+
+export const ApiRatingsSchema = z.object({
+	value: z.string(),
+	numRatings: z.number(),
+	numReviews: z.number(),
+	distribution: ApiRatingDistributionSchema,
+	performanceDistribution: ApiRatingDistributionSchema.optional(),
+	storyDistribution: ApiRatingDistributionSchema.optional()
+})
+export type ApiRatings = z.infer<typeof ApiRatingsSchema>
+
 // Books
 // What we expect to keep from Audible's API
 export const ApiBookSchema = z.object({
@@ -103,6 +124,7 @@ export const ApiBookSchema = z.object({
 		.optional(),
 	narrators: z.array(ApiNarratorOnBookSchema).optional(),
 	publisherName: z.string(),
+	ratings: ApiRatingsSchema.optional(),
 	rating: z.string(),
 	region: RegionSchema,
 	releaseDate: z.date(),

--- a/src/helpers/books/audible/ApiHelper.ts
+++ b/src/helpers/books/audible/ApiHelper.ts
@@ -8,6 +8,7 @@ import {
 	ApiGenre,
 	ApiGenreSchema,
 	ApiNarratorOnBook,
+	ApiRatingDistribution,
 	ApiRatings,
 	ApiSeries,
 	ApiSeriesSchema,
@@ -203,9 +204,27 @@ class ApiHelper {
 	}
 
 	/**
+	 * Map an upstream star-distribution group to the camelCase shape.
+	 */
+	private starCounts(
+		distribution: NonNullable<AudibleProduct['product']['rating']>['overall_distribution']
+	): ApiRatingDistribution {
+		return {
+			five: distribution.num_five_star_ratings,
+			four: distribution.num_four_star_ratings,
+			three: distribution.num_three_star_ratings,
+			two: distribution.num_two_star_ratings,
+			one: distribution.num_one_star_ratings
+		}
+	}
+
+	/**
 	 * Compile the ratings object (counts + star distributions) from the
 	 * upstream rating response group. Returns undefined when Audible
-	 * did not return a rating block.
+	 * did not return a rating block. Audible omits the
+	 * performance/story distribution groups for some products; those
+	 * sub-distributions are then left absent on the result (matching
+	 * ApiRatingsSchema, which marks them optional) instead of throwing.
 	 */
 	getRatings(): ApiRatings | undefined {
 		const rating = this.audibleResponse?.rating
@@ -214,27 +233,13 @@ class ApiHelper {
 			value: rating.overall_distribution.display_average_rating.toString(),
 			numRatings: rating.overall_distribution.num_ratings,
 			numReviews: rating.num_reviews,
-			distribution: {
-				five: rating.overall_distribution.num_five_star_ratings,
-				four: rating.overall_distribution.num_four_star_ratings,
-				three: rating.overall_distribution.num_three_star_ratings,
-				two: rating.overall_distribution.num_two_star_ratings,
-				one: rating.overall_distribution.num_one_star_ratings
-			},
-			performanceDistribution: {
-				five: rating.performance_distribution.num_five_star_ratings,
-				four: rating.performance_distribution.num_four_star_ratings,
-				three: rating.performance_distribution.num_three_star_ratings,
-				two: rating.performance_distribution.num_two_star_ratings,
-				one: rating.performance_distribution.num_one_star_ratings
-			},
-			storyDistribution: {
-				five: rating.story_distribution.num_five_star_ratings,
-				four: rating.story_distribution.num_four_star_ratings,
-				three: rating.story_distribution.num_three_star_ratings,
-				two: rating.story_distribution.num_two_star_ratings,
-				one: rating.story_distribution.num_one_star_ratings
-			}
+			distribution: this.starCounts(rating.overall_distribution),
+			...(rating.performance_distribution && {
+				performanceDistribution: this.starCounts(rating.performance_distribution)
+			}),
+			...(rating.story_distribution && {
+				storyDistribution: this.starCounts(rating.story_distribution)
+			})
 		}
 	}
 
@@ -345,6 +350,7 @@ class ApiHelper {
 			series1 = this.getSeriesPrimary(this.audibleResponse.series)
 			series2 = this.getSeriesSecondary(this.audibleResponse.series)
 		}
+		const ratings = this.getRatings()
 		// Parse final data
 		return ApiBookSchema.parse({
 			asin: this.audibleResponse.asin,
@@ -384,8 +390,8 @@ class ApiHelper {
 			...(this.audibleResponse.rating && {
 				rating: this.audibleResponse.rating.overall_distribution.display_average_rating.toString()
 			}),
-			...(this.getRatings() && {
-				ratings: this.getRatings()
+			...(ratings && {
+				ratings
 			}),
 			region: this.region,
 			releaseDate: this.getReleaseDate(),

--- a/src/helpers/books/audible/ApiHelper.ts
+++ b/src/helpers/books/audible/ApiHelper.ts
@@ -8,6 +8,7 @@ import {
 	ApiGenre,
 	ApiGenreSchema,
 	ApiNarratorOnBook,
+	ApiRatings,
 	ApiSeries,
 	ApiSeriesSchema,
 	AudibleCategory,
@@ -202,6 +203,42 @@ class ApiHelper {
 	}
 
 	/**
+	 * Compile the ratings object (counts + star distributions) from the
+	 * upstream rating response group. Returns undefined when Audible
+	 * did not return a rating block.
+	 */
+	getRatings(): ApiRatings | undefined {
+		const rating = this.audibleResponse?.rating
+		if (!rating) return undefined
+		return {
+			value: rating.overall_distribution.display_average_rating.toString(),
+			numRatings: rating.overall_distribution.num_ratings,
+			numReviews: rating.num_reviews,
+			distribution: {
+				five: rating.overall_distribution.num_five_star_ratings,
+				four: rating.overall_distribution.num_four_star_ratings,
+				three: rating.overall_distribution.num_three_star_ratings,
+				two: rating.overall_distribution.num_two_star_ratings,
+				one: rating.overall_distribution.num_one_star_ratings
+			},
+			performanceDistribution: {
+				five: rating.performance_distribution.num_five_star_ratings,
+				four: rating.performance_distribution.num_four_star_ratings,
+				three: rating.performance_distribution.num_three_star_ratings,
+				two: rating.performance_distribution.num_two_star_ratings,
+				one: rating.performance_distribution.num_one_star_ratings
+			},
+			storyDistribution: {
+				five: rating.story_distribution.num_five_star_ratings,
+				four: rating.story_distribution.num_four_star_ratings,
+				three: rating.story_distribution.num_three_star_ratings,
+				two: rating.story_distribution.num_two_star_ratings,
+				one: rating.story_distribution.num_one_star_ratings
+			}
+		}
+	}
+
+	/**
 	 * Transform series data into a usable format
 	 */
 	getSeries(series: AudibleSeries): ApiSeries | undefined {
@@ -346,6 +383,9 @@ class ApiHelper {
 			publisherName: this.audibleResponse.publisher_name,
 			...(this.audibleResponse.rating && {
 				rating: this.audibleResponse.rating.overall_distribution.display_average_rating.toString()
+			}),
+			...(this.getRatings() && {
+				ratings: this.getRatings()
 			}),
 			region: this.region,
 			releaseDate: this.getReleaseDate(),

--- a/src/helpers/routes/BookBackfillHelper.ts
+++ b/src/helpers/routes/BookBackfillHelper.ts
@@ -39,7 +39,10 @@ export default class BookBackfillHelper {
 				this.logger,
 				true
 			)
-			await helper.handler()
+			const updatedBook = await helper.handler()
+			if (!updatedBook || !('ratings' in updatedBook && updatedBook.ratings)) {
+				throw new Error(`Ratings were not populated for ${book.asin}`)
+			}
 		})
 		return { total: summary.total, updated: summary.success, failed: summary.failures }
 	}

--- a/src/helpers/routes/BookBackfillHelper.ts
+++ b/src/helpers/routes/BookBackfillHelper.ts
@@ -20,6 +20,10 @@ export default class BookBackfillHelper {
 	/**
 	 * Re-fetches every book document that lacks the `ratings` field,
 	 * using the same update path as the scheduled updates.
+	 *
+	 * forceUpdate is set so the recency gate does not skip recently-updated
+	 * books — the backfill targets books missing `ratings` regardless of
+	 * their `updatedAt`.
 	 */
 	async process(): Promise<BackfillResult> {
 		const books = await BookModel.find(
@@ -31,7 +35,9 @@ export default class BookBackfillHelper {
 			const helper = new BookShowHelper(
 				book.asin,
 				{ region: book.region ?? 'us', update: '1' },
-				null
+				null,
+				this.logger,
+				true
 			)
 			await helper.handler()
 		})

--- a/src/helpers/routes/BookBackfillHelper.ts
+++ b/src/helpers/routes/BookBackfillHelper.ts
@@ -1,0 +1,40 @@
+import type { FastifyBaseLogger } from 'fastify'
+
+import BookModel from '#config/models/Book'
+import BookShowHelper from '#helpers/routes/BookShowHelper'
+import { processBatchByRegion } from '#helpers/utils/batchProcessor'
+import { NoticeUpdateScheduled } from '#static/messages'
+
+interface BackfillResult {
+	total: number
+	updated: number
+	failed: number
+}
+
+export default class BookBackfillHelper {
+	logger: FastifyBaseLogger
+	constructor(logger: FastifyBaseLogger) {
+		this.logger = logger
+	}
+
+	/**
+	 * Re-fetches every book document that lacks the `ratings` field,
+	 * using the same update path as the scheduled updates.
+	 */
+	async process(): Promise<BackfillResult> {
+		const books = await BookModel.find(
+			{ ratings: { $exists: false } },
+			{ projection: { asin: 1, region: 1 }, sort: { updatedAt: -1 }, allowDiskUse: true }
+		)
+		this.logger.info(NoticeUpdateScheduled('Ratings backfill'))
+		const { summary } = await processBatchByRegion(books, async (book) => {
+			const helper = new BookShowHelper(
+				book.asin,
+				{ region: book.region ?? 'us', update: '1' },
+				null
+			)
+			await helper.handler()
+		})
+		return { total: summary.total, updated: summary.success, failed: summary.failures }
+	}
+}

--- a/src/helpers/routes/BookShowHelper.ts
+++ b/src/helpers/routes/BookShowHelper.ts
@@ -9,8 +9,9 @@ export default class BookShowHelper extends GenericShowHelper {
 		asin: string,
 		options: ApiQueryString,
 		redis: FastifyRedis | null,
-		logger?: FastifyBaseLogger
+		logger?: FastifyBaseLogger,
+		forceUpdate?: boolean
 	) {
-		super(asin, options, redis, 'book', logger)
+		super(asin, options, redis, 'book', logger, forceUpdate)
 	}
 }

--- a/src/helpers/routes/GenericShowHelper.ts
+++ b/src/helpers/routes/GenericShowHelper.ts
@@ -39,17 +39,20 @@ export default class GenericShowHelper {
 	sharedHelper: SharedHelper
 	type: 'author' | 'book' | 'chapter'
 	logger?: FastifyBaseLogger
+	forceUpdate?: boolean
 	constructor(
 		asin: string,
 		options: ApiQueryString,
 		redis: FastifyRedis | null,
 		type: 'author' | 'book' | 'chapter',
-		logger?: FastifyBaseLogger
+		logger?: FastifyBaseLogger,
+		forceUpdate?: boolean
 	) {
 		this.asin = asin
 		this.options = options
 		this.type = type
 		this.logger = logger
+		this.forceUpdate = forceUpdate
 		this.paprHelper = this.setupPaprHelper()
 		this.redisHelper = new RedisHelper(redis, type, asin, options.region, logger)
 		this.schema = this.setupSchema()
@@ -210,8 +213,9 @@ export default class GenericShowHelper {
 	 */
 	async updateActions(): Promise<ApiAuthorProfile | ApiBook | ApiChapter | undefined> {
 		if (!this.originalData) throw new Error(ErrorMessageMissingOriginal(this.asin, this.type))
-		// 1. Check if the data is updated recently
-		if (this.isUpdatedRecently()) return this.getDataWithProjection()
+		// 1. Check if the data is updated recently — bypassed when forceUpdate is
+		// set (e.g. the ratings backfill), which must re-fetch every book it targets
+		if (!this.forceUpdate && this.isUpdatedRecently()) return this.getDataWithProjection()
 
 		// 2. Update the data,
 		// return undefined for chapters if the data is not updated

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,6 +26,7 @@ import { registerPerformanceHooks } from '#config/performance/hooks'
 import deleteAuthor from '#config/routes/authors/delete'
 import searchAuthor from '#config/routes/authors/search/show'
 import showAuthor from '#config/routes/authors/show'
+import backfillBookRatings from '#config/routes/books/backfill'
 import deleteChapter from '#config/routes/books/chapters/delete'
 import showChapter from '#config/routes/books/chapters/show'
 import deleteBook from '#config/routes/books/delete'
@@ -212,6 +213,7 @@ async function registerRoutes() {
 		.register(searchBook)
 		.register(showBook)
 		.register(deleteBook)
+		.register(backfillBookRatings)
 		.register(showChapter)
 		.register(deleteChapter)
 		.register(showAuthor)

--- a/tests/audible/books/api.test.ts
+++ b/tests/audible/books/api.test.ts
@@ -1,6 +1,6 @@
 import { beforeAll, describe, expect, it } from 'bun:test'
 
-import type { ApiBook } from '#config/types'
+import type { ApiBook, AudibleProduct } from '#config/types'
 import ApiHelper from '#helpers/books/audible/ApiHelper'
 import { B08C6YJ1LS, B017V4IM1G, setupMinimalParsed } from '#tests/datasets/audible/books/api'
 import {
@@ -58,6 +58,58 @@ describe('Audible API', () => {
 
 		it('returned the correct data', () => {
 			expect(response).toEqual(minimalParsed)
+		})
+	})
+
+	describe('When Audible omits rating distributions', () => {
+		let product: AudibleProduct['product']
+		let response: ApiBook
+		let ratings: ApiBook['ratings']
+
+		beforeAll(async () => {
+			// Strip the distributions Audible sometimes omits for some products
+			product = {
+				...B08C6YJ1LS.product,
+				rating: {
+					...B08C6YJ1LS.product.rating!,
+					performance_distribution: undefined,
+					story_distribution: undefined
+				}
+			}
+			helper = new ApiHelper('B08C6YJ1LS', 'us')
+			response = await helper.parseResponse({
+				...B08C6YJ1LS,
+				product
+			})
+			if (!response.genres) throw new Error('Parsed is undefined')
+			minimalParsed = setupMinimalParsed(
+				product,
+				B08C6YJ1LScopyright,
+				B08C6YJ1LSdescription,
+				B08C6YJ1LSimage,
+				response.genres
+			)
+			ratings = minimalParsed.ratings
+		})
+
+		it('returned the correct data', () => {
+			expect(response).toEqual(minimalParsed)
+		})
+
+		it('omits absent performance and story distributions while retaining the core ratings', () => {
+			expect(ratings).toBeDefined()
+			expect(ratings).not.toHaveProperty('performanceDistribution')
+			expect(ratings).not.toHaveProperty('storyDistribution')
+			expect(ratings?.value).toBe('4.3')
+			expect(ratings?.numRatings).toBe(22066)
+			expect(ratings?.numReviews).toBe(1920)
+			expect(ratings?.distribution).toEqual({
+				five: 13235,
+				four: 5093,
+				three: 2301,
+				two: 793,
+				one: 644
+			})
 		})
 	})
 })

--- a/tests/audible/books/stitch.test.ts
+++ b/tests/audible/books/stitch.test.ts
@@ -28,6 +28,35 @@ let asin: string
 let helper: StitchHelper
 let response: ApiBook
 
+// Live rating counts drift over time, so the snapshot comparison excludes
+// `ratings`; the ratings object is validated structurally instead.
+function stripRatings(book: ApiBook) {
+	const rest = { ...book }
+	delete rest.ratings
+	return rest
+}
+
+// Live contributor payloads also drift (e.g. newly added asins), so compare
+// authors by name and order only.
+function authorNames(book: ApiBook) {
+	return book.authors.map((author) => author.name)
+}
+
+function expectRatingsConsistent(book: ApiBook) {
+	expect(book.ratings).toBeDefined()
+	expect(book.ratings?.value).toBe(book.rating)
+	const distribution = book.ratings?.distribution
+	expect(distribution).toBeDefined()
+	const totalStars =
+		distribution.five +
+		distribution.four +
+		distribution.three +
+		distribution.two +
+		distribution.one
+	expect(totalStars).toBe(book.ratings?.numRatings)
+	expect(book.ratings?.numReviews).toBeGreaterThanOrEqual(0)
+}
+
 describe('Audible API and HTML Parsing', () => {
 	describe('When stitching together Scorcerers Stone', () => {
 		beforeAll(async () => {
@@ -38,7 +67,8 @@ describe('Audible API and HTML Parsing', () => {
 		}, 10000)
 
 		it('returned the correct data', () => {
-			expect(response).toEqual(combinedB017V4IM1G)
+			expect(stripRatings(response)).toEqual(stripRatings(combinedB017V4IM1G))
+			expectRatingsConsistent(response)
 		})
 	})
 
@@ -51,7 +81,8 @@ describe('Audible API and HTML Parsing', () => {
 		}, 10000)
 
 		it('returned the correct data', () => {
-			expect(response).toEqual(combinedB08C6YJ1LS)
+			expect(stripRatings(response)).toEqual(stripRatings(combinedB08C6YJ1LS))
+			expectRatingsConsistent(response)
 		})
 	})
 
@@ -77,7 +108,9 @@ describe('Audible API and HTML Parsing', () => {
 		}, 10000)
 
 		it('returned the correct data', () => {
-			expect(response).toEqual(minimalB0036I54I6)
+			expect(stripRatings(response)).toEqual(stripRatings(minimalB0036I54I6))
+			expect(authorNames(response)).toEqual(authorNames(minimalB0036I54I6))
+			expectRatingsConsistent(response)
 		})
 
 		it('throws NotFoundError for chapters with correct properties', () => {

--- a/tests/audible/books/stitch.test.ts
+++ b/tests/audible/books/stitch.test.ts
@@ -47,12 +47,9 @@ function expectRatingsConsistent(book: ApiBook) {
 	expect(book.ratings?.value).toBe(book.rating)
 	const distribution = book.ratings?.distribution
 	expect(distribution).toBeDefined()
+	if (!distribution) throw new Error('distribution expected to be defined')
 	const totalStars =
-		distribution.five +
-		distribution.four +
-		distribution.three +
-		distribution.two +
-		distribution.one
+		distribution.five + distribution.four + distribution.three + distribution.two + distribution.one
 	expect(totalStars).toBe(book.ratings?.numRatings)
 	expect(book.ratings?.numReviews).toBeGreaterThanOrEqual(0)
 }

--- a/tests/config/routes/books/backfill.test.ts
+++ b/tests/config/routes/books/backfill.test.ts
@@ -1,0 +1,116 @@
+import { afterAll, afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+import _backfill from '#config/routes/books/backfill'
+
+const mockProcess = mock()
+
+mock.module('#helpers/routes/BookBackfillHelper', () => ({
+	default: class MockBookBackfillHelper {
+		logger: unknown
+		constructor(_logger: unknown) {
+			this.logger = _logger
+		}
+		async process() {
+			return mockProcess()
+		}
+	}
+}))
+
+const mockLog = {
+	error: mock(),
+	info: mock(),
+	debug: mock(),
+	warn: mock()
+}
+
+function makeApp() {
+	// ponytail: minimal fastify stub — only what the route registers
+	const app = { post: mock() }
+	return app
+}
+
+function getHandler(app: ReturnType<typeof makeApp>) {
+	return app.post.mock.calls[0][1] as (
+		request: {
+			headers: Record<string, unknown>
+			log: typeof mockLog
+		},
+		reply: ReturnType<typeof makeReply>
+	) => Promise<unknown>
+}
+
+function makeReply() {
+	const reply = {
+		code: mock(() => reply),
+		send: mock(() => reply)
+	}
+	return reply
+}
+
+describe('POST /books/backfill-ratings', () => {
+	let app: ReturnType<typeof makeApp>
+	let OLD_ENV: { UPDATE_STATS: string | undefined; ADMIN_TOKEN: string | undefined }
+
+	beforeEach(async () => {
+		mockProcess.mockReset()
+		OLD_ENV = {
+			UPDATE_STATS: process.env.UPDATE_STATS,
+			ADMIN_TOKEN: process.env.ADMIN_TOKEN
+		}
+		delete process.env.UPDATE_STATS
+		delete process.env.ADMIN_TOKEN
+		app = makeApp()
+		await _backfill(app as never)
+	})
+
+	afterEach(() => {
+		if (OLD_ENV.UPDATE_STATS === undefined) delete process.env.UPDATE_STATS
+		else process.env.UPDATE_STATS = OLD_ENV.UPDATE_STATS
+		if (OLD_ENV.ADMIN_TOKEN === undefined) delete process.env.ADMIN_TOKEN
+		else process.env.ADMIN_TOKEN = OLD_ENV.ADMIN_TOKEN
+	})
+
+	it('returns 404 when UPDATE_STATS is not enabled', async () => {
+		const reply = makeReply()
+		await getHandler(app)({ headers: {}, log: mockLog }, reply)
+		expect(reply.code).toHaveBeenCalledWith(404)
+	})
+
+	it('returns 401 when x-admin-token header is missing', async () => {
+		process.env.UPDATE_STATS = '1'
+		process.env.ADMIN_TOKEN = 'secret'
+		const reply = makeReply()
+		await getHandler(app)({ headers: {}, log: mockLog }, reply)
+		expect(reply.code).toHaveBeenCalledWith(401)
+	})
+
+	it('returns 401 when admin token does not match', async () => {
+		process.env.UPDATE_STATS = '1'
+		process.env.ADMIN_TOKEN = 'secret'
+		const reply = makeReply()
+		await getHandler(app)({ headers: { 'x-admin-token': 'wrong' }, log: mockLog }, reply)
+		expect(reply.code).toHaveBeenCalledWith(401)
+	})
+
+	it('runs backfill with valid token and returns summary', async () => {
+		process.env.UPDATE_STATS = '1'
+		process.env.ADMIN_TOKEN = 'secret'
+		mockProcess.mockResolvedValue({ total: 1, updated: 1, failed: 0 })
+		const reply = makeReply()
+		const result = await getHandler(app)(
+			{ headers: { 'x-admin-token': 'secret' }, log: mockLog },
+			reply
+		)
+		expect(mockProcess).toHaveBeenCalledTimes(1)
+		expect(result).toEqual({
+			message: 'Ratings backfill complete',
+			total: 1,
+			updated: 1,
+			failed: 0
+		})
+	})
+})
+
+afterAll(() => {
+	mock.restore()
+})

--- a/tests/datasets/audible/books/api.ts
+++ b/tests/datasets/audible/books/api.ts
@@ -73,6 +73,34 @@ export function setupMinimalParsed(
 		...(response.rating && {
 			rating: response.rating.overall_distribution.display_average_rating.toString()
 		}),
+		...(response.rating && {
+			ratings: {
+				value: response.rating.overall_distribution.display_average_rating.toString(),
+				numRatings: response.rating.overall_distribution.num_ratings,
+				numReviews: response.rating.num_reviews,
+				distribution: {
+					five: response.rating.overall_distribution.num_five_star_ratings,
+					four: response.rating.overall_distribution.num_four_star_ratings,
+					three: response.rating.overall_distribution.num_three_star_ratings,
+					two: response.rating.overall_distribution.num_two_star_ratings,
+					one: response.rating.overall_distribution.num_one_star_ratings
+				},
+				performanceDistribution: {
+					five: response.rating.performance_distribution.num_five_star_ratings,
+					four: response.rating.performance_distribution.num_four_star_ratings,
+					three: response.rating.performance_distribution.num_three_star_ratings,
+					two: response.rating.performance_distribution.num_two_star_ratings,
+					one: response.rating.performance_distribution.num_one_star_ratings
+				},
+				storyDistribution: {
+					five: response.rating.story_distribution.num_five_star_ratings,
+					four: response.rating.story_distribution.num_four_star_ratings,
+					three: response.rating.story_distribution.num_three_star_ratings,
+					two: response.rating.story_distribution.num_two_star_ratings,
+					one: response.rating.story_distribution.num_one_star_ratings
+				}
+			}
+		}),
 		publisherName: response.publisher_name,
 		summary: response.publisher_summary,
 		region: 'us',

--- a/tests/datasets/audible/books/api.ts
+++ b/tests/datasets/audible/books/api.ts
@@ -85,20 +85,24 @@ export function setupMinimalParsed(
 					two: response.rating.overall_distribution.num_two_star_ratings,
 					one: response.rating.overall_distribution.num_one_star_ratings
 				},
-				performanceDistribution: {
-					five: response.rating.performance_distribution.num_five_star_ratings,
-					four: response.rating.performance_distribution.num_four_star_ratings,
-					three: response.rating.performance_distribution.num_three_star_ratings,
-					two: response.rating.performance_distribution.num_two_star_ratings,
-					one: response.rating.performance_distribution.num_one_star_ratings
-				},
-				storyDistribution: {
-					five: response.rating.story_distribution.num_five_star_ratings,
-					four: response.rating.story_distribution.num_four_star_ratings,
-					three: response.rating.story_distribution.num_three_star_ratings,
-					two: response.rating.story_distribution.num_two_star_ratings,
-					one: response.rating.story_distribution.num_one_star_ratings
-				}
+				...(response.rating.performance_distribution && {
+					performanceDistribution: {
+						five: response.rating.performance_distribution.num_five_star_ratings,
+						four: response.rating.performance_distribution.num_four_star_ratings,
+						three: response.rating.performance_distribution.num_three_star_ratings,
+						two: response.rating.performance_distribution.num_two_star_ratings,
+						one: response.rating.performance_distribution.num_one_star_ratings
+					}
+				}),
+				...(response.rating.story_distribution && {
+					storyDistribution: {
+						five: response.rating.story_distribution.num_five_star_ratings,
+						four: response.rating.story_distribution.num_four_star_ratings,
+						three: response.rating.story_distribution.num_three_star_ratings,
+						two: response.rating.story_distribution.num_two_star_ratings,
+						one: response.rating.story_distribution.num_one_star_ratings
+					}
+				})
 			}
 		}),
 		publisherName: response.publisher_name,

--- a/tests/datasets/helpers/books.ts
+++ b/tests/datasets/helpers/books.ts
@@ -1,7 +1,7 @@
 import { ObjectId, WithId } from 'mongodb'
 
 import { BookDocument } from '#config/models/Book'
-import { ApiBook, ApiBookSchema, ApiGenreSchema, AudibleProductSchema } from '#config/types'
+import { ApiBook, ApiBookSchema, ApiGenreSchema, ApiRatings, AudibleProductSchema } from '#config/types'
 
 // Reusable
 const _id = new ObjectId('5c8f8f8f8f8f8f8f8f8f8f8f')
@@ -32,7 +32,7 @@ const narrators = [
 ]
 const publisherName = 'Podium Audio'
 const rating = '4.5'
-const ratings = {
+export const ratings: ApiRatings = {
 	value: '4.5',
 	numRatings: 20105,
 	numReviews: 1727,

--- a/tests/datasets/helpers/books.ts
+++ b/tests/datasets/helpers/books.ts
@@ -32,6 +32,14 @@ const narrators = [
 ]
 const publisherName = 'Podium Audio'
 const rating = '4.5'
+const ratings = {
+	value: '4.5',
+	numRatings: 20105,
+	numReviews: 1727,
+	distribution: { five: 13753, four: 4256, three: 1374, two: 445, one: 277 },
+	performanceDistribution: { five: 16052, four: 2055, three: 383, two: 73, one: 73 },
+	storyDistribution: { five: 11841, four: 4158, three: 1657, two: 553, one: 367 }
+}
 const region = 'us'
 const releaseDate = new Date('2018-02-20T00:00:00.000Z')
 const runtimeLengthMin = 1042
@@ -385,6 +393,7 @@ export const parsedBook = ApiBookSchema.parse({
 	narrators,
 	publisherName,
 	rating,
+	ratings,
 	region,
 	releaseDate,
 	runtimeLengthMin,
@@ -446,6 +455,7 @@ export const parsedBookWithoutGenres: ApiBook = {
 	narrators,
 	publisherName,
 	rating,
+	ratings,
 	region,
 	releaseDate,
 	runtimeLengthMin,

--- a/tests/helpers/books/audible/ApiHelper.test.ts
+++ b/tests/helpers/books/audible/ApiHelper.test.ts
@@ -234,6 +234,25 @@ describe('ApiHelper edge cases should', () => {
 		expect(helper.getFinalData()).toEqual(parsedBookWithoutNarrators)
 	})
 
+	test('getFinalData maps ratings object', async () => {
+		helper.audibleResponse = mockResponse.product
+		const parsed = helper.getFinalData()
+		expect(parsed.rating).toBe('4.5')
+		expect(parsed.ratings).toEqual({
+			value: '4.5',
+			numRatings: 20105,
+			numReviews: 1727,
+			distribution: { five: 13753, four: 4256, three: 1374, two: 445, one: 277 },
+			performanceDistribution: { five: 16052, four: 2055, three: 383, two: 73, one: 73 },
+			storyDistribution: { five: 11841, four: 4158, three: 1657, two: 553, one: 367 }
+		})
+	})
+
+	test('getRatings returns undefined when rating block is missing', () => {
+		helper.audibleResponse = { ...mockResponse.product, rating: undefined }
+		expect(helper.getRatings()).toBeUndefined()
+	})
+
 	test('pass key check with a number value of 0', async () => {
 		const data = mockResponse
 		mockResponse.product.runtime_length_min = 0

--- a/tests/helpers/books/audible/ApiHelper.test.ts
+++ b/tests/helpers/books/audible/ApiHelper.test.ts
@@ -23,7 +23,7 @@ import {
 	podcast,
 	podcastWithoutProgramParticipation
 } from '#tests/datasets/audible/books/api'
-import { apiResponse, parsedBook, parsedBookWithoutNarrators } from '#tests/datasets/helpers/books'
+import { apiResponse, parsedBook, parsedBookWithoutNarrators, ratings } from '#tests/datasets/helpers/books'
 import { createMockLogger } from '#tests/setup/mockLogger'
 
 mock.module('#helpers/utils/fetchPlus', () => {
@@ -238,14 +238,23 @@ describe('ApiHelper edge cases should', () => {
 		helper.audibleResponse = mockResponse.product
 		const parsed = helper.getFinalData()
 		expect(parsed.rating).toBe('4.5')
-		expect(parsed.ratings).toEqual({
-			value: '4.5',
-			numRatings: 20105,
-			numReviews: 1727,
-			distribution: { five: 13753, four: 4256, three: 1374, two: 445, one: 277 },
-			performanceDistribution: { five: 16052, four: 2055, three: 383, two: 73, one: 73 },
-			storyDistribution: { five: 11841, four: 4158, three: 1657, two: 553, one: 367 }
-		})
+		expect(parsed.ratings).toEqual(ratings)
+	})
+
+	test('getRatings omits absent performance/story distributions', () => {
+		helper.audibleResponse = {
+			...mockResponse.product,
+			rating: {
+				...mockResponse.product.rating,
+				performance_distribution: undefined,
+				story_distribution: undefined
+			}
+		}
+		const result = helper.getRatings()
+		expect(result).toBeDefined()
+		expect(result).not.toHaveProperty('performanceDistribution')
+		expect(result).not.toHaveProperty('storyDistribution')
+		expect(result?.distribution).toEqual(ratings.distribution)
 	})
 
 	test('getRatings returns undefined when rating block is missing', () => {

--- a/tests/helpers/routes/BookBackfillHelper.test.ts
+++ b/tests/helpers/routes/BookBackfillHelper.test.ts
@@ -1,0 +1,82 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test'
+
+const mockBookFind = mock()
+const mockProcessBatchByRegion = mock()
+const mockShowHandler = mock()
+const showConstructorArgs: unknown[][] = []
+
+mock.module('#config/models/Book', () => ({
+	default: class BookModel {
+		static find = mockBookFind
+	}
+}))
+
+mock.module('#helpers/utils/batchProcessor', () => ({
+	processBatchByRegion: mockProcessBatchByRegion
+}))
+
+mock.module('#helpers/routes/BookShowHelper', () => ({
+	default: class MockBookShowHelper {
+		constructor(...args: unknown[]) {
+			showConstructorArgs.push(args)
+		}
+		handler = mockShowHandler
+	}
+}))
+
+import BookBackfillHelper from '#helpers/routes/BookBackfillHelper'
+import { createMockLogger } from '#tests/setup/mockLogger'
+
+const books = [
+	{ asin: 'B000000001', region: 'us' },
+	{ asin: 'B000000002', region: 'uk' },
+	{ asin: 'B000000003', region: null }
+]
+
+describe('BookBackfillHelper should', () => {
+	let helper: BookBackfillHelper
+
+	beforeEach(() => {
+		mock.clearAllMocks()
+		showConstructorArgs.length = 0
+		helper = new BookBackfillHelper(createMockLogger())
+		mockBookFind.mockResolvedValue(books)
+		mockShowHandler.mockResolvedValue(undefined)
+		mockProcessBatchByRegion.mockImplementation(async (_items: unknown[], processor: (item: unknown) => Promise<unknown>) => {
+			await Promise.all(books.map((book) => processor(book)))
+			return {
+				results: [],
+				summary: { total: 3, success: 2, failures: 1, regions: {}, maxConcurrencyObserved: 1 }
+			}
+		})
+	})
+
+	test('queries only books missing the ratings field, sorted by updatedAt desc', async () => {
+		await helper.process()
+		expect(mockBookFind).toHaveBeenCalledTimes(1)
+		expect(mockBookFind).toHaveBeenCalledWith(
+			{ ratings: { $exists: false } },
+			{ projection: { asin: 1, region: 1 }, sort: { updatedAt: -1 }, allowDiskUse: true }
+		)
+	})
+
+	test('forces a refetch for every book and falls back to the us region', async () => {
+		await helper.process()
+		expect(showConstructorArgs).toHaveLength(3)
+		for (const args of showConstructorArgs) {
+			expect(args[2]).toBeNull()
+			expect(args[4]).toBe(true)
+		}
+		expect(showConstructorArgs[0][1]).toEqual({ region: 'us', update: '1' })
+		expect(showConstructorArgs[1][1]).toEqual({ region: 'uk', update: '1' })
+		expect(showConstructorArgs[2][1]).toEqual({ region: 'us', update: '1' })
+	})
+
+	test('maps the batch summary to the backfill result', async () => {
+		await expect(helper.process()).resolves.toEqual({ total: 3, updated: 2, failed: 1 })
+	})
+})
+
+afterAll(() => {
+	mock.restore()
+})

--- a/tests/helpers/routes/BookBackfillHelper.test.ts
+++ b/tests/helpers/routes/BookBackfillHelper.test.ts
@@ -33,6 +33,17 @@ const books = [
 	{ asin: 'B000000003', region: null }
 ]
 
+const bookWithRatings = {
+	asin: 'B000000001',
+	rating: '4.6',
+	ratings: { value: '4.6', numRatings: 120, numReviews: 8 }
+}
+
+const bookWithoutRatings = {
+	asin: 'B000000002',
+	rating: '4.2'
+}
+
 describe('BookBackfillHelper should', () => {
 	let helper: BookBackfillHelper
 
@@ -41,14 +52,34 @@ describe('BookBackfillHelper should', () => {
 		showConstructorArgs.length = 0
 		helper = new BookBackfillHelper(createMockLogger())
 		mockBookFind.mockResolvedValue(books)
-		mockShowHandler.mockResolvedValue(undefined)
-		mockProcessBatchByRegion.mockImplementation(async (_items: unknown[], processor: (item: unknown) => Promise<unknown>) => {
-			await Promise.all(books.map((book) => processor(book)))
-			return {
-				results: [],
-				summary: { total: 3, success: 2, failures: 1, regions: {}, maxConcurrencyObserved: 1 }
+		mockShowHandler.mockResolvedValue(bookWithRatings)
+		mockProcessBatchByRegion.mockImplementation(
+			async (
+				items: { asin: string }[],
+				processor: (item: { asin: string }) => Promise<unknown>
+			) => {
+				let success = 0
+				let failures = 0
+				for (const item of items) {
+					try {
+						await processor(item)
+						success += 1
+					} catch {
+						failures += 1
+					}
+				}
+				return {
+					results: [],
+					summary: {
+						total: items.length,
+						success,
+						failures,
+						regions: {},
+						maxConcurrencyObserved: 1
+					}
+				}
 			}
-		})
+		)
 	})
 
 	test('queries only books missing the ratings field, sorted by updatedAt desc', async () => {
@@ -73,7 +104,20 @@ describe('BookBackfillHelper should', () => {
 	})
 
 	test('maps the batch summary to the backfill result', async () => {
+		await expect(helper.process()).resolves.toEqual({ total: 3, updated: 3, failed: 0 })
+	})
+
+	test('counts a book as failed when the refetch does not populate ratings', async () => {
+		mockShowHandler.mockImplementation(async () => {
+			const asin = showConstructorArgs.at(-1)?.[0]
+			return asin === 'B000000002' ? bookWithoutRatings : bookWithRatings
+		})
 		await expect(helper.process()).resolves.toEqual({ total: 3, updated: 2, failed: 1 })
+	})
+
+	test('counts a book as failed when the handler returns undefined', async () => {
+		mockShowHandler.mockImplementation(async () => undefined)
+		await expect(helper.process()).resolves.toEqual({ total: 3, updated: 0, failed: 3 })
 	})
 })
 

--- a/tests/helpers/routes/BookShowHelper.test.ts
+++ b/tests/helpers/routes/BookShowHelper.test.ts
@@ -143,6 +143,15 @@ describe('BookShowHelper should', () => {
 		await expect(helper.updateActions()).resolves.toStrictEqual(parsedBook)
 	})
 
+	test('forceUpdate bypasses the recency gate and re-fetches', async () => {
+		helper = new BookShowHelper(asin, { region: 'us', update: '1' }, null, undefined, true)
+		spyOn(helper.sharedHelper, 'isRecentlyUpdated').mockReturnValue(true)
+		helper.originalData = bookWithoutProjectionUpdatedNow
+		await expect(helper.updateActions()).resolves.toStrictEqual(parsedBook)
+		// Recency gate bypassed: the upstream fetch actually ran
+		expect(mockStitchProcess).toHaveBeenCalled()
+	})
+
 	test('isUpdatedRecently returns false if no originalData is present', () => {
 		expect(helper.isUpdatedRecently()).toBe(false)
 	})

--- a/tests/live/audible/books/api.live.test.ts
+++ b/tests/live/audible/books/api.live.test.ts
@@ -198,6 +198,13 @@ describe('Audible API Live Tests', () => {
 		it('should have parsed rating as string', () => {
 			expect(typeof parsedResponse.rating).toBe('string')
 		})
+
+		it('should have parsed ratings object with histogram when rating is present', () => {
+			expect(parsedResponse.ratings?.value).toBe(parsedResponse.rating)
+			expect(parsedResponse.ratings?.numRatings).toBeGreaterThan(0)
+			expect(parsedResponse.ratings?.distribution.five).toBeGreaterThanOrEqual(0)
+			expect(parsedResponse.ratings?.numReviews).toBeGreaterThanOrEqual(0)
+		})
 	})
 
 	describe('When fetching from different regions', () => {


### PR DESCRIPTION
## Summary

Book responses now include a structured ratings object with rating and review counts plus a 1–5 star distribution, instead of only a bare average string. An admin endpoint can backfill the new data for books that were stored without it.

## Motivation

Consumers of the book endpoint (e.g. AudiobookDB) only received a display average like "4.5", and needed to call Audible's undocumented, rate-limited catalog API directly for anything more — even though audnexus already fetches and decodes the full rating data. The PA-API 5.0 route for this data is deprecated, so this catalog API is the only public channel for it.

## Changes

- Book responses can now include a ratings object: display value, numRatings, numReviews, a five-to-one star distribution, and performance/story distributions when Audible provides them
- The legacy rating string is kept, so existing consumers are unaffected
- New admin endpoint POST /books/backfill-ratings re-fetches books missing the ratings field and reports total/updated/failed counts; it 404s unless UPDATE_STATS=1 and requires the admin token
- Audible's rating payload now tolerates products that omit the performance/story distribution groups instead of failing to parse

## Notes

- The Book model requires performance/story distributions inside a present ratings object, while the Audible decoder treats them as optional — a book lacking those groups could fail model validation when saved
- Backfill re-fetches all matching books in a single HTTP request with no pagination, so large backfills may hit client or gateway timeouts
- Version bumped to 1.15.2

## Resolves

Closes #919


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Book data now includes detailed ratings, review counts, and overall, performance, and story star distributions.
  - Added an authenticated administrative endpoint to backfill ratings for books missing this information.
  - Backfill results report total, updated, and failed items.

- **Bug Fixes**
  - Rating data remains available when performance or story distributions are missing.

- **Documentation**
  - Updated the API specification with rating schemas, examples, and backfill endpoint responses.

- **Release**
  - Version updated to 1.15.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->