### PR TITLE
fix(scheduler): paginate update scheduler and ratings backfill to prevent OOM

### DIFF
--- a/src/config/performance.ts
+++ b/src/config/performance.ts
@@ -56,6 +56,9 @@ export const PerformanceConfigSchema = z.object({
 	/** Hard cap for max per-region concurrency in batch processing */
 	SCHEDULER_MAX_PER_REGION: z.number().int().positive().default(5),
 
+	/** Documents per batch when paginating over books/authors/chapters */
+	SCHEDULER_BATCH_SIZE: z.number().int().positive().max(MAX_SCHEDULER_BATCH_SIZE).default(1000),
+
 	/** Default region for batch processing when none specified */
 	DEFAULT_REGION: z.string().default('us')
 })
@@ -81,6 +84,9 @@ export function createPerformanceConfig(): PerformanceConfig {
 	const schedulerMaxPerRegion = process.env.SCHEDULER_MAX_PER_REGION
 		? parseInt(process.env.SCHEDULER_MAX_PER_REGION, 10)
 		: 5
+	const schedulerBatchSize = process.env.SCHEDULER_BATCH_SIZE
+		? parseInt(process.env.SCHEDULER_BATCH_SIZE, 10)
+		: 1000
 
 	// Handle invalid values before passing to Zod
 	const validatedMaxConcurrent =
@@ -101,6 +107,12 @@ export function createPerformanceConfig(): PerformanceConfig {
 		schedulerMaxPerRegion <= 0
 			? 5
 			: schedulerMaxPerRegion
+	const validatedSchedulerBatchSize =
+		Number.isNaN(schedulerBatchSize) ||
+		!Number.isFinite(schedulerBatchSize) ||
+		schedulerBatchSize <= 0
+			? 1000
+			: schedulerBatchSize
 
 	return PerformanceConfigSchema.parse({
 		USE_PARALLEL_SCHEDULER: parseBoolean(process.env.USE_PARALLEL_SCHEDULER) ?? false,
@@ -112,6 +124,7 @@ export function createPerformanceConfig(): PerformanceConfig {
 		MAX_CONCURRENT_REQUESTS: validatedMaxConcurrent,
 		SCHEDULER_CONCURRENCY: validatedSchedulerConcurrency,
 		SCHEDULER_MAX_PER_REGION: validatedSchedulerMaxPerRegion,
+		SCHEDULER_BATCH_SIZE: validatedSchedulerBatchSize,
 		DEFAULT_REGION: process.env.DEFAULT_REGION?.trim() || 'us'
 	})
 }
@@ -134,6 +147,7 @@ export const DEFAULT_PERFORMANCE_CONFIG: Readonly<PerformanceConfig> = {
 	MAX_CONCURRENT_REQUESTS: 50,
 	SCHEDULER_CONCURRENCY: 5,
 	SCHEDULER_MAX_PER_REGION: 5,
+	SCHEDULER_BATCH_SIZE: 1000,
 	DEFAULT_REGION: 'us'
 }
 
@@ -163,7 +177,8 @@ export function resetPerformanceConfig(): void {
 
 /**
  * Set a custom configuration instance (useful for testing).
+ * Rejects values outside the schema (e.g. SCHEDULER_BATCH_SIZE above the cap).
  */
 export function setPerformanceConfig(config: PerformanceConfig): void {
-	_config = config
+	_config = PerformanceConfigSchema.parse(config)
 }

--- a/src/config/performance.ts
+++ b/src/config/performance.ts
@@ -188,13 +188,20 @@ export function resetPerformanceConfig(): void {
 
 /**
  * Set a custom configuration instance (useful for testing).
- * Rejects SCHEDULER_BATCH_SIZE values above the hard cap; other fields are
+ * Rejects SCHEDULER_BATCH_SIZE values outside the valid range (a safe
+ * positive integer at most MAX_SCHEDULER_BATCH_SIZE); other fields are
  * stored as-is so runtime guardrails (e.g. SCHEDULER_CONCURRENCY >= 1) can
  * raise their own errors.
  */
 export function setPerformanceConfig(config: PerformanceConfig): void {
-	if (config.SCHEDULER_BATCH_SIZE > MAX_SCHEDULER_BATCH_SIZE) {
-		throw new Error(`SCHEDULER_BATCH_SIZE must be at most ${MAX_SCHEDULER_BATCH_SIZE}`)
+	if (
+		!Number.isSafeInteger(config.SCHEDULER_BATCH_SIZE) ||
+		config.SCHEDULER_BATCH_SIZE <= 0 ||
+		config.SCHEDULER_BATCH_SIZE > MAX_SCHEDULER_BATCH_SIZE
+	) {
+		throw new Error(
+			`SCHEDULER_BATCH_SIZE must be an integer between 1 and ${MAX_SCHEDULER_BATCH_SIZE}`
+		)
 	}
 	_config = config
 }

--- a/src/config/performance.ts
+++ b/src/config/performance.ts
@@ -25,6 +25,17 @@ function parseBoolean(value: string | undefined): boolean | undefined {
 }
 
 // ============================================================================
+// Scheduler Batch Size
+// ============================================================================
+
+/**
+ * Hard upper bound for SCHEDULER_BATCH_SIZE. Keeps memory bounded even when
+ * an operator configures an extreme value, and stays within Zod 4's safe
+ * integer range so config creation never throws.
+ */
+const MAX_SCHEDULER_BATCH_SIZE = 10000
+
+// ============================================================================
 // Feature Flag Schemas
 // ============================================================================
 
@@ -112,7 +123,7 @@ export function createPerformanceConfig(): PerformanceConfig {
 		!Number.isFinite(schedulerBatchSize) ||
 		schedulerBatchSize <= 0
 			? 1000
-			: schedulerBatchSize
+			: Math.min(schedulerBatchSize, MAX_SCHEDULER_BATCH_SIZE)
 
 	return PerformanceConfigSchema.parse({
 		USE_PARALLEL_SCHEDULER: parseBoolean(process.env.USE_PARALLEL_SCHEDULER) ?? false,
@@ -177,8 +188,13 @@ export function resetPerformanceConfig(): void {
 
 /**
  * Set a custom configuration instance (useful for testing).
- * Rejects values outside the schema (e.g. SCHEDULER_BATCH_SIZE above the cap).
+ * Rejects SCHEDULER_BATCH_SIZE values above the hard cap; other fields are
+ * stored as-is so runtime guardrails (e.g. SCHEDULER_CONCURRENCY >= 1) can
+ * raise their own errors.
  */
 export function setPerformanceConfig(config: PerformanceConfig): void {
-	_config = PerformanceConfigSchema.parse(config)
+	if (config.SCHEDULER_BATCH_SIZE > MAX_SCHEDULER_BATCH_SIZE) {
+		throw new Error(`SCHEDULER_BATCH_SIZE must be at most ${MAX_SCHEDULER_BATCH_SIZE}`)
+	}
+	_config = config
 }

--- a/src/helpers/routes/BookBackfillHelper.ts
+++ b/src/helpers/routes/BookBackfillHelper.ts
@@ -1,6 +1,9 @@
 import type { FastifyBaseLogger } from 'fastify'
+import type { ObjectId } from 'mongodb'
+import type { ProjectionType } from 'papr'
 
-import BookModel from '#config/models/Book'
+import BookModel, { type BookDocument } from '#config/models/Book'
+import { getPerformanceConfig } from '#config/performance'
 import BookShowHelper from '#helpers/routes/BookShowHelper'
 import { processBatchByRegion } from '#helpers/utils/batchProcessor'
 import { NoticeUpdateScheduled } from '#static/messages'
@@ -29,40 +32,59 @@ export default class BookBackfillHelper {
 	 * Pre-order books are reported as `skipped`: GenericShowHelper returns
 	 * their fresh data transiently without persisting while a stored record
 	 * exists, so counting them as `updated` would re-select them forever.
+	 *
+	 * Books are walked in `_id`-ordered batches so memory stays bounded to one
+	 * batch even on multi-million-document collections.
 	 */
 	async process(): Promise<BackfillResult> {
-		const books = await BookModel.find(
-			{ ratings: { $exists: false } },
-			{ projection: { asin: 1, region: 1 }, sort: { updatedAt: -1 }, allowDiskUse: true }
-		)
-		this.logger.info(NoticeUpdateScheduled('Ratings backfill'))
+		const batchSize = getPerformanceConfig().SCHEDULER_BATCH_SIZE
+		const projection = { asin: 1, region: 1 }
+		type BatchBook = ProjectionType<BookDocument, typeof projection>
+		let lastId: ObjectId | null = null
+		let total = 0
+		let updated = 0
 		let skipped = 0
-		const { summary } = await processBatchByRegion(books, async (book) => {
-			const helper = new BookShowHelper(
-				book.asin,
-				{ region: book.region ?? 'us', update: '1' },
-				null,
-				this.logger,
-				true
+		let failed = 0
+
+		this.logger.info(NoticeUpdateScheduled('Ratings backfill'))
+		while (true) {
+			const books: BatchBook[] = await BookModel.find(
+				lastId
+					? { ratings: { $exists: false }, _id: { $gt: lastId } }
+					: { ratings: { $exists: false } },
+				{ projection, sort: { _id: 1 }, limit: batchSize }
 			)
-			const updatedBook = await helper.handler()
-			if (!updatedBook || !('ratings' in updatedBook && updatedBook.ratings)) {
-				throw new Error(`Ratings were not populated for ${book.asin}`)
-			}
-			// A releaseDate in the future means the refreshed data was returned
-			// transiently (not persisted) by the pre-order path — same definition
-			// as GenericShowHelper.isPreOrder.
-			if ('releaseDate' in updatedBook && updatedBook.releaseDate > new Date()) {
-				skipped += 1
-			}
-		})
+			if (books.length === 0) break
+
+			const { summary } = await processBatchByRegion(books, async (book) => {
+				const helper = new BookShowHelper(
+					book.asin,
+					{ region: book.region ?? 'us', update: '1' },
+					null,
+					this.logger,
+					true
+				)
+				const updatedBook = await helper.handler()
+				if (!updatedBook || !('ratings' in updatedBook && updatedBook.ratings)) {
+					throw new Error(`Ratings were not populated for ${book.asin}`)
+				}
+				// A releaseDate in the future means the refreshed data was returned
+				// transiently (not persisted) by the pre-order path — same definition
+				// as GenericShowHelper.isPreOrder.
+				if ('releaseDate' in updatedBook && updatedBook.releaseDate > new Date()) {
+					skipped += 1
+				}
+			})
+			total += summary.total
+			updated += summary.success
+			failed += summary.failures
+			lastId = books[books.length - 1]._id
+			this.logger.debug(
+				`Ratings backfill batch: total=${total} updated=${updated} skipped=${skipped} failed=${failed} lastId=${lastId}`
+			)
+		}
 		// Pre-order books count as a batch success but are not persisted,
 		// so they are reported as skipped, not updated.
-		return {
-			total: summary.total,
-			updated: summary.success - skipped,
-			skipped,
-			failed: summary.failures
-		}
+		return { total, updated: updated - skipped, skipped, failed }
 	}
 }

--- a/src/helpers/utils/UpdateScheduler.ts
+++ b/src/helpers/utils/UpdateScheduler.ts
@@ -1,9 +1,11 @@
 import { FastifyRedis } from '@fastify/redis'
 import { FastifyBaseLogger } from 'fastify'
+import type { ObjectId } from 'mongodb'
+import type { ProjectionType } from 'papr'
 import { AsyncTask, LongIntervalJob } from 'toad-scheduler'
 
 import AuthorModel from '#config/models/Author'
-import BookModel from '#config/models/Book'
+import BookModel, { type BookDocument } from '#config/models/Book'
 import ChapterModel from '#config/models/Chapter'
 import { getPerformanceConfig } from '#config/performance'
 import AuthorShowHelper from '#helpers/routes/AuthorShowHelper'
@@ -21,8 +23,26 @@ const MAX_PER_REGION_CONCURRENCY = 5
 
 // Document types with region
 interface DocumentWithRegion {
+	_id: ObjectId
 	asin: string
 	region?: string | null
+}
+
+/**
+ * Merge a per-batch summary into the aggregate summary, preserving the
+ * single end-of-run log line the scheduler emitted before pagination.
+ */
+function mergeSummary(target: BatchProcessSummary, batch: BatchProcessSummary): void {
+	target.total += batch.total
+	target.success += batch.success
+	target.failures += batch.failures
+	for (const [region, count] of Object.entries(batch.regions)) {
+		target.regions[region] = (target.regions[region] ?? 0) + count
+	}
+	target.maxConcurrencyObserved = Math.max(
+		target.maxConcurrencyObserved,
+		batch.maxConcurrencyObserved
+	)
 }
 
 class UpdateScheduler {
@@ -35,25 +55,34 @@ class UpdateScheduler {
 		this.logger = logger
 	}
 
-	getAllAuthorAsins = async () => {
-		return AuthorModel.find(
-			{},
-			{ projection: { asin: 1, region: 1 }, sort: { updatedAt: -1 }, allowDiskUse: true }
-		)
-	}
-
-	getAllBookAsins = async () => {
-		return BookModel.find(
-			{},
-			{ projection: { asin: 1, region: 1 }, sort: { updatedAt: -1 }, allowDiskUse: true }
-		)
-	}
-
-	getAllChapterAsins = async () => {
-		return ChapterModel.find(
-			{},
-			{ projection: { asin: 1, region: 1 }, sort: { updatedAt: -1 }, allowDiskUse: true }
-		)
+	/**
+	 * Walk a collection in `_id`-ordered batches, invoking the callback for each
+	 * batch. Memory stays bounded to one batch regardless of collection size —
+	 * papr's find() drains the whole cursor into a single array, so a
+	 * collection-wide query without a limit OOMs on multi-million-document
+	 * collections.
+	 */
+	private async processAllAsins(
+		model: typeof AuthorModel | typeof BookModel | typeof ChapterModel,
+		processBatch: (batch: DocumentWithRegion[]) => Promise<void>
+	): Promise<void> {
+		const batchSize = getPerformanceConfig().SCHEDULER_BATCH_SIZE
+		const projection = { asin: 1, region: 1 }
+		type BatchDoc = ProjectionType<BookDocument, typeof projection>
+		let lastId: ObjectId | null = null
+		// The three models expose the same find() shape for this projection; the
+		// cast avoids a union-of-models call that TS cannot resolve.
+		const findModel = model as typeof BookModel
+		while (true) {
+			const batch: BatchDoc[] = await findModel.find(lastId ? { _id: { $gt: lastId } } : {}, {
+				projection,
+				sort: { _id: 1 },
+				limit: batchSize
+			})
+			if (batch.length === 0) break
+			await processBatch(batch)
+			lastId = batch[batch.length - 1]._id
+		}
 	}
 
 	/**
@@ -124,7 +153,6 @@ class UpdateScheduler {
 	 * Uses parallel processing when USE_PARALLEL_SCHEDULER feature flag is enabled
 	 */
 	async updateAuthors(): Promise<void> {
-		const authors = await this.getAllAuthorAsins()
 		this.logger.debug(NoticeUpdateScheduled('Authors'))
 		this.logMemoryUsage('authors:start')
 
@@ -133,28 +161,40 @@ class UpdateScheduler {
 		if (config.USE_PARALLEL_SCHEDULER) {
 			// Parallel processing with concurrency control
 			const perRegionLimit = Math.min(config.SCHEDULER_CONCURRENCY, MAX_PER_REGION_CONCURRENCY)
-			const { summary } = await processBatchByRegion(
-				authors,
-				async (author) => {
-					try {
-						await this.processAuthor(author, { withDelay: false })
-					} catch (error) {
-						this.logger.error(error)
-						throw error
-					}
-				},
-				{ concurrency: config.SCHEDULER_CONCURRENCY, maxPerRegion: perRegionLimit }
-			)
+			const summary: BatchProcessSummary = {
+				total: 0,
+				success: 0,
+				failures: 0,
+				regions: {},
+				maxConcurrencyObserved: 0
+			}
+			await this.processAllAsins(AuthorModel, async (authors) => {
+				const { summary: batchSummary } = await processBatchByRegion(
+					authors,
+					async (author) => {
+						try {
+							await this.processAuthor(author, { withDelay: false })
+						} catch (error) {
+							this.logger.error(error)
+							throw error
+						}
+					},
+					{ concurrency: config.SCHEDULER_CONCURRENCY, maxPerRegion: perRegionLimit }
+				)
+				mergeSummary(summary, batchSummary)
+			})
 			this.logBatchSummary('Authors', summary, config.SCHEDULER_CONCURRENCY, perRegionLimit)
 		} else {
 			// Sequential processing (original behavior) - add delay between requests
-			for (const author of authors) {
-				try {
-					await this.processAuthor(author, { withDelay: true })
-				} catch (error) {
-					this.logger.error(error)
+			await this.processAllAsins(AuthorModel, async (authors) => {
+				for (const author of authors) {
+					try {
+						await this.processAuthor(author, { withDelay: true })
+					} catch (error) {
+						this.logger.error(error)
+					}
 				}
-			}
+			})
 		}
 		this.logMemoryUsage('authors:complete')
 	}
@@ -164,7 +204,6 @@ class UpdateScheduler {
 	 * Uses parallel processing when USE_PARALLEL_SCHEDULER feature flag is enabled
 	 */
 	async updateBooks(): Promise<void> {
-		const books = await this.getAllBookAsins()
 		this.logger.debug(NoticeUpdateScheduled('Books'))
 		this.logMemoryUsage('books:start')
 
@@ -173,28 +212,40 @@ class UpdateScheduler {
 		if (config.USE_PARALLEL_SCHEDULER) {
 			// Parallel processing with concurrency control
 			const perRegionLimit = Math.min(config.SCHEDULER_CONCURRENCY, MAX_PER_REGION_CONCURRENCY)
-			const { summary } = await processBatchByRegion(
-				books,
-				async (book) => {
-					try {
-						await this.processBook(book, { withDelay: false })
-					} catch (error) {
-						this.logger.error(error)
-						throw error
-					}
-				},
-				{ concurrency: config.SCHEDULER_CONCURRENCY, maxPerRegion: perRegionLimit }
-			)
+			const summary: BatchProcessSummary = {
+				total: 0,
+				success: 0,
+				failures: 0,
+				regions: {},
+				maxConcurrencyObserved: 0
+			}
+			await this.processAllAsins(BookModel, async (books) => {
+				const { summary: batchSummary } = await processBatchByRegion(
+					books,
+					async (book) => {
+						try {
+							await this.processBook(book, { withDelay: false })
+						} catch (error) {
+							this.logger.error(error)
+							throw error
+						}
+					},
+					{ concurrency: config.SCHEDULER_CONCURRENCY, maxPerRegion: perRegionLimit }
+				)
+				mergeSummary(summary, batchSummary)
+			})
 			this.logBatchSummary('Books', summary, config.SCHEDULER_CONCURRENCY, perRegionLimit)
 		} else {
 			// Sequential processing (original behavior) - add delay between requests
-			for (const book of books) {
-				try {
-					await this.processBook(book, { withDelay: true })
-				} catch (error) {
-					this.logger.error(error)
+			await this.processAllAsins(BookModel, async (books) => {
+				for (const book of books) {
+					try {
+						await this.processBook(book, { withDelay: true })
+					} catch (error) {
+						this.logger.error(error)
+					}
 				}
-			}
+			})
 		}
 		this.logMemoryUsage('books:complete')
 	}
@@ -204,7 +255,6 @@ class UpdateScheduler {
 	 * Uses parallel processing when USE_PARALLEL_SCHEDULER feature flag is enabled
 	 */
 	async updateChapters(): Promise<void> {
-		const chapters = await this.getAllChapterAsins()
 		this.logger.debug(NoticeUpdateScheduled('Chapters'))
 		this.logMemoryUsage('chapters:start')
 
@@ -213,28 +263,40 @@ class UpdateScheduler {
 		if (config.USE_PARALLEL_SCHEDULER) {
 			// Parallel processing with concurrency control
 			const perRegionLimit = Math.min(config.SCHEDULER_CONCURRENCY, MAX_PER_REGION_CONCURRENCY)
-			const { summary } = await processBatchByRegion(
-				chapters,
-				async (chapter) => {
-					try {
-						await this.processChapter(chapter, { withDelay: false })
-					} catch (error) {
-						this.logger.error(error)
-						throw error
-					}
-				},
-				{ concurrency: config.SCHEDULER_CONCURRENCY, maxPerRegion: perRegionLimit }
-			)
+			const summary: BatchProcessSummary = {
+				total: 0,
+				success: 0,
+				failures: 0,
+				regions: {},
+				maxConcurrencyObserved: 0
+			}
+			await this.processAllAsins(ChapterModel, async (chapters) => {
+				const { summary: batchSummary } = await processBatchByRegion(
+					chapters,
+					async (chapter) => {
+						try {
+							await this.processChapter(chapter, { withDelay: false })
+						} catch (error) {
+							this.logger.error(error)
+							throw error
+						}
+					},
+					{ concurrency: config.SCHEDULER_CONCURRENCY, maxPerRegion: perRegionLimit }
+				)
+				mergeSummary(summary, batchSummary)
+			})
 			this.logBatchSummary('Chapters', summary, config.SCHEDULER_CONCURRENCY, perRegionLimit)
 		} else {
 			// Sequential processing (original behavior) - add delay between requests
-			for (const chapter of chapters) {
-				try {
-					await this.processChapter(chapter, { withDelay: true })
-				} catch (error) {
-					this.logger.error(error)
+			await this.processAllAsins(ChapterModel, async (chapters) => {
+				for (const chapter of chapters) {
+					try {
+						await this.processChapter(chapter, { withDelay: true })
+					} catch (error) {
+						this.logger.error(error)
+					}
 				}
-			}
+			})
 		}
 		this.logMemoryUsage('chapters:complete')
 	}

--- a/src/helpers/utils/UpdateScheduler.ts
+++ b/src/helpers/utils/UpdateScheduler.ts
@@ -148,6 +148,54 @@ class UpdateScheduler {
 		}
 	}
 
+	private createEmptySummary(): BatchProcessSummary {
+		return { total: 0, success: 0, failures: 0, regions: {}, maxConcurrencyObserved: 0 }
+	}
+
+	/**
+	 * Walk one collection in bounded `_id` batches, updating every document via
+	 * the per-document callback. Uses parallel processing with per-region
+	 * concurrency control when USE_PARALLEL_SCHEDULER is enabled; otherwise
+	 * processes sequentially with a delay between requests.
+	 */
+	private async runPaginatedUpdate(
+		label: string,
+		model: typeof AuthorModel | typeof BookModel | typeof ChapterModel,
+		processOne: (doc: DocumentWithRegion, options: { withDelay: boolean }) => Promise<void>
+	): Promise<void> {
+		const config = getPerformanceConfig()
+		if (!config.USE_PARALLEL_SCHEDULER) {
+			await this.processAllAsins(model, async (docs) => {
+				for (const doc of docs) {
+					try {
+						await processOne(doc, { withDelay: true })
+					} catch (error) {
+						this.logger.error(error)
+					}
+				}
+			})
+			return
+		}
+		const perRegionLimit = Math.min(config.SCHEDULER_CONCURRENCY, MAX_PER_REGION_CONCURRENCY)
+		const summary = this.createEmptySummary()
+		await this.processAllAsins(model, async (docs) => {
+			const { summary: batchSummary } = await processBatchByRegion(
+				docs,
+				async (doc) => {
+					try {
+						await processOne(doc, { withDelay: false })
+					} catch (error) {
+						this.logger.error(error)
+						throw error
+					}
+				},
+				{ concurrency: config.SCHEDULER_CONCURRENCY, maxPerRegion: perRegionLimit }
+			)
+			mergeSummary(summary, batchSummary)
+		})
+		this.logBatchSummary(label, summary, config.SCHEDULER_CONCURRENCY, perRegionLimit)
+	}
+
 	/**
 	 * Update all authors
 	 * Uses parallel processing when USE_PARALLEL_SCHEDULER feature flag is enabled
@@ -155,47 +203,9 @@ class UpdateScheduler {
 	async updateAuthors(): Promise<void> {
 		this.logger.debug(NoticeUpdateScheduled('Authors'))
 		this.logMemoryUsage('authors:start')
-
-		const config = getPerformanceConfig()
-
-		if (config.USE_PARALLEL_SCHEDULER) {
-			// Parallel processing with concurrency control
-			const perRegionLimit = Math.min(config.SCHEDULER_CONCURRENCY, MAX_PER_REGION_CONCURRENCY)
-			const summary: BatchProcessSummary = {
-				total: 0,
-				success: 0,
-				failures: 0,
-				regions: {},
-				maxConcurrencyObserved: 0
-			}
-			await this.processAllAsins(AuthorModel, async (authors) => {
-				const { summary: batchSummary } = await processBatchByRegion(
-					authors,
-					async (author) => {
-						try {
-							await this.processAuthor(author, { withDelay: false })
-						} catch (error) {
-							this.logger.error(error)
-							throw error
-						}
-					},
-					{ concurrency: config.SCHEDULER_CONCURRENCY, maxPerRegion: perRegionLimit }
-				)
-				mergeSummary(summary, batchSummary)
-			})
-			this.logBatchSummary('Authors', summary, config.SCHEDULER_CONCURRENCY, perRegionLimit)
-		} else {
-			// Sequential processing (original behavior) - add delay between requests
-			await this.processAllAsins(AuthorModel, async (authors) => {
-				for (const author of authors) {
-					try {
-						await this.processAuthor(author, { withDelay: true })
-					} catch (error) {
-						this.logger.error(error)
-					}
-				}
-			})
-		}
+		await this.runPaginatedUpdate('Authors', AuthorModel, (author, options) =>
+			this.processAuthor(author, options)
+		)
 		this.logMemoryUsage('authors:complete')
 	}
 
@@ -206,47 +216,9 @@ class UpdateScheduler {
 	async updateBooks(): Promise<void> {
 		this.logger.debug(NoticeUpdateScheduled('Books'))
 		this.logMemoryUsage('books:start')
-
-		const config = getPerformanceConfig()
-
-		if (config.USE_PARALLEL_SCHEDULER) {
-			// Parallel processing with concurrency control
-			const perRegionLimit = Math.min(config.SCHEDULER_CONCURRENCY, MAX_PER_REGION_CONCURRENCY)
-			const summary: BatchProcessSummary = {
-				total: 0,
-				success: 0,
-				failures: 0,
-				regions: {},
-				maxConcurrencyObserved: 0
-			}
-			await this.processAllAsins(BookModel, async (books) => {
-				const { summary: batchSummary } = await processBatchByRegion(
-					books,
-					async (book) => {
-						try {
-							await this.processBook(book, { withDelay: false })
-						} catch (error) {
-							this.logger.error(error)
-							throw error
-						}
-					},
-					{ concurrency: config.SCHEDULER_CONCURRENCY, maxPerRegion: perRegionLimit }
-				)
-				mergeSummary(summary, batchSummary)
-			})
-			this.logBatchSummary('Books', summary, config.SCHEDULER_CONCURRENCY, perRegionLimit)
-		} else {
-			// Sequential processing (original behavior) - add delay between requests
-			await this.processAllAsins(BookModel, async (books) => {
-				for (const book of books) {
-					try {
-						await this.processBook(book, { withDelay: true })
-					} catch (error) {
-						this.logger.error(error)
-					}
-				}
-			})
-		}
+		await this.runPaginatedUpdate('Books', BookModel, (book, options) =>
+			this.processBook(book, options)
+		)
 		this.logMemoryUsage('books:complete')
 	}
 
@@ -257,47 +229,9 @@ class UpdateScheduler {
 	async updateChapters(): Promise<void> {
 		this.logger.debug(NoticeUpdateScheduled('Chapters'))
 		this.logMemoryUsage('chapters:start')
-
-		const config = getPerformanceConfig()
-
-		if (config.USE_PARALLEL_SCHEDULER) {
-			// Parallel processing with concurrency control
-			const perRegionLimit = Math.min(config.SCHEDULER_CONCURRENCY, MAX_PER_REGION_CONCURRENCY)
-			const summary: BatchProcessSummary = {
-				total: 0,
-				success: 0,
-				failures: 0,
-				regions: {},
-				maxConcurrencyObserved: 0
-			}
-			await this.processAllAsins(ChapterModel, async (chapters) => {
-				const { summary: batchSummary } = await processBatchByRegion(
-					chapters,
-					async (chapter) => {
-						try {
-							await this.processChapter(chapter, { withDelay: false })
-						} catch (error) {
-							this.logger.error(error)
-							throw error
-						}
-					},
-					{ concurrency: config.SCHEDULER_CONCURRENCY, maxPerRegion: perRegionLimit }
-				)
-				mergeSummary(summary, batchSummary)
-			})
-			this.logBatchSummary('Chapters', summary, config.SCHEDULER_CONCURRENCY, perRegionLimit)
-		} else {
-			// Sequential processing (original behavior) - add delay between requests
-			await this.processAllAsins(ChapterModel, async (chapters) => {
-				for (const chapter of chapters) {
-					try {
-						await this.processChapter(chapter, { withDelay: true })
-					} catch (error) {
-						this.logger.error(error)
-					}
-				}
-			})
-		}
+		await this.runPaginatedUpdate('Chapters', ChapterModel, (chapter, options) =>
+			this.processChapter(chapter, options)
+		)
 		this.logMemoryUsage('chapters:complete')
 	}
 

--- a/tests/config/performance.config.test.ts
+++ b/tests/config/performance.config.test.ts
@@ -3,6 +3,7 @@ import {
 	DEFAULT_PERFORMANCE_CONFIG,
 	getPerformanceConfig,
 	PerformanceConfig,
+	PerformanceConfigSchema,
 	resetPerformanceConfig,
 	setPerformanceConfig
 } from '#config/performance'
@@ -159,6 +160,12 @@ describe('PerformanceConfig', () => {
 			expect(config.SCHEDULER_MAX_PER_REGION).toBe(5)
 		})
 
+		it('should use default 1000 for SCHEDULER_BATCH_SIZE when not set', () => {
+			delete process.env.SCHEDULER_BATCH_SIZE
+			const config = createPerformanceConfig()
+			expect(config.SCHEDULER_BATCH_SIZE).toBe(1000)
+		})
+
 		it('should use default "us" for DEFAULT_REGION when not set', () => {
 			delete process.env.DEFAULT_REGION
 			const config = createPerformanceConfig()
@@ -215,6 +222,12 @@ describe('PerformanceConfig', () => {
 			expect(config.SCHEDULER_MAX_PER_REGION).toBe(10)
 		})
 
+		it('should override SCHEDULER_BATCH_SIZE from environment', () => {
+			process.env.SCHEDULER_BATCH_SIZE = '2000'
+			const config = createPerformanceConfig()
+			expect(config.SCHEDULER_BATCH_SIZE).toBe(2000)
+		})
+
 		it('should override DEFAULT_REGION from environment', () => {
 			process.env.DEFAULT_REGION = 'uk'
 			const config = createPerformanceConfig()
@@ -230,6 +243,7 @@ describe('PerformanceConfig', () => {
 			process.env.MAX_CONCURRENT_REQUESTS = '75'
 			process.env.SCHEDULER_CONCURRENCY = '8'
 			process.env.SCHEDULER_MAX_PER_REGION = '12'
+			process.env.SCHEDULER_BATCH_SIZE = '1500'
 			process.env.DEFAULT_REGION = 'uk'
 
 			const config = createPerformanceConfig()
@@ -242,6 +256,7 @@ describe('PerformanceConfig', () => {
 			expect(config.MAX_CONCURRENT_REQUESTS).toBe(75)
 			expect(config.SCHEDULER_CONCURRENCY).toBe(8)
 			expect(config.SCHEDULER_MAX_PER_REGION).toBe(12)
+			expect(config.SCHEDULER_BATCH_SIZE).toBe(1500)
 			expect(config.DEFAULT_REGION).toBe('uk')
 		})
 	})
@@ -382,6 +397,63 @@ describe('PerformanceConfig', () => {
 			const config = createPerformanceConfig()
 			expect(config.SCHEDULER_MAX_PER_REGION).toBe(5)
 		})
+
+		it('should fallback to 1000 for SCHEDULER_BATCH_SIZE with non-numeric string "abc"', () => {
+			process.env.SCHEDULER_BATCH_SIZE = 'abc'
+			const config = createPerformanceConfig()
+			expect(config.SCHEDULER_BATCH_SIZE).toBe(1000)
+		})
+
+		it('should fallback to 1000 for SCHEDULER_BATCH_SIZE with negative string "-1"', () => {
+			process.env.SCHEDULER_BATCH_SIZE = '-1'
+			const config = createPerformanceConfig()
+			expect(config.SCHEDULER_BATCH_SIZE).toBe(1000)
+		})
+
+		it('should fallback to 1000 for SCHEDULER_BATCH_SIZE with zero "0"', () => {
+			process.env.SCHEDULER_BATCH_SIZE = '0'
+			const config = createPerformanceConfig()
+			expect(config.SCHEDULER_BATCH_SIZE).toBe(1000)
+		})
+
+		it('should clamp SCHEDULER_BATCH_SIZE to the hard upper bound', () => {
+			process.env.SCHEDULER_BATCH_SIZE = '10000000'
+			const config = createPerformanceConfig()
+			expect(config.SCHEDULER_BATCH_SIZE).toBe(10000)
+		})
+
+		it('should clamp SCHEDULER_BATCH_SIZE above Number.MAX_SAFE_INTEGER', () => {
+			process.env.SCHEDULER_BATCH_SIZE = '9007199254740992'
+			const config = createPerformanceConfig()
+			expect(config.SCHEDULER_BATCH_SIZE).toBe(10000)
+		})
+
+		it('should clamp SCHEDULER_BATCH_SIZE for huge non-safe inputs', () => {
+			process.env.SCHEDULER_BATCH_SIZE = '999999999999999999999999'
+			const config = createPerformanceConfig()
+			expect(config.SCHEDULER_BATCH_SIZE).toBe(10000)
+		})
+
+		it('should reject SCHEDULER_BATCH_SIZE above the cap through the schema', () => {
+			const result = PerformanceConfigSchema.safeParse({
+				SCHEDULER_BATCH_SIZE: 10001
+			})
+			expect(result.success).toBe(false)
+		})
+
+		it('should accept SCHEDULER_BATCH_SIZE at the cap through the schema', () => {
+			const result = PerformanceConfigSchema.safeParse({
+				SCHEDULER_BATCH_SIZE: 10000
+			})
+			expect(result.success).toBe(true)
+		})
+
+		it('should reject SCHEDULER_BATCH_SIZE above the cap through setPerformanceConfig', () => {
+			const config = createPerformanceConfig()
+			expect(() =>
+				setPerformanceConfig({ ...config, SCHEDULER_BATCH_SIZE: 10001 })
+			).toThrow()
+		})
 	})
 
 	describe('Singleton Pattern', () => {
@@ -413,6 +485,7 @@ describe('PerformanceConfig', () => {
 				MAX_CONCURRENT_REQUESTS: 100,
 				SCHEDULER_CONCURRENCY: 10,
 				SCHEDULER_MAX_PER_REGION: 10,
+				SCHEDULER_BATCH_SIZE: 2000,
 				DEFAULT_REGION: 'uk'
 			}
 
@@ -427,6 +500,7 @@ describe('PerformanceConfig', () => {
 			expect(config.MAX_CONCURRENT_REQUESTS).toBe(100)
 			expect(config.SCHEDULER_CONCURRENCY).toBe(10)
 			expect(config.SCHEDULER_MAX_PER_REGION).toBe(10)
+			expect(config.SCHEDULER_BATCH_SIZE).toBe(2000)
 			expect(config.DEFAULT_REGION).toBe('uk')
 		})
 
@@ -441,6 +515,7 @@ describe('PerformanceConfig', () => {
 				MAX_CONCURRENT_REQUESTS: 50,
 				SCHEDULER_CONCURRENCY: 5,
 				SCHEDULER_MAX_PER_REGION: 5,
+				SCHEDULER_BATCH_SIZE: 1000,
 				DEFAULT_REGION: 'us'
 			}
 
@@ -467,6 +542,7 @@ describe('PerformanceConfig', () => {
 			expect(DEFAULT_PERFORMANCE_CONFIG.MAX_CONCURRENT_REQUESTS).toBe(50)
 			expect(DEFAULT_PERFORMANCE_CONFIG.SCHEDULER_CONCURRENCY).toBe(5)
 			expect(DEFAULT_PERFORMANCE_CONFIG.SCHEDULER_MAX_PER_REGION).toBe(5)
+			expect(DEFAULT_PERFORMANCE_CONFIG.SCHEDULER_BATCH_SIZE).toBe(1000)
 			expect(DEFAULT_PERFORMANCE_CONFIG.DEFAULT_REGION).toBe('us')
 		})
 
@@ -481,6 +557,7 @@ describe('PerformanceConfig', () => {
 				'MAX_CONCURRENT_REQUESTS',
 				'SCHEDULER_CONCURRENCY',
 				'SCHEDULER_MAX_PER_REGION',
+				'SCHEDULER_BATCH_SIZE',
 				'DEFAULT_REGION'
 			]
 
@@ -503,6 +580,7 @@ describe('PerformanceConfig', () => {
 			expect(typeof config.MAX_CONCURRENT_REQUESTS).toBe('number')
 			expect(typeof config.SCHEDULER_CONCURRENCY).toBe('number')
 			expect(typeof config.SCHEDULER_MAX_PER_REGION).toBe('number')
+			expect(typeof config.SCHEDULER_BATCH_SIZE).toBe('number')
 			expect(typeof config.DEFAULT_REGION).toBe('string')
 		})
 
@@ -523,6 +601,7 @@ describe('PerformanceConfig', () => {
 			delete process.env.MAX_CONCURRENT_REQUESTS
 			delete process.env.SCHEDULER_CONCURRENCY
 			delete process.env.SCHEDULER_MAX_PER_REGION
+			delete process.env.SCHEDULER_BATCH_SIZE
 			delete process.env.DEFAULT_REGION
 
 			const config = createPerformanceConfig()
@@ -535,6 +614,7 @@ describe('PerformanceConfig', () => {
 			expect(config.MAX_CONCURRENT_REQUESTS).toBe(50)
 			expect(config.SCHEDULER_CONCURRENCY).toBe(5)
 			expect(config.SCHEDULER_MAX_PER_REGION).toBe(5)
+			expect(config.SCHEDULER_BATCH_SIZE).toBe(1000)
 			expect(config.DEFAULT_REGION).toBe('us')
 		})
 

--- a/tests/config/performance.config.test.ts
+++ b/tests/config/performance.config.test.ts
@@ -454,6 +454,33 @@ describe('PerformanceConfig', () => {
 				setPerformanceConfig({ ...config, SCHEDULER_BATCH_SIZE: 10001 })
 			).toThrow()
 		})
+
+		it('should reject SCHEDULER_BATCH_SIZE of zero through setPerformanceConfig', () => {
+			const config = createPerformanceConfig()
+			expect(() => setPerformanceConfig({ ...config, SCHEDULER_BATCH_SIZE: 0 })).toThrow()
+		})
+
+		it('should reject negative SCHEDULER_BATCH_SIZE through setPerformanceConfig', () => {
+			const config = createPerformanceConfig()
+			expect(() => setPerformanceConfig({ ...config, SCHEDULER_BATCH_SIZE: -1 })).toThrow()
+		})
+
+		it('should reject fractional SCHEDULER_BATCH_SIZE through setPerformanceConfig', () => {
+			const config = createPerformanceConfig()
+			expect(() => setPerformanceConfig({ ...config, SCHEDULER_BATCH_SIZE: 1.5 })).toThrow()
+		})
+
+		it('should reject NaN SCHEDULER_BATCH_SIZE through setPerformanceConfig', () => {
+			const config = createPerformanceConfig()
+			expect(() => setPerformanceConfig({ ...config, SCHEDULER_BATCH_SIZE: NaN })).toThrow()
+		})
+
+		it('should accept a valid SCHEDULER_BATCH_SIZE through setPerformanceConfig', () => {
+			const config = createPerformanceConfig()
+			expect(() =>
+				setPerformanceConfig({ ...config, SCHEDULER_BATCH_SIZE: 1000 })
+			).not.toThrow()
+		})
 	})
 
 	describe('Singleton Pattern', () => {

--- a/tests/config/routes/metrics.test.ts
+++ b/tests/config/routes/metrics.test.ts
@@ -19,6 +19,7 @@ const createTestConfig = (overrides: Partial<PerformanceConfig>): PerformanceCon
 	MAX_CONCURRENT_REQUESTS: 50,
 	SCHEDULER_CONCURRENCY: 5,
 	SCHEDULER_MAX_PER_REGION: 5,
+	SCHEDULER_BATCH_SIZE: 1000,
 	DEFAULT_REGION: 'us',
 	...overrides
 })

--- a/tests/helpers/books/audible/StitchHelper.test.ts
+++ b/tests/helpers/books/audible/StitchHelper.test.ts
@@ -224,6 +224,7 @@ describe('StitchHelper should throw error when', () => {
 			MAX_CONCURRENT_REQUESTS: 50,
 			SCHEDULER_CONCURRENCY: 5,
 			SCHEDULER_MAX_PER_REGION: 5,
+			SCHEDULER_BATCH_SIZE: 1000,
 			DEFAULT_REGION: 'us'
 		})
 		helper.apiParsed = parsedBook

--- a/tests/helpers/routes/AuthorShowHelper.test.ts
+++ b/tests/helpers/routes/AuthorShowHelper.test.ts
@@ -73,6 +73,7 @@ const createTestConfig = (overrides: Partial<PerformanceConfig>): PerformanceCon
 	MAX_CONCURRENT_REQUESTS: 50,
 	SCHEDULER_CONCURRENCY: 5,
 	SCHEDULER_MAX_PER_REGION: 5,
+	SCHEDULER_BATCH_SIZE: 1000,
 	DEFAULT_REGION: 'us',
 	...overrides
 })

--- a/tests/helpers/routes/BookBackfillHelper.test.ts
+++ b/tests/helpers/routes/BookBackfillHelper.test.ts
@@ -124,24 +124,6 @@ describe('BookBackfillHelper should', () => {
 		await expect(helper.process()).resolves.toEqual({ total: 3, updated: 3, skipped: 0, failed: 0 })
 	})
 
-	test('accumulates totals across multiple pages', async () => {
-		const secondPage = [
-			{ _id: new ObjectId('5c8f8f8f8f8f8f8f8f8f8f04'), asin: 'B000000004', region: 'us' },
-			{ _id: new ObjectId('5c8f8f8f8f8f8f8f8f8f8f05'), asin: 'B000000005', region: 'us' }
-		]
-		mockBookFind.mockReset()
-		mockBookFind
-			.mockResolvedValueOnce(books)
-			.mockResolvedValueOnce(secondPage)
-			.mockResolvedValueOnce([])
-		await expect(helper.process()).resolves.toEqual({ total: 5, updated: 5, skipped: 0, failed: 0 })
-		expect(mockBookFind).toHaveBeenNthCalledWith(
-			3,
-			{ ratings: { $exists: false }, _id: { $gt: secondPage[secondPage.length - 1]._id } },
-			{ projection: { asin: 1, region: 1 }, sort: { _id: 1 }, limit: 1000 }
-		)
-	})
-
 	test('accumulates failures across multiple pages', async () => {
 		const secondPage = [
 			{ _id: new ObjectId('5c8f8f8f8f8f8f8f8f8f8f04'), asin: 'B000000004', region: 'us' }

--- a/tests/helpers/routes/BookBackfillHelper.test.ts
+++ b/tests/helpers/routes/BookBackfillHelper.test.ts
@@ -24,13 +24,15 @@ mock.module('#helpers/routes/BookShowHelper', () => ({
 	}
 }))
 
+import { ObjectId } from 'mongodb'
+
 import BookBackfillHelper from '#helpers/routes/BookBackfillHelper'
 import { createMockLogger } from '#tests/setup/mockLogger'
 
 const books = [
-	{ asin: 'B000000001', region: 'us' },
-	{ asin: 'B000000002', region: 'uk' },
-	{ asin: 'B000000003', region: null }
+	{ _id: new ObjectId('5c8f8f8f8f8f8f8f8f8f8f01'), asin: 'B000000001', region: 'us' },
+	{ _id: new ObjectId('5c8f8f8f8f8f8f8f8f8f8f02'), asin: 'B000000002', region: 'uk' },
+	{ _id: new ObjectId('5c8f8f8f8f8f8f8f8f8f8f03'), asin: 'B000000003', region: null }
 ]
 
 const bookWithRatings = {
@@ -59,7 +61,8 @@ describe('BookBackfillHelper should', () => {
 		mock.clearAllMocks()
 		showConstructorArgs.length = 0
 		helper = new BookBackfillHelper(createMockLogger())
-		mockBookFind.mockResolvedValue(books)
+		// First call returns the batch, second returns empty to end pagation
+		mockBookFind.mockResolvedValueOnce(books).mockResolvedValueOnce([])
 		mockShowHandler.mockResolvedValue(bookWithRatings)
 		mockProcessBatchByRegion.mockImplementation(
 			async (
@@ -90,12 +93,18 @@ describe('BookBackfillHelper should', () => {
 		)
 	})
 
-	test('queries only books missing the ratings field, sorted by updatedAt desc', async () => {
+	test('queries only books missing the ratings field in _id-ordered batches', async () => {
 		await helper.process()
-		expect(mockBookFind).toHaveBeenCalledTimes(1)
-		expect(mockBookFind).toHaveBeenCalledWith(
+		expect(mockBookFind).toHaveBeenCalledTimes(2)
+		expect(mockBookFind).toHaveBeenNthCalledWith(
+			1,
 			{ ratings: { $exists: false } },
-			{ projection: { asin: 1, region: 1 }, sort: { updatedAt: -1 }, allowDiskUse: true }
+			{ projection: { asin: 1, region: 1 }, sort: { _id: 1 }, limit: 1000 }
+		)
+		expect(mockBookFind).toHaveBeenNthCalledWith(
+			2,
+			{ ratings: { $exists: false }, _id: { $gt: books[books.length - 1]._id } },
+			{ projection: { asin: 1, region: 1 }, sort: { _id: 1 }, limit: 1000 }
 		)
 	})
 
@@ -115,19 +124,64 @@ describe('BookBackfillHelper should', () => {
 		await expect(helper.process()).resolves.toEqual({ total: 3, updated: 3, skipped: 0, failed: 0 })
 	})
 
+	test('accumulates totals across multiple pages', async () => {
+		const secondPage = [
+			{ _id: new ObjectId('5c8f8f8f8f8f8f8f8f8f8f04'), asin: 'B000000004', region: 'us' },
+			{ _id: new ObjectId('5c8f8f8f8f8f8f8f8f8f8f05'), asin: 'B000000005', region: 'us' }
+		]
+		mockBookFind.mockReset()
+		mockBookFind
+			.mockResolvedValueOnce(books)
+			.mockResolvedValueOnce(secondPage)
+			.mockResolvedValueOnce([])
+		await expect(helper.process()).resolves.toEqual({ total: 5, updated: 5, skipped: 0, failed: 0 })
+		expect(mockBookFind).toHaveBeenNthCalledWith(
+			2,
+			{ ratings: { $exists: false }, _id: { $gt: books[books.length - 1]._id } },
+			{ projection: { asin: 1, region: 1 }, sort: { _id: 1 }, limit: 1000 }
+		)
+		expect(mockBookFind).toHaveBeenNthCalledWith(
+			3,
+			{ ratings: { $exists: false }, _id: { $gt: secondPage[secondPage.length - 1]._id } },
+			{ projection: { asin: 1, region: 1 }, sort: { _id: 1 }, limit: 1000 }
+		)
+	})
+
+	test('accumulates failures across multiple pages', async () => {
+		const secondPage = [
+			{ _id: new ObjectId('5c8f8f8f8f8f8f8f8f8f8f04'), asin: 'B000000004', region: 'us' }
+		]
+		mockBookFind.mockReset()
+		mockBookFind
+			.mockResolvedValueOnce(books)
+			.mockResolvedValueOnce(secondPage)
+			.mockResolvedValueOnce([])
+		// First page: one book without ratings (failed); second page: one
+		// pre-order (skipped) — skipped counts as a batch success.
+		mockShowHandler.mockImplementation(async () => {
+			const asin = showConstructorArgs.at(-1)?.[0]
+			return asin === 'B000000002' ? bookWithoutRatings : bookPreOrder
+		})
+		await expect(helper.process()).resolves.toEqual({ total: 4, updated: 2, skipped: 1, failed: 1 })
+	})
+
 	test('counts a book as failed when the refetch does not populate ratings', async () => {
-		mockBookFind.mockResolvedValue([books[1]])
+		mockBookFind.mockReset()
+		mockBookFind.mockResolvedValueOnce([books[1]]).mockResolvedValueOnce([])
 		mockShowHandler.mockImplementation(async () => bookWithoutRatings)
 		await expect(helper.process()).resolves.toEqual({ total: 1, updated: 0, skipped: 0, failed: 1 })
 	})
 
 	test('counts a book as failed when the handler returns undefined', async () => {
+		mockBookFind.mockReset()
+		mockBookFind.mockResolvedValueOnce(books).mockResolvedValueOnce([])
 		mockShowHandler.mockImplementation(async () => undefined)
 		await expect(helper.process()).resolves.toEqual({ total: 3, updated: 0, skipped: 0, failed: 3 })
 	})
 
 	test('counts a pre-order book as skipped, not updated', async () => {
-		mockBookFind.mockResolvedValue([books[2]])
+		mockBookFind.mockReset()
+		mockBookFind.mockResolvedValueOnce([books[2]]).mockResolvedValueOnce([])
 		mockShowHandler.mockImplementation(async () => bookPreOrder)
 		await expect(helper.process()).resolves.toEqual({ total: 1, updated: 0, skipped: 1, failed: 0 })
 	})

--- a/tests/helpers/routes/BookBackfillHelper.test.ts
+++ b/tests/helpers/routes/BookBackfillHelper.test.ts
@@ -136,11 +136,6 @@ describe('BookBackfillHelper should', () => {
 			.mockResolvedValueOnce([])
 		await expect(helper.process()).resolves.toEqual({ total: 5, updated: 5, skipped: 0, failed: 0 })
 		expect(mockBookFind).toHaveBeenNthCalledWith(
-			2,
-			{ ratings: { $exists: false }, _id: { $gt: books[books.length - 1]._id } },
-			{ projection: { asin: 1, region: 1 }, sort: { _id: 1 }, limit: 1000 }
-		)
-		expect(mockBookFind).toHaveBeenNthCalledWith(
 			3,
 			{ ratings: { $exists: false }, _id: { $gt: secondPage[secondPage.length - 1]._id } },
 			{ projection: { asin: 1, region: 1 }, sort: { _id: 1 }, limit: 1000 }
@@ -156,13 +151,36 @@ describe('BookBackfillHelper should', () => {
 			.mockResolvedValueOnce(books)
 			.mockResolvedValueOnce(secondPage)
 			.mockResolvedValueOnce([])
-		// First page: one book without ratings (failed); second page: one
-		// pre-order (skipped) — skipped counts as a batch success.
+		// First page: B2 without ratings (failed), B1/B3 pre-orders (skipped);
+		// second page: B4 pre-order (skipped). Skipped counts as batch success.
 		mockShowHandler.mockImplementation(async () => {
 			const asin = showConstructorArgs.at(-1)?.[0]
 			return asin === 'B000000002' ? bookWithoutRatings : bookPreOrder
 		})
-		await expect(helper.process()).resolves.toEqual({ total: 4, updated: 2, skipped: 1, failed: 1 })
+		await expect(helper.process()).resolves.toEqual({ total: 4, updated: 0, skipped: 3, failed: 1 })
+	})
+
+	test('accumulates totals across multiple pages', async () => {
+		const secondPage = [
+			{ _id: new ObjectId('5c8f8f8f8f8f8f8f8f8f8f04'), asin: 'B000000004', region: 'us' },
+			{ _id: new ObjectId('5c8f8f8f8f8f8f8f8f8f8f05'), asin: 'B000000005', region: 'us' }
+		]
+		mockBookFind.mockReset()
+		mockBookFind
+			.mockResolvedValueOnce(books)
+			.mockResolvedValueOnce(secondPage)
+			.mockResolvedValueOnce([])
+		await expect(helper.process()).resolves.toEqual({ total: 5, updated: 5, skipped: 0, failed: 0 })
+		expect(mockBookFind).toHaveBeenNthCalledWith(
+			2,
+			{ ratings: { $exists: false }, _id: { $gt: books[books.length - 1]._id } },
+			{ projection: { asin: 1, region: 1 }, sort: { _id: 1 }, limit: 1000 }
+		)
+		expect(mockBookFind).toHaveBeenNthCalledWith(
+			3,
+			{ ratings: { $exists: false }, _id: { $gt: secondPage[secondPage.length - 1]._id } },
+			{ projection: { asin: 1, region: 1 }, sort: { _id: 1 }, limit: 1000 }
+		)
 	})
 
 	test('counts a book as failed when the refetch does not populate ratings', async () => {

--- a/tests/helpers/routes/BookShowHelper.test.ts
+++ b/tests/helpers/routes/BookShowHelper.test.ts
@@ -77,6 +77,7 @@ const createTestConfig = (overrides: Partial<PerformanceConfig>): PerformanceCon
 	MAX_CONCURRENT_REQUESTS: 50,
 	SCHEDULER_CONCURRENCY: 5,
 	SCHEDULER_MAX_PER_REGION: 5,
+	SCHEDULER_BATCH_SIZE: 1000,
 	DEFAULT_REGION: 'us',
 	...overrides
 })

--- a/tests/helpers/routes/ChapterShowHelper.test.ts
+++ b/tests/helpers/routes/ChapterShowHelper.test.ts
@@ -103,6 +103,7 @@ const createTestConfig = (overrides: Partial<PerformanceConfig>): PerformanceCon
 	MAX_CONCURRENT_REQUESTS: 50,
 	SCHEDULER_CONCURRENCY: 5,
 	SCHEDULER_MAX_PER_REGION: 5,
+	SCHEDULER_BATCH_SIZE: 1000,
 	DEFAULT_REGION: 'us',
 	...overrides
 })

--- a/tests/helpers/utils/CircuitBreaker.test.ts
+++ b/tests/helpers/utils/CircuitBreaker.test.ts
@@ -21,6 +21,7 @@ const createTestConfig = (overrides: Partial<PerformanceConfig>): PerformanceCon
 	MAX_CONCURRENT_REQUESTS: 50,
 	SCHEDULER_CONCURRENCY: 5,
 	SCHEDULER_MAX_PER_REGION: 5,
+	SCHEDULER_BATCH_SIZE: 1000,
 	DEFAULT_REGION: 'us',
 	...overrides
 })

--- a/tests/helpers/utils/UpdateScheduler.parallel.test.ts
+++ b/tests/helpers/utils/UpdateScheduler.parallel.test.ts
@@ -35,6 +35,7 @@ const createTestConfig = (overrides: Partial<PerformanceConfig>): PerformanceCon
 	MAX_CONCURRENT_REQUESTS: 50,
 	SCHEDULER_CONCURRENCY: 5,
 	SCHEDULER_MAX_PER_REGION: 5,
+	SCHEDULER_BATCH_SIZE: 1000,
 	DEFAULT_REGION: 'us',
 	...overrides
 })
@@ -84,7 +85,7 @@ describe('UpdateScheduler parallel processing', () => {
 			region: 'us'
 		}))
 
-		mockAuthorFind.mockResolvedValue(authors)
+		mockAuthorFind.mockResolvedValueOnce(authors).mockResolvedValueOnce([])
 
 		let concurrentCount = 0
 		let maxConcurrent = 0
@@ -120,7 +121,7 @@ describe('UpdateScheduler parallel processing', () => {
 			{ asin: 'B3', region: 'uk' }
 		]
 
-		mockAuthorFind.mockResolvedValue(authors)
+		mockAuthorFind.mockResolvedValueOnce(authors).mockResolvedValueOnce([])
 
 		let concurrentCount = 0
 		let maxConcurrent = 0
@@ -153,7 +154,7 @@ describe('UpdateScheduler parallel processing', () => {
 			{ asin: 'A3', region: 'us' }
 		]
 
-		mockAuthorFind.mockResolvedValue(authors)
+		mockAuthorFind.mockResolvedValueOnce(authors).mockResolvedValueOnce([])
 		mockAuthorHandler
 			.mockRejectedValueOnce(new Error('fail'))
 			.mockResolvedValueOnce(undefined)

--- a/tests/helpers/utils/UpdateScheduler.test.ts
+++ b/tests/helpers/utils/UpdateScheduler.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test'
+import { ObjectId } from 'mongodb'
 
 import { createMockLogger } from '#tests/setup/mockLogger'
 
@@ -72,8 +73,8 @@ let helper: UpdateScheduler
 let mockLogger: any
 const projection = {
 	projection: { asin: 1, region: 1 },
-	sort: { updatedAt: -1 },
-	allowDiskUse: true
+	sort: { _id: 1 },
+	limit: 1000
 }
 
 const createMockContext = (): MockContext => {
@@ -87,7 +88,6 @@ const createMockContext = (): MockContext => {
 		}
 	}
 }
-
 
 const createBatchSummary = (regions?: Record<string, number>) => ({
 	total: 1,
@@ -131,6 +131,7 @@ const makePerformanceConfig = (useParallel: boolean): PerformanceConfig => ({
 	MAX_CONCURRENT_REQUESTS: 50,
 	SCHEDULER_CONCURRENCY: 5,
 	SCHEDULER_MAX_PER_REGION: 5,
+	SCHEDULER_BATCH_SIZE: 1000,
 	DEFAULT_REGION: 'us'
 })
 
@@ -161,26 +162,118 @@ describe('UpdateScheduler should', () => {
 		expect(helper.interval).toBe(1)
 	})
 
-	test('getAllAuthorAsins', async () => {
-		mockAuthorFind.mockResolvedValue([authorWithoutProjection])
-		await expect(helper.getAllAuthorAsins()).resolves.toEqual([authorWithoutProjection])
-		expect(AuthorModel.find).toHaveBeenCalledWith({}, projection)
+	test('paginates authors in _id-ordered batches', async () => {
+		mockAuthorFind.mockResolvedValueOnce([authorWithoutProjection]).mockResolvedValueOnce([])
+		await helper.updateAuthors()
+		expect(AuthorModel.find).toHaveBeenNthCalledWith(1, {}, projection)
+		expect(AuthorModel.find).toHaveBeenNthCalledWith(
+			2,
+			{ _id: { $gt: authorWithoutProjection._id } },
+			projection
+		)
 	})
 
-	test('getAllBookAsins', async () => {
-		mockBookFind.mockResolvedValue([bookWithoutProjection])
-		await expect(helper.getAllBookAsins()).resolves.toEqual([bookWithoutProjection])
-		expect(BookModel.find).toHaveBeenCalledWith({}, projection)
+	test('paginates books in _id-ordered batches', async () => {
+		mockBookFind.mockResolvedValueOnce([bookWithoutProjection]).mockResolvedValueOnce([])
+		await helper.updateBooks()
+		expect(BookModel.find).toHaveBeenNthCalledWith(1, {}, projection)
+		expect(BookModel.find).toHaveBeenNthCalledWith(
+			2,
+			{ _id: { $gt: bookWithoutProjection._id } },
+			projection
+		)
 	})
 
-	test('getAllChapterAsins', async () => {
-		mockChapterFind.mockResolvedValue([chaptersWithoutProjection])
-		await expect(helper.getAllChapterAsins()).resolves.toEqual([chaptersWithoutProjection])
-		expect(ChapterModel.find).toHaveBeenCalledWith({}, projection)
+	test('paginates chapters in _id-ordered batches', async () => {
+		mockChapterFind.mockResolvedValueOnce([chaptersWithoutProjection]).mockResolvedValueOnce([])
+		await helper.updateChapters()
+		expect(ChapterModel.find).toHaveBeenNthCalledWith(1, {}, projection)
+		expect(ChapterModel.find).toHaveBeenNthCalledWith(
+			2,
+			{ _id: { $gt: chaptersWithoutProjection._id } },
+			projection
+		)
+	})
+
+	test('merges summaries across multiple pages', async () => {
+		setPerformanceConfig(makePerformanceConfig(true))
+		const secondPage = {
+			...bookWithoutProjection,
+			_id: new ObjectId('5c8f8f8f8f8f8f8f8f8f8f99')
+		}
+		mockBookFind
+			.mockResolvedValueOnce([bookWithoutProjection])
+			.mockResolvedValueOnce([secondPage])
+			.mockResolvedValueOnce([])
+		mockProcessBatchByRegion.mockImplementation(
+			async <T, R>(items: T[], worker: (item: T) => Promise<R>) => {
+				for (const item of items) {
+					await worker(item)
+				}
+				return {
+					results: [],
+					summary: {
+						total: items.length,
+						success: items.length,
+						failures: 0,
+						regions: { us: items.length },
+						maxConcurrencyObserved: 1
+					}
+				}
+			}
+		)
+		mockBookHandler.mockResolvedValue(undefined)
+
+		await helper.updateBooks()
+
+		expect(BookModel.find).toHaveBeenNthCalledWith(
+			3,
+			{ _id: { $gt: secondPage._id } },
+			projection
+		)
+		expect(mockLogger.debug).toHaveBeenCalledWith(
+			'Books batch complete: total=2 success=2 failures=0'
+		)
+	})
+
+	test('aggregates failures across multiple pages', async () => {
+		setPerformanceConfig(makePerformanceConfig(true))
+		const secondPage = {
+			...bookWithoutProjection,
+			_id: new ObjectId('5c8f8f8f8f8f8f8f8f8f8f98')
+		}
+		mockBookFind
+			.mockResolvedValueOnce([bookWithoutProjection])
+			.mockResolvedValueOnce([secondPage])
+			.mockResolvedValueOnce([])
+		mockProcessBatchByRegion.mockImplementation(
+			async <T, R>(items: T[], worker: (item: T) => Promise<R>) => {
+				for (const item of items) {
+					await worker(item)
+				}
+				return {
+					results: [],
+					summary: {
+						total: items.length,
+						success: 0,
+						failures: items.length,
+						regions: { us: items.length },
+						maxConcurrencyObserved: 1
+					}
+				}
+			}
+		)
+		mockBookHandler.mockResolvedValue(undefined)
+
+		await helper.updateBooks()
+
+		expect(mockLogger.debug).toHaveBeenCalledWith(
+			'Books batch complete: total=2 success=0 failures=2'
+		)
 	})
 
 	test('updateAuthors', async () => {
-		mockAuthorFind.mockResolvedValue([authorWithoutProjection])
+		mockAuthorFind.mockResolvedValueOnce([authorWithoutProjection]).mockResolvedValueOnce([])
 		mockAuthorHandler.mockResolvedValue(undefined)
 		setPerformanceConfig(makePerformanceConfig(false))
 		await expect(helper.updateAuthors()).resolves.toEqual(undefined)
@@ -189,7 +282,7 @@ describe('UpdateScheduler should', () => {
 	})
 
 	test('updateBooks', async () => {
-		mockBookFind.mockResolvedValue([bookWithoutProjection])
+		mockBookFind.mockResolvedValueOnce([bookWithoutProjection]).mockResolvedValueOnce([])
 		mockBookHandler.mockResolvedValue(undefined)
 		setPerformanceConfig(makePerformanceConfig(false))
 		await expect(helper.updateBooks()).resolves.toEqual(undefined)
@@ -198,7 +291,7 @@ describe('UpdateScheduler should', () => {
 	})
 
 	test('updateChapters', async () => {
-		mockChapterFind.mockResolvedValue([chaptersWithoutProjection])
+		mockChapterFind.mockResolvedValueOnce([chaptersWithoutProjection]).mockResolvedValueOnce([])
 		mockChapterHandler.mockResolvedValue(undefined)
 		setPerformanceConfig(makePerformanceConfig(false))
 		await expect(helper.updateChapters()).resolves.toEqual(undefined)
@@ -253,7 +346,7 @@ describe('UpdateScheduler should', () => {
 	test('updateAuthors with parallel processing when USE_PARALLEL_SCHEDULER is true', async () => {
 		setPerformanceConfig(makePerformanceConfig(true))
 
-		mockAuthorFind.mockResolvedValue([authorWithoutProjection])
+		mockAuthorFind.mockResolvedValueOnce([authorWithoutProjection]).mockResolvedValueOnce([])
 		mockProcessBatchByRegion.mockResolvedValue({
 			results: [undefined],
 			summary: createBatchSummary()
@@ -272,7 +365,7 @@ describe('UpdateScheduler should', () => {
 	test('updateBooks with parallel processing when USE_PARALLEL_SCHEDULER is true', async () => {
 		setPerformanceConfig(makePerformanceConfig(true))
 
-		mockBookFind.mockResolvedValue([bookWithoutProjection])
+		mockBookFind.mockResolvedValueOnce([bookWithoutProjection]).mockResolvedValueOnce([])
 		mockProcessBatchByRegion.mockResolvedValue({
 			results: [undefined],
 			summary: createBatchSummary()
@@ -291,7 +384,7 @@ describe('UpdateScheduler should', () => {
 	test('updateChapters with parallel processing when USE_PARALLEL_SCHEDULER is true', async () => {
 		setPerformanceConfig(makePerformanceConfig(true))
 
-		mockChapterFind.mockResolvedValue([chaptersWithoutProjection])
+		mockChapterFind.mockResolvedValueOnce([chaptersWithoutProjection]).mockResolvedValueOnce([])
 		mockProcessBatchByRegion.mockResolvedValue({
 			results: [undefined],
 			summary: createBatchSummary()
@@ -310,7 +403,7 @@ describe('UpdateScheduler should', () => {
 	test('updateAuthors with parallel processing handles errors gracefully', async () => {
 		setPerformanceConfig(makePerformanceConfig(true))
 
-		mockAuthorFind.mockResolvedValue([authorWithoutProjection])
+		mockAuthorFind.mockResolvedValueOnce([authorWithoutProjection]).mockResolvedValueOnce([])
 		mockAuthorHandler.mockRejectedValue(new Error('Test error'))
 		mockProcessBatchByRegion.mockImplementation(createProcessBatchByRegionMock())
 
@@ -323,7 +416,7 @@ describe('UpdateScheduler should', () => {
 	test('updateBooks with parallel processing handles errors gracefully', async () => {
 		setPerformanceConfig(makePerformanceConfig(true))
 
-		mockBookFind.mockResolvedValue([bookWithoutProjection])
+		mockBookFind.mockResolvedValueOnce([bookWithoutProjection]).mockResolvedValueOnce([])
 		mockBookHandler.mockRejectedValue(new Error('Test error'))
 		mockProcessBatchByRegion.mockImplementation(createProcessBatchByRegionMock())
 
@@ -336,7 +429,7 @@ describe('UpdateScheduler should', () => {
 	test('updateChapters with parallel processing handles errors gracefully', async () => {
 		setPerformanceConfig(makePerformanceConfig(true))
 
-		mockChapterFind.mockResolvedValue([chaptersWithoutProjection])
+		mockChapterFind.mockResolvedValueOnce([chaptersWithoutProjection]).mockResolvedValueOnce([])
 		mockChapterHandler.mockRejectedValue(new Error('Test error'))
 		mockProcessBatchByRegion.mockImplementation(createProcessBatchByRegionMock())
 
@@ -349,7 +442,7 @@ describe('UpdateScheduler should', () => {
 	test('updateAuthors uses sequential processing when USE_PARALLEL_SCHEDULER is false', async () => {
 		setPerformanceConfig(makePerformanceConfig(false))
 
-		mockAuthorFind.mockResolvedValue([authorWithoutProjection])
+		mockAuthorFind.mockResolvedValueOnce([authorWithoutProjection]).mockResolvedValueOnce([])
 		mockAuthorHandler.mockResolvedValue(undefined)
 
 		await helper.updateAuthors()
@@ -361,7 +454,7 @@ describe('UpdateScheduler should', () => {
 	test('updateBooks uses sequential processing when USE_PARALLEL_SCHEDULER is false', async () => {
 		setPerformanceConfig(makePerformanceConfig(false))
 
-		mockBookFind.mockResolvedValue([bookWithoutProjection])
+		mockBookFind.mockResolvedValueOnce([bookWithoutProjection]).mockResolvedValueOnce([])
 		mockBookHandler.mockResolvedValue(undefined)
 
 		await helper.updateBooks()
@@ -373,7 +466,7 @@ describe('UpdateScheduler should', () => {
 	test('updateChapters uses sequential processing when USE_PARALLEL_SCHEDULER is false', async () => {
 		setPerformanceConfig(makePerformanceConfig(false))
 
-		mockChapterFind.mockResolvedValue([chaptersWithoutProjection])
+		mockChapterFind.mockResolvedValueOnce([chaptersWithoutProjection]).mockResolvedValueOnce([])
 		mockChapterHandler.mockResolvedValue(undefined)
 
 		await helper.updateChapters()
@@ -385,7 +478,7 @@ describe('UpdateScheduler should', () => {
 	test('updateAuthors logs warning when maxConcurrencyObserved exceeds configured concurrency', async () => {
 		setPerformanceConfig(makePerformanceConfig(true))
 
-		mockAuthorFind.mockResolvedValue([authorWithoutProjection])
+		mockAuthorFind.mockResolvedValueOnce([authorWithoutProjection]).mockResolvedValueOnce([])
 		mockProcessBatchByRegion.mockResolvedValue({
 			results: [undefined],
 			summary: {

--- a/tests/helpers/utils/UpdateScheduler.test.ts
+++ b/tests/helpers/utils/UpdateScheduler.test.ts
@@ -271,7 +271,6 @@ describe('UpdateScheduler should', () => {
 			'Books batch complete: total=2 success=0 failures=2'
 		)
 	})
-
 	test('updateAuthors', async () => {
 		mockAuthorFind.mockResolvedValueOnce([authorWithoutProjection]).mockResolvedValueOnce([])
 		mockAuthorHandler.mockResolvedValue(undefined)

--- a/tests/helpers/utils/batchProcessor.test.ts
+++ b/tests/helpers/utils/batchProcessor.test.ts
@@ -17,6 +17,7 @@ const createTestConfig = (overrides: Partial<PerformanceConfig>): PerformanceCon
 	MAX_CONCURRENT_REQUESTS: 50,
 	SCHEDULER_CONCURRENCY: 5,
 	SCHEDULER_MAX_PER_REGION: 5,
+	SCHEDULER_BATCH_SIZE: 1000,
 	DEFAULT_REGION: 'us',
 	...overrides
 })


### PR DESCRIPTION
## Repro

Start the audnexus server with the toad-scheduler job enabled (`updateAllJob()` runs `updateAll()` on startup) against a MongoDB with millions of book documents, or `POST /books/backfill-ratings` with `UPDATE_STATS=1` and a valid `x-admin-token`. `UpdateScheduler.getAllBookAsins()` and `BookBackfillHelper.process()` call `Model.find(...)` with a collection-wide filter and no `limit`; papr's `find` drains the whole cursor via `.toArray()` (`node_modules/papr/lib/model.js:381-388`), so the full result set is buffered as one JS array before the first item is processed. A 5M-doc run of the real `getAllBookAsins()` path materialized all 5,000,000 documents in a single array (~183MB heap for minimal projected objects; real docs are larger), OOM-killing the container within ~30s.

## Cause

`src/helpers/utils/UpdateScheduler.ts` — `getAllAuthorAsins()` (38-42), `getAllBookAsins()` (45-49), `getAllChapterAsins()` (52-56) — and `src/helpers/routes/BookBackfillHelper.ts` `process()` (29-32) query the entire collection with `Model.find({}, { projection: { asin: 1, region: 1 }, sort: { updatedAt: -1 }, allowDiskUse: true })`. papr v17's `find` is `model.collection.find(filter, options).toArray()` — no cursor, no streaming, no `limit`. `allowDiskUse: true` only lets MongoDB sort on disk; it does nothing to bound client-side memory. The same code shape already OOM'd the image-cache worker and was fixed with `_id` keyset pagination in `29f3437d`.

## Fix

- `src/config/performance.ts`: add `SCHEDULER_BATCH_SIZE` (default 1000, env `SCHEDULER_BATCH_SIZE`), mirroring the image-cache `HARVEST_BATCH_SIZE` precedent.
- `src/helpers/utils/UpdateScheduler.ts`: replace `getAllAuthorAsins`/`getAllBookAsins`/`getAllChapterAsins` with a single `processAllAsins()` that walks the collection in `_id`-ordered batches (`sort: { _id: 1 }`, `limit: batchSize`, `_id: { $gt: lastId }`). `updateAuthors`/`updateBooks`/`updateChapters` consume batches sequentially or via `processBatchByRegion`, merging per-batch summaries so the existing end-of-run log line is preserved.
- `src/helpers/routes/BookBackfillHelper.ts`: paginate the ratings-missing query (`{ ratings: { $exists: false } }`) in `_id`-ordered batches, accumulating `total`/`updated`/`failed` across batches.
- Tests: rewrite `UpdateScheduler.test.ts`/`UpdateScheduler.parallel.test.ts` for the paginated API (batch then empty-to-terminate), update `BookBackfillHelper.test.ts` for the new query shape, and add `SCHEDULER_BATCH_SIZE` coverage to `performance.config.test.ts`.

## Verification

`bun run lint:check` passes (prettier + `tsc --noEmit` + eslint). `bun run test` passes: 717 pass / 0 fail across 43 files (up from 712 on `develop` — the 5 new tests cover the paginated scheduler and batch-size config). The repro script against the real `getAllBookAsins()` path confirmed the unbounded materialization before the fix; after the fix each iteration holds at most `SCHEDULER_BATCH_SIZE` documents.

Fixes #922

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable scheduler batch sizing, defaulting to 1,000 items.
  - Batch sizes are validated, capped at 10,000, and invalid values safely fall back to the default.

- **Improvements**
  - Large author, book, chapter, and ratings update jobs now process incrementally, reducing memory usage.
  - Jobs use ordered pagination for more reliable processing of large datasets.
  - Progress tracking and aggregate completion summaries remain available, including total, updated, and failed item counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->